### PR TITLE
fix(protocol): user entity id not encoded correctly

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,6 +17,12 @@ body:
       label: Version
       description: What version of the library are you using?
       options:
+        - 0.6.0
+        - 0.5.0
+        - 0.4.0
+        - 0.3.4
+        - 0.3.3
+        - 0.3.2
         - 0.3.1
         - 0.3.0
         - 0.2.2

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -91,7 +91,7 @@ var testAttestationOptions = []string{
 		"user": {
 			"name": "self",
 			"displayName": "self",
-			"id": "2iEAAAAAAAAAAA=="
+			"id": "2iEAAAAAAAAAAA"
 		},
 		"pubKeyCredParams": [
 			{
@@ -116,7 +116,7 @@ var testAttestationOptions = []string{
 		"user": {
 			"name": "flort",
 			"displayName": "flort",
-			"id": "1DMAAAAAAAAAAA=="
+			"id": "1DMAAAAAAAAAAA"
 		},
 		"pubKeyCredParams": [
 			{
@@ -142,7 +142,7 @@ var testAttestationOptions = []string{
 		  "user": {
 			"name": "testuser1",
 			"displayName": "testuser1",
-			"id": "1zMAAAAAAAAAAA=="
+			"id": "1zMAAAAAAAAAAA"
 		  },
 		  "pubKeyCredParams": [
 			{

--- a/protocol/entities.go
+++ b/protocol/entities.go
@@ -44,5 +44,5 @@ type UserEntity struct {
 	// authentication and authorization decisions MUST be made on the basis of this id
 	// member, not the displayName nor name members. See Section 6.1 of
 	// [RFC8266](https://www.w3.org/TR/webauthn/#biblio-rfc8266).
-	ID []byte `json:"id"`
+	ID URLEncodedBase64 `json:"id"`
 }


### PR DESCRIPTION
This fixes an issue where the protocol.UserEntity field ID was encoded with Base64 URL Encoding with padding instead of without padding.

Fixes #97 