### PR TITLE
feat: add with setters for appid related extensions

### DIFF
--- a/protocol/attestation_u2f.go
+++ b/protocol/attestation_u2f.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )
 
-var u2fAttestationKey = "fido-u2f"
+var u2fAttestationKey = CredentialTypeFIDOU2F
 
 func init() {
 	RegisterAttestationFormat(u2fAttestationKey, verifyU2FFormat)

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -198,11 +198,11 @@ func (ppkc ParsedPublicKeyCredential) GetAppID(authExt AuthenticationExtensions,
 
 	// If the credential does not have the correct attestation type it is assumed to NOT be a fido-u2f credential.
 	// https://w3c.github.io/webauthn/#sctn-fido-u2f-attestation
-	if credentialAttestationType != "fido-u2f" {
+	if credentialAttestationType != CredentialTypeFIDOU2F {
 		return "", nil
 	}
 
-	if clientValue, ok = ppkc.ClientExtensionResults["appid"]; !ok {
+	if clientValue, ok = ppkc.ClientExtensionResults[ExtensionAppID]; !ok {
 		return "", nil
 	}
 
@@ -214,7 +214,7 @@ func (ppkc ParsedPublicKeyCredential) GetAppID(authExt AuthenticationExtensions,
 		return "", nil
 	}
 
-	if value, ok = authExt["appid"]; !ok {
+	if value, ok = authExt[ExtensionAppID]; !ok {
 		return "", ErrBadRequest.WithDetails("Session Data does not have an appid but Client Output indicates it should be set")
 	}
 
@@ -224,3 +224,7 @@ func (ppkc ParsedPublicKeyCredential) GetAppID(authExt AuthenticationExtensions,
 
 	return appID, nil
 }
+
+const (
+	CredentialTypeFIDOU2F = "fido-u2f"
+)

--- a/protocol/extensions.go
+++ b/protocol/extensions.go
@@ -6,3 +6,8 @@ package protocol
 // (https://www.w3.org/TR/webauthn/#sctn-defined-extensions).
 
 type AuthenticationExtensionsClientOutputs map[string]interface{}
+
+const (
+	ExtensionAppID        = "appid"
+	ExtensionAppIDExclude = "appidExclude"
+)

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -49,6 +49,9 @@ type CredentialDescriptor struct {
 	CredentialID []byte `json:"id"`
 	// The authenticator transports that can be used
 	Transport []AuthenticatorTransport `json:"transports,omitempty"`
+
+	// The AttestationType from the Credential. Used internally only.
+	AttestationType string `json:"-"`
 }
 
 // CredentialParameter is the credential type and algorithm

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -21,6 +21,16 @@ type Credential struct {
 	Authenticator Authenticator
 }
 
+// ToCredentialDescriptor converts a Credential into a protocol.CredentialDescriptor.
+func (c Credential) ToCredentialDescriptor() (descriptor protocol.CredentialDescriptor) {
+	return protocol.CredentialDescriptor{
+		CredentialID:    c.ID,
+		Transport:       c.Transport,
+		Type:            protocol.PublicKeyCredentialType,
+		AttestationType: c.AttestationType,
+	}
+}
+
 // MakeNewCredential will return a credential pointer on successful validation of a registration response
 func MakeNewCredential(c *protocol.ParsedCredentialCreationData) (*Credential, error) {
 	newCredential := &Credential{

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -89,6 +89,22 @@ func WithAssertionExtensions(extensions protocol.AuthenticationExtensions) Login
 	}
 }
 
+// WithAppIdExtension automatically includes the specified appid if the AllowedCredentials contains a credential
+// with the type `fido-u2f`.
+func WithAppIdExtension(appid string) LoginOption {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
+		for _, credential := range cco.AllowedCredentials {
+			if credential.AttestationType == protocol.CredentialTypeFIDOU2F {
+				if cco.Extensions == nil {
+					cco.Extensions = map[string]interface{}{}
+				}
+
+				cco.Extensions[protocol.ExtensionAppID] = appid
+			}
+		}
+	}
+}
+
 // Take the response from the client and validate it against the user credentials and stored session data
 func (webauthn *WebAuthn) FinishLogin(user User, session SessionData, response *http.Request) (*Credential, error) {
 	parsedResponse, err := protocol.ParseCredentialRequestResponse(response)

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -97,6 +97,22 @@ func WithExtensions(extension protocol.AuthenticationExtensions) RegistrationOpt
 	}
 }
 
+// WithAppIdExcludeExtension automatically includes the specified appid if the CredentialExcludeList contains a credential
+// with the type `fido-u2f`.
+func WithAppIdExcludeExtension(appid string) RegistrationOption {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+		for _, credential := range cco.CredentialExcludeList {
+			if credential.AttestationType == protocol.CredentialTypeFIDOU2F {
+				if cco.Extensions == nil {
+					cco.Extensions = map[string]interface{}{}
+				}
+
+				cco.Extensions[protocol.ExtensionAppIDExclude] = appid
+			}
+		}
+	}
+}
+
 // Take the response from the authenticator and client and verify the credential against the user's credentials and
 // session data.
 func (webauthn *WebAuthn) FinishRegistration(user User, session SessionData, response *http.Request) (*Credential, error) {


### PR DESCRIPTION
This automatically includes the specified appid if one of the credentials contains a credential with type fido-u2f.