### PR TITLE
fix(protocol): potential panic in u2f attestation

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -156,7 +156,7 @@ func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPa
 
 	valid, err := webauthncose.VerifySignature(key, sigData, p.Response.Signature)
 	if !valid || err != nil {
-		return ErrAssertionSignature.WithDetails(fmt.Sprintf("Error validating the assertion signature: %+v\n", err))
+		return ErrAssertionSignature.WithDetails(fmt.Sprintf("Error validating the assertion signature: %+v", err))
 	}
 
 	return nil

--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -18,14 +18,17 @@ func init() {
 // From §8.4. https://www.w3.org/TR/webauthn/#android-key-attestation
 // The android-key attestation statement looks like:
 // $$attStmtType //= (
-// 	fmt: "android-key",
-// 	attStmt: androidStmtFormat
+//
+//	fmt: "android-key",
+//	attStmt: androidStmtFormat
+//
 // )
-// androidStmtFormat = {
-// 		alg: COSEAlgorithmIdentifier,
-// 		sig: bytes,
-// 		x5c: [ credCert: bytes, * (caCert: bytes) ]
-//   }
+//
+//	androidStmtFormat = {
+//			alg: COSEAlgorithmIdentifier,
+//			sig: bytes,
+//			x5c: [ credCert: bytes, * (caCert: bytes) ]
+//	  }
 func verifyAndroidKeyFormat(att AttestationObject, clientDataHash []byte) (string, []interface{}, error) {
 	// Given the verification procedure inputs attStmt, authenticatorData and clientDataHash, the verification procedure is as follows:
 	// §8.4.1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to extract
@@ -67,19 +70,19 @@ func verifyAndroidKeyFormat(att AttestationObject, clientDataHash []byte) (strin
 
 	coseAlg := webauthncose.COSEAlgorithmIdentifier(alg)
 	sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg)
-	err = attCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), signatureData, sig)
-	if err != nil {
-		return androidAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
+
+	if err = attCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), signatureData, sig); err != nil {
+		return androidAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err))
 	}
 	// Verify that the public key in the first certificate in x5c matches the credentialPublicKey in the attestedCredentialData in authenticatorData.
 	pubKey, err := webauthncose.ParsePublicKey(att.AuthData.AttData.CredentialPublicKey)
 	if err != nil {
-		return androidAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error parsing public key: %+v\n", err))
+		return androidAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error parsing public key: %+v", err))
 	}
 	e := pubKey.(webauthncose.EC2PublicKeyData)
 	valid, err = e.Verify(signatureData, sig)
 	if err != nil || !valid {
-		return androidAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error parsing public key: %+v\n", err))
+		return androidAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error parsing public key: %+v", err))
 	}
 	// §8.4.3. Verify that the attestationChallenge field in the attestation certificate extension data is identical to clientDataHash.
 	// attCert.Extensions

