### PR TITLE
revert: remove resident key unrequired method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ There are several differences between the upstream library and this one. We will
 
 * There are minimal breaking changes between this library and the upstream one. Identified breaking changes exist in the 
   following commits:
-  *  Change of protocol.ResidentKeyUnrequired() to protocol.ResidentKeyNotRequired() [5ad54f8](https://github.com/go-webauthn/webauthn/commit/5ad54f89952eb238a7d6e10ed2d443738351d67f).
+  * ~~Change of protocol.ResidentKeyUnrequired() to protocol.ResidentKeyNotRequired() [5ad54f8](https://github.com/go-webauthn/webauthn/commit/5ad54f89952eb238a7d6e10ed2d443738351d67f).~~
+    This method has been restored as a deprecated function making the migration path clearer.
 * This library is versioned with branches per minor version for back-porting fixes.
 * The following PR's in the upstream repository are merged in one form or another:
   * PR132 was merged in [401a3f6](https://github.com/go-webauthn/webauthn/commit/401a3f63b5fb3c91faa52c56a9295b78d62e039f).

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/go-webauthn/webauthn/metadata"
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
-	"github.com/google/uuid"
 )
 
 var packedAttestationKey = "packed"

--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-webauthn/webauthn/metadata"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/go-webauthn/webauthn/metadata"
 )
 
 var safetyNetAttestationKey = "android-safetynet"

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -263,6 +263,11 @@ func ResidentKeyNotRequired() *bool {
 	return &required
 }
 
+// Deprecated: ResidentKeyUnrequired is an alias for ResidentKeyNotRequired and will be completely removed in the future.
+func ResidentKeyUnrequired() *bool {
+	return ResidentKeyNotRequired()
+}
+
 // Verify on AuthenticatorData handles Steps 9 through 12 for Registration
 // and Steps 11 through 14 for Assertion.
 func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerificationRequired bool) error {


### PR DESCRIPTION
This restores the method protocol.ResidentKeyUnrequired() as an alias of the new option. The restored method is CLEARLY marked as deprecated and will be removed in the future.