### PR TITLE
fix: encode hashes as hex

### DIFF
--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -224,7 +224,7 @@ func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerifi
 	// Verify that the RP ID hash in authData is indeed the SHA-256
 	// hash of the RP ID expected by the RP.
 	if !bytes.Equal(a.RPIDHash[:], rpIdHash) && !bytes.Equal(a.RPIDHash[:], appIDHash) {
-		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %s and Received %s\n", a.RPIDHash, rpIdHash))
+		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x\n", a.RPIDHash, rpIdHash))
 	}
 
 	// Registration Step 10 & Assertion Step 12

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"net/url"
 	"strings"
@@ -77,7 +78,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	// passed to the get() call.
 
 	challenge := c.Challenge
-	if 0 != strings.Compare(storedChallenge, challenge) {
+	if subtle.ConstantTimeCompare([]byte(storedChallenge), []byte(challenge)) == 1 {
 		err := ErrVerification.WithDetails("Error validating challenge")
 		return err.WithInfo(fmt.Sprintf("Expected b Value: %#v\nReceived b: %#v\n", storedChallenge, challenge))
 	}


### PR DESCRIPTION
This encodes the RP hashes as hexidecimal and properly handles a few other errors/checks.