### PR TITLE
fix: unused json tag

### DIFF
--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -51,8 +51,8 @@ type CredentialCreationResponse struct {
 type ParsedCredentialCreationData struct {
 	ParsedPublicKeyCredential
 	Response   ParsedAttestationResponse
+	Transports []AuthenticatorTransport
 	Raw        CredentialCreationResponse
-	Transports []AuthenticatorTransport `json:"transports,omitempty"`
 }
 
 func ParseCredentialCreationResponse(response *http.Request) (*ParsedCredentialCreationData, error) {


### PR DESCRIPTION
The struct in question is used internally not for unmarshalling JSON (i.e. post parsing the JSON struct).