### PR TITLE
refactor: use type switch with assignment

### DIFF
--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -238,22 +238,19 @@ func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, signatur
 		return attestationType, nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Error parsing the public key: %+v\n", err))
 	}
 
-	switch key.(type) {
+	switch k := key.(type) {
 	case webauthncose.OKPPublicKeyData:
-		k := key.(webauthncose.OKPPublicKeyData)
-		err := verifyKeyAlgorithm(k.Algorithm, alg)
+		err = verifyKeyAlgorithm(k.Algorithm, alg)
 		if err != nil {
 			return attestationType, nil, err
 		}
 	case webauthncose.EC2PublicKeyData:
-		k := key.(webauthncose.EC2PublicKeyData)
-		err := verifyKeyAlgorithm(k.Algorithm, alg)
+		err = verifyKeyAlgorithm(k.Algorithm, alg)
 		if err != nil {
 			return attestationType, nil, err
 		}
 	case webauthncose.RSAPublicKeyData:
-		k := key.(webauthncose.RSAPublicKeyData)
-		err := verifyKeyAlgorithm(k.Algorithm, alg)
+		err = verifyKeyAlgorithm(k.Algorithm, alg)
 		if err != nil {
 			return attestationType, nil, err
 		}

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -78,18 +78,16 @@ func verifyTPMFormat(att AttestationObject, clientDataHash []byte) (string, []in
 	}
 
 	key, err := webauthncose.ParsePublicKey(att.AuthData.AttData.CredentialPublicKey)
-	switch key.(type) {
+	switch k := key.(type) {
 	case webauthncose.EC2PublicKeyData:
-		e := key.(webauthncose.EC2PublicKeyData)
-		if pubArea.ECCParameters.CurveID != googletpm.EllipticCurve(e.Curve) ||
-			0 != pubArea.ECCParameters.Point.X.Cmp(new(big.Int).SetBytes(e.XCoord)) ||
-			0 != pubArea.ECCParameters.Point.Y.Cmp(new(big.Int).SetBytes(e.YCoord)) {
+		if pubArea.ECCParameters.CurveID != googletpm.EllipticCurve(k.Curve) ||
+			0 != pubArea.ECCParameters.Point.X.Cmp(new(big.Int).SetBytes(k.XCoord)) ||
+			0 != pubArea.ECCParameters.Point.Y.Cmp(new(big.Int).SetBytes(k.YCoord)) {
 			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Mismatch between ECCParameters in pubArea and credentialPublicKey")
 		}
 	case webauthncose.RSAPublicKeyData:
-		r := key.(webauthncose.RSAPublicKeyData)
-		mod := new(big.Int).SetBytes(r.Modulus)
-		exp := uint32(r.Exponent[0]) + uint32(r.Exponent[1])<<8 + uint32(r.Exponent[2])<<16
+		mod := new(big.Int).SetBytes(k.Modulus)
+		exp := uint32(k.Exponent[0]) + uint32(k.Exponent[1])<<8 + uint32(k.Exponent[2])<<16
 		if 0 != pubArea.RSAParameters.Modulus.Cmp(mod) ||
 			pubArea.RSAParameters.Exponent != exp {
 			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails("Mismatch between RSAParameters in pubArea and credentialPublicKey")

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/pem"
-	"fmt"
 	"hash"
 	"math/big"
 
@@ -240,16 +239,13 @@ const (
 
 func VerifySignature(key interface{}, data []byte, sig []byte) (bool, error) {
 
-	switch key.(type) {
+	switch k := key.(type) {
 	case OKPPublicKeyData:
-		o := key.(OKPPublicKeyData)
-		return o.Verify(data, sig)
+		return k.Verify(data, sig)
 	case EC2PublicKeyData:
-		e := key.(EC2PublicKeyData)
-		return e.Verify(data, sig)
+		return k.Verify(data, sig)
 	case RSAPublicKeyData:
-		r := key.(RSAPublicKeyData)
-		return r.Verify(data, sig)
+		return k.Verify(data, sig)
 	default:
 		return false, ErrUnsupportedKey
 	}
@@ -260,25 +256,27 @@ func DisplayPublicKey(cpk []byte) string {
 	if err != nil {
 		return "Cannot display key"
 	}
-	switch parsedKey.(type) {
+	switch pKey := parsedKey.(type) {
 	case RSAPublicKeyData:
-		pKey := parsedKey.(RSAPublicKeyData)
 		rKey := &rsa.PublicKey{
 			N: big.NewInt(0).SetBytes(pKey.Modulus),
 			E: int(uint(pKey.Exponent[2]) | uint(pKey.Exponent[1])<<8 | uint(pKey.Exponent[0])<<16),
 		}
+
 		data, err := x509.MarshalPKIXPublicKey(rKey)
 		if err != nil {
 			return "Cannot display key"
 		}
+
 		pemBytes := pem.EncodeToMemory(&pem.Block{
 			Type:  "RSA PUBLIC KEY",
 			Bytes: data,
 		})
-		return fmt.Sprintf("%s", pemBytes)
+
+		return string(pemBytes)
 	case EC2PublicKeyData:
-		pKey := parsedKey.(EC2PublicKeyData)
 		var curve elliptic.Curve
+
 		switch COSEAlgorithmIdentifier(pKey.Algorithm) {
 		case AlgES256:
 			curve = elliptic.P256()
@@ -289,37 +287,44 @@ func DisplayPublicKey(cpk []byte) string {
 		default:
 			return "Cannot display key"
 		}
+
 		eKey := &ecdsa.PublicKey{
 			Curve: curve,
 			X:     big.NewInt(0).SetBytes(pKey.XCoord),
 			Y:     big.NewInt(0).SetBytes(pKey.YCoord),
 		}
+
 		data, err := x509.MarshalPKIXPublicKey(eKey)
 		if err != nil {
 			return "Cannot display key"
 		}
+
 		pemBytes := pem.EncodeToMemory(&pem.Block{
 			Type:  "PUBLIC KEY",
 			Bytes: data,
 		})
-		return fmt.Sprintf("%s", pemBytes)
+
+		return string(pemBytes)
 	case OKPPublicKeyData:
-		pKey := parsedKey.(OKPPublicKeyData)
 		if len(pKey.XCoord) != ed25519.PublicKeySize {
 			return "Cannot display key"
 		}
+
 		var oKey ed25519.PublicKey = make([]byte, ed25519.PublicKeySize)
+
 		copy(oKey, pKey.XCoord)
+
 		data, err := marshalEd25519PublicKey(oKey)
 		if err != nil {
 			return "Cannot display key"
 		}
+
 		pemBytes := pem.EncodeToMemory(&pem.Block{
 			Type:  "PUBLIC KEY",
 			Bytes: data,
 		})
-		return fmt.Sprintf("%s", pemBytes)
 
+		return string(pemBytes)
 	default:
 		return "Cannot display key of this type"
 	}


### PR DESCRIPTION
This minor refactor utilizes type switch assignments instead of basic switch statements. This results in less allocations. In addition it dumps the usage of fmt.Sprintf to format bytes as a string.