### PR TITLE
fix: incorrect usage of subtle

### DIFF
--- a/protocol/client.go
+++ b/protocol/client.go
@@ -78,7 +78,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	// passed to the get() call.
 
 	challenge := c.Challenge
-	if subtle.ConstantTimeCompare([]byte(storedChallenge), []byte(challenge)) == 1 {
+	if subtle.ConstantTimeCompare([]byte(storedChallenge), []byte(challenge)) != 1 {
 		err := ErrVerification.WithDetails("Error validating challenge")
 		return err.WithInfo(fmt.Sprintf("Expected b Value: %#v\nReceived b: %#v\n", storedChallenge, challenge))
 	}


### PR DESCRIPTION
This fixes an incorrect usage of subtle.ConstantTimeCompare.