--- a/protocol/attestation_apple.go
+++ b/protocol/attestation_apple.go
@@ -22,12 +22,15 @@ func init() {
 // From §8.8. https://www.w3.org/TR/webauthn-2/#sctn-apple-anonymous-attestation
 // The apple attestation statement looks like:
 // $$attStmtType //= (
-// 	fmt: "apple",
-// 	attStmt: appleStmtFormat
+//
+//	fmt: "apple",
+//	attStmt: appleStmtFormat
+//
 // )
-// appleStmtFormat = {
-// 		x5c: [ credCert: bytes, * (caCert: bytes) ]
-//   }
+//
+//	appleStmtFormat = {
+//			x5c: [ credCert: bytes, * (caCert: bytes) ]
+//	  }
 func verifyAppleKeyFormat(att AttestationObject, clientDataHash []byte) (string, []interface{}, error) {
 
 	// Step 1. Verify that attStmt is valid CBOR conforming to the syntax defined
@@ -81,7 +84,7 @@ func verifyAppleKeyFormat(att AttestationObject, clientDataHash []byte) (string,
 	// TODO: Probably move this part to webauthncose.go
 	pubKey, err := webauthncose.ParsePublicKey(att.AuthData.AttData.CredentialPublicKey)
 	if err != nil {
-		return appleAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error parsing public key: %+v\n", err))
+		return appleAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error parsing public key: %+v", err))
 	}
 	credPK := pubKey.(webauthncose.EC2PublicKeyData)
 	subjectPK := credCert.PublicKey.(*ecdsa.PublicKey)

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -22,20 +22,21 @@ func init() {
 
 // From §8.2. https://www.w3.org/TR/webauthn/#packed-attestation
 // The packed attestation statement looks like:
-//		packedStmtFormat = {
-//		 	alg: COSEAlgorithmIdentifier,
-//		 	sig: bytes,
-//		 	x5c: [ attestnCert: bytes, * (caCert: bytes) ]
-//		 } OR
-//		 {
-//		 	alg: COSEAlgorithmIdentifier, (-260 for ED256 / -261 for ED512)
-//		 	sig: bytes,
-//		 	ecdaaKeyId: bytes
-//		 } OR
-//		 {
-//		 	alg: COSEAlgorithmIdentifier
-//		 	sig: bytes,
-//		 }
+//
+//	packedStmtFormat = {
+//	 	alg: COSEAlgorithmIdentifier,
+//	 	sig: bytes,
+//	 	x5c: [ attestnCert: bytes, * (caCert: bytes) ]
+//	 } OR
+//	 {
+//	 	alg: COSEAlgorithmIdentifier, (-260 for ED256 / -261 for ED512)
+//	 	sig: bytes,
+//	 	ecdaaKeyId: bytes
+//	 } OR
+//	 {
+//	 	alg: COSEAlgorithmIdentifier
+//	 	sig: bytes,
+//	 }
 func verifyPackedFormat(att AttestationObject, clientDataHash []byte) (string, []interface{}, error) {
 	// Step 1. Verify that attStmt is valid CBOR conforming to the syntax defined
 	// above and perform CBOR decoding on it to extract the contained fields.
@@ -107,9 +108,9 @@ func handleBasicAttestation(signature, clientDataHash, authData, aaguid []byte, 
 
 	coseAlg := webauthncose.COSEAlgorithmIdentifier(alg)
 	sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg)
-	err = attCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), signatureData, signature)
-	if err != nil {
-		return attestationType, x5c, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
+
+	if err = attCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), signatureData, signature); err != nil {
+		return attestationType, x5c, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err))
 	}
 
 	// Step 2.2 Verify that attestnCert meets the requirements in §8.2.1 Packed attestation statement certificate requirements.
@@ -244,7 +245,7 @@ func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, signatur
 
 	key, err := webauthncose.ParsePublicKey(pubKey)
 	if err != nil {
-		return attestationType, nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Error parsing the public key: %+v\n", err))
+		return attestationType, nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Error parsing the public key: %+v", err))
 	}
 
 	switch k := key.(type) {
@@ -269,7 +270,7 @@ func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, signatur
 
 	valid, err := webauthncose.VerifySignature(key, verificationData, signature)
 	if !valid && err == nil {
-		return attestationType, nil, ErrInvalidAttestation.WithDetails("Unabled to verify signature")
+		return attestationType, nil, ErrInvalidAttestation.WithDetails("Unable to verify signature")
 	}
 
 	return attestationType, nil, err

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -155,9 +155,8 @@ func verifyTPMFormat(att AttestationObject, clientDataHash []byte) (string, []in
 
 		sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg)
 
-		err = aikCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), certInfoBytes, sigBytes)
-		if err != nil {
-			return tpmAttestationKey, nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
+		if err = aikCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), certInfoBytes, sigBytes); err != nil {
+			return tpmAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err))
 		}
 		// Verify that aikCert meets the requirements in §8.3.1 TPM Attestation Statement Certificate Requirements
 
@@ -231,6 +230,7 @@ func verifyTPMFormat(att AttestationObject, clientDataHash []byte) (string, []in
 
 	return tpmAttestationKey, x5c, err
 }
