### PR TITLE
fix(challenge): urlsafe base64 encoding

### DIFF
--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -151,7 +151,7 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 		Raw                       CredentialAssertionResponse
 	}
 	type args struct {
-		storedChallenge    string
+		storedChallenge    URLEncodedBase64
 		relyingPartyID     string
 		relyingPartyOrigin string
 		verifyUser         bool
@@ -173,7 +173,7 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 				Raw:                       tt.fields.Raw,
 			}
 
-			if err := p.Verify(tt.args.storedChallenge, tt.args.relyingPartyID, tt.args.relyingPartyOrigin, "", tt.args.verifyUser, tt.args.credentialBytes); (err != nil) != tt.wantErr {
+			if err := p.Verify(tt.args.storedChallenge.String(), tt.args.relyingPartyID, tt.args.relyingPartyOrigin, "", tt.args.verifyUser, tt.args.credentialBytes); (err != nil) != tt.wantErr {
 				t.Errorf("ParsedCredentialAssertionData.Verify() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -151,7 +151,7 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 		Raw                       CredentialAssertionResponse
 	}
 	type args struct {
-		storedChallenge    Challenge
+		storedChallenge    string
 		relyingPartyID     string
 		relyingPartyOrigin string
 		verifyUser         bool
@@ -173,7 +173,7 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 				Raw:                       tt.fields.Raw,
 			}
 
-			if err := p.Verify(tt.args.storedChallenge.String(), tt.args.relyingPartyID, tt.args.relyingPartyOrigin, "", tt.args.verifyUser, tt.args.credentialBytes); (err != nil) != tt.wantErr {
+			if err := p.Verify(tt.args.storedChallenge, tt.args.relyingPartyID, tt.args.relyingPartyOrigin, "", tt.args.verifyUser, tt.args.credentialBytes); (err != nil) != tt.wantErr {
 				t.Errorf("ParsedCredentialAssertionData.Verify() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -30,7 +30,7 @@ func TestAttestationVerify(t *testing.T) {
 			pcc.Response = *parsedAttestationResponse
 
 			// Test Base Verification
-			err = pcc.Verify(options.Response.Challenge.String(), false, options.Response.RelyingParty.ID, options.Response.RelyingParty.Name)
+			err = pcc.Verify(options.Response.Challenge, false, options.Response.RelyingParty.ID, options.Response.RelyingParty.Name)
 			if err != nil {
 				t.Fatalf("Not valid: %+v (%s)", err, err.(*Error).DevInfo)
 			}
@@ -83,7 +83,7 @@ func TestPackedAttestationVerification(t *testing.T) {
 var testAttestationOptions = []string{
 	// Direct Self Attestation with EC256 - MacOS
 	`{"publicKey": {
-		"challenge": "rWiex8xDOPfiCgyFu4BLW6vVOmXKgPwHrlMCgEs9SBA=",
+		"challenge": "rWiex8xDOPfiCgyFu4BLW6vVOmXKgPwHrlMCgEs9SBA",
 		"rp": {
 		"name": "http://localhost:9005",
 		"id": "localhost"
@@ -108,7 +108,7 @@ var testAttestationOptions = []string{
 	}}`,
 	// Direct Attestation with EC256
 	`{"publicKey": {
-		"challenge": "+Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc=",
+		"challenge": "-Ri5NZTzJ8b6mvW3TVScLotEoALfgBa2Bn4YSaIObHc",
 		"rp": {
 		"name": "https://webauthn.io",
 		"id": "webauthn.io"
@@ -134,7 +134,7 @@ var testAttestationOptions = []string{
 	// None Attestation with EC256
 	`{
 		"publicKey": {
-		  "challenge": "sVt4ScceMzqFSnfAq8hgLzblvo3fa4/aFVEcIESHIJ0=",
+		  "challenge": "sVt4ScceMzqFSnfAq8hgLzblvo3fa4_aFVEcIESHIJ0",
 		  "rp": {
 			"name": "https://webauthn.io",
 			"id": "webauthn.io"

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -30,7 +30,7 @@ func TestAttestationVerify(t *testing.T) {
 			pcc.Response = *parsedAttestationResponse
 
 			// Test Base Verification
-			err = pcc.Verify(options.Response.Challenge, false, options.Response.RelyingParty.ID, options.Response.RelyingParty.Name)
+			err = pcc.Verify(options.Response.Challenge.String(), false, options.Response.RelyingParty.ID, options.Response.RelyingParty.Name)
 			if err != nil {
 				t.Fatalf("Not valid: %+v (%s)", err, err.(*Error).DevInfo)
 			}

--- a/protocol/base64.go
+++ b/protocol/base64.go
@@ -11,6 +11,10 @@ import (
 // decoded into a byte slice.
 type URLEncodedBase64 []byte
 
+func (e URLEncodedBase64) String() string {
+	return base64.RawURLEncoding.EncodeToString(e)
+}
+
 // UnmarshalJSON base64 decodes a URL-encoded value, storing the result in the
 // provided byte slice.
 func (e *URLEncodedBase64) UnmarshalJSON(data []byte) error {

--- a/protocol/challenge.go
+++ b/protocol/challenge.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"crypto/rand"
-	"encoding/base64"
 )
 
 // ChallengeLength - Length of bytes to generate for a challenge
@@ -10,11 +9,11 @@ const ChallengeLength = 32
 
 // Create a new challenge that should be signed and returned by the authenticator.
 // The spec recommends using at least 16 bytes with 100 bits of entropy. We use 32 bytes.
-func CreateChallenge() (string, error) {
+func CreateChallenge() (URLEncodedBase64, error) {
 	challenge := make([]byte, ChallengeLength)
 	_, err := rand.Read(challenge)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return base64.RawURLEncoding.EncodeToString(challenge), nil
+	return URLEncodedBase64(challenge), nil
 }

--- a/protocol/challenge.go
+++ b/protocol/challenge.go
@@ -8,20 +8,13 @@ import (
 // ChallengeLength - Length of bytes to generate for a challenge
 const ChallengeLength = 32
 
-// Challenge that should be signed and returned by the authenticator
-type Challenge URLEncodedBase64
-
-// Create a new challenge to be sent to the authenticator. The spec recommends using
-// at least 16 bytes with 100 bits of entropy. We use 32 bytes.
-func CreateChallenge() (Challenge, error) {
+// Create a new challenge that should be signed and returned by the authenticator.
+// The spec recommends using at least 16 bytes with 100 bits of entropy. We use 32 bytes.
+func CreateChallenge() (string, error) {
 	challenge := make([]byte, ChallengeLength)
 	_, err := rand.Read(challenge)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return challenge, nil
-}
-
-func (c Challenge) String() string {
-	return base64.RawURLEncoding.EncodeToString(c)
+	return base64.RawURLEncoding.EncodeToString(challenge), nil
 }

--- a/protocol/challenge_test.go
+++ b/protocol/challenge_test.go
@@ -2,60 +2,23 @@ package protocol
 
 import (
 	"encoding/base64"
-	"reflect"
 	"testing"
 )
 
 func TestCreateChallenge(t *testing.T) {
-	tests := []struct {
-		name    string
-		want    Challenge
-		wantErr bool
-	}{
-		{
-			"Successfull Challenge Create",
-			Challenge{},
-			false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := CreateChallenge()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateChallenge() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			tt.want = got
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CreateChallenge() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestChallenge_String(t *testing.T) {
-	newChallenge, err := CreateChallenge()
+	got, err := CreateChallenge()
 	if err != nil {
-		t.Errorf("CreateChallenge() error = %v", err)
+		t.Errorf("CreateChallenge() error = %v, wantErr %v", err, false)
 		return
 	}
-	wantChallenge := base64.RawURLEncoding.EncodeToString(newChallenge)
-	tests := []struct {
-		name string
-		c    Challenge
-		want string
-	}{
-		{
-			"Successful String",
-			newChallenge,
-			wantChallenge,
-		},
+
+	decoded, err := base64.RawURLEncoding.DecodeString(got)
+	if err != nil {
+		t.Errorf("decode base64 encoded challenge, error = %v, wantErr %v", err, false)
+		return
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.c.String(); got != tt.want {
-				t.Errorf("Challenge.String() = %v, want %v", got, tt.want)
-			}
-		})
+
+	if len(decoded) != ChallengeLength {
+		t.Errorf("invalid challenge length, len = %d, want = %d", len(decoded), ChallengeLength)
 	}
 }

--- a/protocol/challenge_test.go
+++ b/protocol/challenge_test.go
@@ -2,23 +2,60 @@ package protocol
 
 import (
 	"encoding/base64"
+	"reflect"
 	"testing"
 )
 
 func TestCreateChallenge(t *testing.T) {
-	got, err := CreateChallenge()
+	tests := []struct {
+		name    string
+		want    URLEncodedBase64
+		wantErr bool
+	}{
+		{
+			"Successfull Challenge Create",
+			URLEncodedBase64{},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateChallenge()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateChallenge() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			tt.want = got
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateChallenge() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChallenge_String(t *testing.T) {
+	newChallenge, err := CreateChallenge()
 	if err != nil {
-		t.Errorf("CreateChallenge() error = %v, wantErr %v", err, false)
+		t.Errorf("CreateChallenge() error = %v", err)
 		return
 	}
-
-	decoded, err := base64.RawURLEncoding.DecodeString(got)
-	if err != nil {
-		t.Errorf("decode base64 encoded challenge, error = %v, wantErr %v", err, false)
-		return
+	wantChallenge := base64.RawURLEncoding.EncodeToString(newChallenge)
+	tests := []struct {
+		name string
+		c    URLEncodedBase64
+		want string
+	}{
+		{
+			"Successful String",
+			newChallenge,
+			wantChallenge,
+		},
 	}
-
-	if len(decoded) != ChallengeLength {
-		t.Errorf("invalid challenge length, len = %d, want = %d", len(decoded), ChallengeLength)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.c.String(); got != tt.want {
+				t.Errorf("Challenge.String() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -78,7 +78,6 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	challenge := c.Challenge
 	if subtle.ConstantTimeCompare([]byte(storedChallenge), []byte(challenge)) != 1 {
 		err := ErrVerification.WithDetails("Error validating challenge")
-		fmt.Printf("%s %s\n", storedChallenge, challenge)
 		return err.WithInfo(fmt.Sprintf("Expected b Value: %#v\nReceived b: %#v\n", storedChallenge, challenge))
 	}
 

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -78,6 +78,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	challenge := c.Challenge
 	if subtle.ConstantTimeCompare([]byte(storedChallenge), []byte(challenge)) != 1 {
 		err := ErrVerification.WithDetails("Error validating challenge")
+		fmt.Printf("%s %s\n", storedChallenge, challenge)
 		return err.WithInfo(fmt.Sprintf("Expected b Value: %#v\nReceived b: %#v\n", storedChallenge, challenge))
 	}
 

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -1,19 +1,16 @@
 package protocol
 
 import (
-	"encoding/base64"
 	"net/url"
 	"testing"
 )
 
-func setupCollectedClientData(challenge []byte) *CollectedClientData {
-	ccd := &CollectedClientData{
-		Type:   CreateCeremony,
-		Origin: "example.com",
+func setupCollectedClientData(challenge string) *CollectedClientData {
+	return &CollectedClientData{
+		Type:      CreateCeremony,
+		Origin:    "example.com",
+		Challenge: challenge,
 	}
-
-	ccd.Challenge = base64.RawURLEncoding.EncodeToString(challenge)
-	return ccd
 }
 
 func TestVerifyCollectedClientData(t *testing.T) {
@@ -26,9 +23,9 @@ func TestVerifyCollectedClientData(t *testing.T) {
 	var storedChallenge = newChallenge
 
 	originURL, _ := url.Parse(ccd.Origin)
-	err = ccd.Verify(storedChallenge.String(), ccd.Type, FullyQualifiedOrigin(originURL))
+	err = ccd.Verify(storedChallenge, ccd.Type, FullyQualifiedOrigin(originURL))
 	if err != nil {
-		t.Fatalf("error verifying challenge: expected %#v got %#v", Challenge(ccd.Challenge), storedChallenge)
+		t.Fatalf("error verifying challenge: expected %#v got %#v", ccd.Challenge, storedChallenge)
 	}
 }
 
@@ -42,9 +39,8 @@ func TestVerifyCollectedClientDataIncorrectChallenge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating challenge: %s", err)
 	}
-	storedChallenge := Challenge(bogusChallenge)
-	err = ccd.Verify(storedChallenge.String(), ccd.Type, ccd.Origin)
+	err = ccd.Verify(bogusChallenge, ccd.Type, ccd.Origin)
 	if err == nil {
-		t.Fatalf("error expected but not received. expected %#v got %#v", Challenge(ccd.Challenge), storedChallenge)
+		t.Fatalf("error expected but not received. expected %#v got %#v", ccd.Challenge, bogusChallenge)
 	}
 }

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 )
 
-func setupCollectedClientData(challenge string) *CollectedClientData {
+func setupCollectedClientData(challenge URLEncodedBase64) *CollectedClientData {
 	return &CollectedClientData{
 		Type:      CreateCeremony,
 		Origin:    "example.com",
-		Challenge: challenge,
+		Challenge: challenge.String(),
 	}
 }
 
@@ -23,7 +23,7 @@ func TestVerifyCollectedClientData(t *testing.T) {
 	var storedChallenge = newChallenge
 
 	originURL, _ := url.Parse(ccd.Origin)
-	err = ccd.Verify(storedChallenge, ccd.Type, FullyQualifiedOrigin(originURL))
+	err = ccd.Verify(storedChallenge.String(), ccd.Type, FullyQualifiedOrigin(originURL))
 	if err != nil {
 		t.Fatalf("error verifying challenge: expected %#v got %#v", ccd.Challenge, storedChallenge)
 	}
@@ -39,7 +39,7 @@ func TestVerifyCollectedClientDataIncorrectChallenge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating challenge: %s", err)
 	}
-	err = ccd.Verify(bogusChallenge, ccd.Type, ccd.Origin)
+	err = ccd.Verify(bogusChallenge.String(), ccd.Type, ccd.Origin)
 	if err == nil {
 		t.Fatalf("error expected but not received. expected %#v got %#v", ccd.Challenge, bogusChallenge)
 	}

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -149,7 +149,7 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 
 func TestParsedCredentialCreationData_Verify(t *testing.T) {
 	byteID, _ := base64.RawURLEncoding.DecodeString("6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g")
-	byteChallenge, _ := base64.RawURLEncoding.DecodeString("VzhHekZVOHBHamhvUmJXckxEbGFtQWZxX3k0UzFDWkcxVnVvZVJMQVJyRQ")
+	byteChallenge, _ := base64.RawURLEncoding.DecodeString("W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE")
 	byteAuthData, _ := base64.RawURLEncoding.DecodeString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw")
 	byteRPIDHash, _ := base64.RawURLEncoding.DecodeString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA")
 	byteCredentialPubKey, _ := base64.RawURLEncoding.DecodeString("pSJYIMfCKfxl2SvnqJIiHQysHmpmITNgtCkQ5ESExSRjqrhXAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNc")
@@ -162,7 +162,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 		Raw                       CredentialCreationResponse
 	}
 	type args struct {
-		storedChallenge    string
+		storedChallenge    URLEncodedBase64
 		verifyUser         bool
 		relyingPartyID     string
 		relyingPartyOrigin string
@@ -221,7 +221,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				},
 			},
 			args: args{
-				storedChallenge:    string(byteChallenge),
+				storedChallenge:    URLEncodedBase64(byteChallenge),
 				verifyUser:         false,
 				relyingPartyID:     `webauthn.io`,
 				relyingPartyOrigin: `https://webauthn.io`,
@@ -236,7 +236,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				Response:                  tt.fields.Response,
 				Raw:                       tt.fields.Raw,
 			}
-			if err := pcc.Verify(tt.args.storedChallenge, tt.args.verifyUser, tt.args.relyingPartyID, tt.args.relyingPartyOrigin); (err != nil) != tt.wantErr {
+			if err := pcc.Verify(tt.args.storedChallenge.String(), tt.args.verifyUser, tt.args.relyingPartyID, tt.args.relyingPartyOrigin); (err != nil) != tt.wantErr {
 				t.Errorf("ParsedCredentialCreationData.Verify() error = %+v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -149,7 +149,7 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 
 func TestParsedCredentialCreationData_Verify(t *testing.T) {
 	byteID, _ := base64.RawURLEncoding.DecodeString("6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g")
-	byteChallenge, _ := base64.RawURLEncoding.DecodeString("W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE")
+	byteChallenge, _ := base64.RawURLEncoding.DecodeString("VzhHekZVOHBHamhvUmJXckxEbGFtQWZxX3k0UzFDWkcxVnVvZVJMQVJyRQ")
 	byteAuthData, _ := base64.RawURLEncoding.DecodeString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw")
 	byteRPIDHash, _ := base64.RawURLEncoding.DecodeString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA")
 	byteCredentialPubKey, _ := base64.RawURLEncoding.DecodeString("pSJYIMfCKfxl2SvnqJIiHQysHmpmITNgtCkQ5ESExSRjqrhXAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNc")
@@ -162,7 +162,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 		Raw                       CredentialCreationResponse
 	}
 	type args struct {
-		storedChallenge    Challenge
+		storedChallenge    string
 		verifyUser         bool
 		relyingPartyID     string
 		relyingPartyOrigin string
@@ -221,7 +221,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				},
 			},
 			args: args{
-				storedChallenge:    byteChallenge,
+				storedChallenge:    string(byteChallenge),
 				verifyUser:         false,
 				relyingPartyID:     `webauthn.io`,
 				relyingPartyOrigin: `https://webauthn.io`,
@@ -236,7 +236,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				Response:                  tt.fields.Response,
 				Raw:                       tt.fields.Raw,
 			}
-			if err := pcc.Verify(tt.args.storedChallenge.String(), tt.args.verifyUser, tt.args.relyingPartyID, tt.args.relyingPartyOrigin); (err != nil) != tt.wantErr {
+			if err := pcc.Verify(tt.args.storedChallenge, tt.args.verifyUser, tt.args.relyingPartyID, tt.args.relyingPartyOrigin); (err != nil) != tt.wantErr {
 				t.Errorf("ParsedCredentialCreationData.Verify() error = %+v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -15,7 +15,7 @@ type CredentialAssertion struct {
 // In order to create a Credential via create(), the caller specifies a few parameters in a CredentialCreationOptions object.
 // See §5.4. Options for Credential Creation https://www.w3.org/TR/webauthn/#dictionary-makecredentialoptions
 type PublicKeyCredentialCreationOptions struct {
-	Challenge              Challenge                `json:"challenge"`
+	Challenge              string                   `json:"challenge"`
 	RelyingParty           RelyingPartyEntity       `json:"rp"`
 	User                   UserEntity               `json:"user"`
 	Parameters             []CredentialParameter    `json:"pubKeyCredParams,omitempty"`
@@ -30,7 +30,7 @@ type PublicKeyCredentialCreationOptions struct {
 // Its challenge member MUST be present, while its other members are OPTIONAL.
 // See §5.5. Options for Assertion Generation https://www.w3.org/TR/webauthn/#assertion-options
 type PublicKeyCredentialRequestOptions struct {
-	Challenge          Challenge                   `json:"challenge"`
+	Challenge          string                      `json:"challenge"`
 	Timeout            int                         `json:"timeout,omitempty"`
 	RelyingPartyID     string                      `json:"rpId,omitempty"`
 	AllowedCredentials []CredentialDescriptor      `json:"allowCredentials,omitempty"`

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -15,7 +15,7 @@ type CredentialAssertion struct {
 // In order to create a Credential via create(), the caller specifies a few parameters in a CredentialCreationOptions object.
 // See §5.4. Options for Credential Creation https://www.w3.org/TR/webauthn/#dictionary-makecredentialoptions
 type PublicKeyCredentialCreationOptions struct {
-	Challenge              string                   `json:"challenge"`
+	Challenge              URLEncodedBase64         `json:"challenge"`
 	RelyingParty           RelyingPartyEntity       `json:"rp"`
 	User                   UserEntity               `json:"user"`
 	Parameters             []CredentialParameter    `json:"pubKeyCredParams,omitempty"`
@@ -30,7 +30,7 @@ type PublicKeyCredentialCreationOptions struct {
 // Its challenge member MUST be present, while its other members are OPTIONAL.
 // See §5.5. Options for Assertion Generation https://www.w3.org/TR/webauthn/#assertion-options
 type PublicKeyCredentialRequestOptions struct {
-	Challenge          string                      `json:"challenge"`
+	Challenge          URLEncodedBase64            `json:"challenge"`
 	Timeout            int                         `json:"timeout,omitempty"`
 	RelyingPartyID     string                      `json:"rpId,omitempty"`
 	AllowedCredentials []CredentialDescriptor      `json:"allowCredentials,omitempty"`

--- a/protocol/options_test.go
+++ b/protocol/options_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPublicKeyCredentialRequestOptions_GetAllowedCredentialIDs(t *testing.T) {
 	type fields struct {
-		Challenge          Challenge
+		Challenge          string
 		Timeout            int
 		RelyingPartyID     string
 		AllowedCredentials []CredentialDescriptor
@@ -22,7 +22,7 @@ func TestPublicKeyCredentialRequestOptions_GetAllowedCredentialIDs(t *testing.T)
 		{
 			"Correct Credential IDs",
 			fields{
-				Challenge: Challenge([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
+				Challenge: string([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
 				Timeout:   60,
 				AllowedCredentials: []CredentialDescriptor{
 					{

--- a/protocol/options_test.go
+++ b/protocol/options_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPublicKeyCredentialRequestOptions_GetAllowedCredentialIDs(t *testing.T) {
 	type fields struct {
-		Challenge          string
+		Challenge          URLEncodedBase64
 		Timeout            int
 		RelyingPartyID     string
 		AllowedCredentials []CredentialDescriptor
@@ -22,7 +22,7 @@ func TestPublicKeyCredentialRequestOptions_GetAllowedCredentialIDs(t *testing.T)
 		{
 			"Correct Credential IDs",
 			fields{
-				Challenge: string([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
+				Challenge: URLEncodedBase64([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
 				Timeout:   60,
 				AllowedCredentials: []CredentialDescriptor{
 					{

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -63,7 +63,7 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 	}
 
 	sessionData := SessionData{
-		Challenge:            challenge,
+		Challenge:            challenge.String(),
 		UserID:               userID,
 		AllowedCredentialIDs: requestOptions.GetAllowedCredentialIDs(),
 		UserVerification:     requestOptions.UserVerification,

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -2,7 +2,6 @@ package webauthn
 
 import (
 	"bytes"
-	"encoding/base64"
 	"net/http"
 
 	"github.com/go-webauthn/webauthn/protocol"
@@ -64,7 +63,7 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 	}
 
 	sessionData := SessionData{
-		Challenge:            base64.RawURLEncoding.EncodeToString(challenge),
+		Challenge:            challenge,
 		UserID:               userID,
 		AllowedCredentialIDs: requestOptions.GetAllowedCredentialIDs(),
 		UserVerification:     requestOptions.UserVerification,

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -2,7 +2,6 @@ package webauthn
 
 import (
 	"bytes"
-	"encoding/base64"
 	"net/http"
 
 	"github.com/go-webauthn/webauthn/protocol"
@@ -57,7 +56,7 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 
 	response := protocol.CredentialCreation{Response: creationOptions}
 	newSessionData := SessionData{
-		Challenge:        base64.RawURLEncoding.EncodeToString(challenge),
+		Challenge:        challenge,
 		UserID:           user.WebAuthnID(),
 		UserVerification: creationOptions.AuthenticatorSelection.UserVerification,
 	}

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -56,7 +56,7 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 
 	response := protocol.CredentialCreation{Response: creationOptions}
 	newSessionData := SessionData{
-		Challenge:        challenge,
+		Challenge:        challenge.String(),
 		UserID:           user.WebAuthnID(),
 		UserVerification: creationOptions.AuthenticatorSelection.UserVerification,
 	}


### PR DESCRIPTION
This fixes issue with wrong encoding being used for the challenge. According to the specs[^1] the challenge should be base64 url-safe encoded. Until now, the package used std encoding which uses slightly different set of characters. This was reported in the linked issue and we also encountered the same issue when testing our implementation of webauthn e2e using github.com/descope/virtualwebauthn.

The commit removes the custom type for challenge and instead passes around the challenge url-safe base64 encoded right from the point of creation. Because the string is fully valid it can be safely used in json as well as stored in redis or other possible storage implementations that might be used by the clients of the library.

I tried to keep the tests as close to the original as possible. In some cases that required transforming the challenge back to bytes considering the previously used padding to be part of the bytes and then re-encoding into url-safe base64 string.

[^1]: https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-challenge

Fix: https://github.com/duo-labs/webauthn/issues/128