+
 func forEachSAN(extension []byte, callback func(tag int, data []byte) error) error {
 	// RFC 5280, 4.2.1.6
 

--- a/protocol/attestation_u2f.go
+++ b/protocol/attestation_u2f.go
@@ -130,11 +130,10 @@ func verifyU2FFormat(att AttestationObject, clientDataHash []byte) (string, []in
 	verificationData.Write(publicKeyU2F.Bytes())
 
 	// Step 6. Verify the sig using verificationData and certificate public key per SEC1[https://www.w3.org/TR/webauthn/#biblio-sec1].
-	sigErr := attCert.CheckSignature(x509.ECDSAWithSHA256, verificationData.Bytes(), signature)
-	if sigErr != nil {
-		return u2fAttestationKey, nil, sigErr
+	if err = attCert.CheckSignature(x509.ECDSAWithSHA256, verificationData.Bytes(), signature); err != nil {
+		return u2fAttestationKey, nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err))
 	}
 
 	// Step 7. If successful, return attestation type Basic with the attestation trust path set to x5c.
-	return "Fido U2F Basic", x5c, sigErr
+	return "Fido U2F Basic", x5c, nil
 }

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -167,7 +167,7 @@ func (flag AuthenticatorFlags) HasExtensions() bool {
 func (a *AuthenticatorData) Unmarshal(rawAuthData []byte) error {
 	if minAuthDataLength > len(rawAuthData) {
 		err := ErrBadRequest.WithDetails("Authenticator data length too short")
-		info := fmt.Sprintf("Expected data greater than %d bytes. Got %d bytes\n", minAuthDataLength, len(rawAuthData))
+		info := fmt.Sprintf("Expected data greater than %d bytes. Got %d bytes", minAuthDataLength, len(rawAuthData))
 		return err.WithInfo(info)
 	}
 
@@ -276,7 +276,7 @@ func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerifi
 	// Verify that the RP ID hash in authData is indeed the SHA-256
 	// hash of the RP ID expected by the RP.
 	if !bytes.Equal(a.RPIDHash[:], rpIdHash) && !bytes.Equal(a.RPIDHash[:], appIDHash) {
-		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x\n", a.RPIDHash, rpIdHash))
+		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x", a.RPIDHash, rpIdHash))
 	}
 
 	// Registration Step 10 & Assertion Step 12

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -65,7 +65,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 
 	// Assertion Step 7. Verify that the value of C.type is the string webauthn.get.
 	if c.Type != ceremony {
-		return ErrVerification.WithDetails("Error validating ceremony type").WithInfo(fmt.Sprintf("Expected Value: %s\n Received: %s\n", ceremony, c.Type))
+		return ErrVerification.WithDetails("Error validating ceremony type").WithInfo(fmt.Sprintf("Expected Value: %s, Received: %s", ceremony, c.Type))
 	}
 
 	// Registration Step 4. Verify that the value of C.challenge matches the challenge
@@ -90,7 +90,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 
 	if !strings.EqualFold(FullyQualifiedOrigin(clientDataOrigin), relyingPartyOrigin) {
 		err := ErrVerification.WithDetails("Error validating origin")
-		return err.WithInfo(fmt.Sprintf("Expected Value: %s\n Received: %s\n", relyingPartyOrigin, FullyQualifiedOrigin(clientDataOrigin)))
+		return err.WithInfo(fmt.Sprintf("Expected Value: %s, Received: %s", relyingPartyOrigin, FullyQualifiedOrigin(clientDataOrigin)))
 	}
 
 	// Registration Step 6 and Assertion Step 10. Verify that the value of C.tokenBinding.status
@@ -102,7 +102,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 			return ErrParsingData.WithDetails("Error decoding clientData, token binding present without status")
 		}
 		if c.TokenBinding.Status != Present && c.TokenBinding.Status != Supported && c.TokenBinding.Status != NotSupported {
-			return ErrParsingData.WithDetails("Error decoding clientData, token binding present with invalid status").WithInfo(fmt.Sprintf("Got: %s\n", c.TokenBinding.Status))
+			return ErrParsingData.WithDetails("Error decoding clientData, token binding present with invalid status").WithInfo(fmt.Sprintf("Got: %s", c.TokenBinding.Status))
 		}
 	}
 	// Not yet fully implemented by the spec, browsers, and me.


### PR DESCRIPTION
This fixes a potential panic caused by the U2F attestation format due to it returning a non protocol error. It uses the same return format as most other attestation format handlers.