### PR TITLE
fix(protocol): creation invalid transports path

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -51,6 +51,7 @@ func ParseCredentialRequestResponse(response *http.Request) (*ParsedCredentialAs
 	if response == nil || response.Body == nil {
 		return nil, ErrBadRequest.WithDetails("No response given")
 	}
+
 	return ParseCredentialRequestResponseBody(response.Body)
 }
 

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -3,7 +3,7 @@ package protocol
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseCredentialRequestResponse(t *testing.T) {
-	reqBody := ioutil.NopCloser(bytes.NewReader([]byte(testAssertionResponses["success"])))
+	reqBody := io.NopCloser(bytes.NewReader([]byte(testAssertionResponses["success"])))
 	httpReq := &http.Request{Body: reqBody}
 
 	byteID, _ := base64.RawURLEncoding.DecodeString("AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng")

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -45,6 +45,9 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 						Type: "public-key",
 					},
 					RawID: byteID,
+					ClientExtensionResults: map[string]interface{}{
+						"appID": "example.com",
+					},
 				},
 				Response: ParsedAssertionResponse{
 					CollectedClientData: CollectedClientData{
@@ -73,6 +76,9 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 							ID:   "AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
 						},
 						RawID: byteID,
+						ClientExtensionResults: map[string]interface{}{
+							"appID": "example.com",
+						},
 					},
 					AssertionResponse: AuthenticatorAssertionResponse{
 						AuthenticatorResponse: AuthenticatorResponse{
@@ -198,6 +204,7 @@ var testAssertionResponses = map[string]string{
 	`success`: `{
 		"id":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
 		"rawId":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
+		"clientExtensionResults":{"appID":"example.com"},
 		"type":"public-key",
 		"response":{
 			"authenticatorData":"dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBFXJJiGa3OAAI1vMYKZIsLJfHwVQMANwCOw-atj9C0vhWpfWU-whzNjeQS21Lpxfdk_G-omAtffWztpGoErlNOfuXWRqm9Uj9ANJck1p6lAQIDJiABIVggKAhfsdHcBIc0KPgAcRyAIK_-Vi-nCXHkRHPNaCMBZ-4iWCBxB8fGYQSBONi9uvq0gv95dGWlhJrBwCsj_a4LJQKVHQ",

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -171,19 +171,6 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 	}
 }
 
-var testAssertionOptions = map[string]string{
-	// None Attestation - MacOS TouchID
-	`success`: `{
-		"id":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
-		"rawId":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
-		"type":"public-key",
-		"response":{
-			"attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVi7dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBFXJJiFa3OAAI1vMYKZIsLJfHwVQMANwCOw-atj9C0vhWpfWU-whzNjeQS21Lpxfdk_G-omAtffWztpGoErlNOfuXWRqm9Uj9ANJck1p6lAQIDJiABIVggKAhfsdHcBIc0KPgAcRyAIK_-Vi-nCXHkRHPNaCMBZ-4iWCBxB8fGYQSBONi9uvq0gv95dGWlhJrBwCsj_a4LJQKVHQ",
-			"clientDataJSON":"eyJjaGFsbGVuZ2UiOiJmeWV1dUdQOXp1ZWoyRkdqZXZpNzlienFNS1d4aTRQWUlhXzV3ajI2MVcwIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ"}
-		}
-	`,
-}
-
 var testAssertionResponses = map[string]string{
 	// None Attestation - MacOS TouchID
 	`success`: `{

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -66,7 +66,7 @@ func verifyPackedFormat(att AttestationObject, clientDataHash []byte) (string, [
 	ecdaaKeyID, ecdaaKeyPresent := att.AttStatement["ecdaaKeyId"].([]byte)
 	if ecdaaKeyPresent {
 		// Handle ECDAA Attestation steps for the x509 Certificate
-		return handleECDAAAttesation(sig, clientDataHash, ecdaaKeyID)
+		return handleECDAAAttestation(sig, clientDataHash, ecdaaKeyID)
 	}
 
 	// Step 4. If neither x5c nor ecdaaKeyId is present, self attestation is in use.
@@ -195,7 +195,7 @@ func handleBasicAttestation(signature, clientDataHash, authData, aaguid []byte, 
 	return string(metadata.BasicFull), x5c, nil
 }
 
-func handleECDAAAttesation(signature, clientDataHash, ecdaaKeyID []byte) (string, []interface{}, error) {
+func handleECDAAAttestation(signature, clientDataHash, ecdaaKeyID []byte) (string, []interface{}, error) {
 	return "Packed (ECDAA)", nil, ErrNotSpecImplemented
 }
 

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -98,16 +98,11 @@ func ParseCredentialCreationResponseBody(body io.Reader) (pcc *ParsedCredentialC
 	}
 
 	return &ParsedCredentialCreationData{
-		ParsedPublicKeyCredential: ParsedPublicKeyCredential{
-			ParsedCredential: ParsedCredential{
-				ID:   ccr.ID,
-				Type: ccr.Type,
-			},
-			RawID:                  ccr.RawID,
-			ClientExtensionResults: ccr.ClientExtensionResults,
+		ParsedPublicKeyCredential{
+			ParsedCredential{ccr.ID, ccr.Type}, ccr.RawID, ccr.ClientExtensionResults,
 		},
-		Response: *response,
-		Raw:      ccr,
+		*response,
+		ccr,
 	}, nil
 }
 

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -62,10 +62,10 @@ func ParseCredentialCreationResponse(response *http.Request) (*ParsedCredentialC
 	return ParseCredentialCreationResponseBody(response.Body)
 }
 
-func ParseCredentialCreationResponseBody(body io.Reader) (*ParsedCredentialCreationData, error) {
+func ParseCredentialCreationResponseBody(body io.Reader) (pcc *ParsedCredentialCreationData, err error) {
 	var ccr CredentialCreationResponse
-	err := json.NewDecoder(body).Decode(&ccr)
-	if err != nil {
+
+	if err = json.NewDecoder(body).Decode(&ccr); err != nil {
 		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo(err.Error())
 	}
 
@@ -86,26 +86,37 @@ func ParseCredentialCreationResponseBody(body io.Reader) (*ParsedCredentialCreat
 		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo("Type not public-key")
 	}
 
-	var pcc ParsedCredentialCreationData
-	pcc.ID, pcc.RawID, pcc.Type, pcc.ClientExtensionResults = ccr.ID, ccr.RawID, ccr.Type, ccr.ClientExtensionResults
-	pcc.Raw = ccr
-
-	for _, t := range ccr.Transports {
-		pcc.Transports = append(pcc.Transports, AuthenticatorTransport(t))
-	}
-
-	parsedAttestationResponse, err := ccr.AttestationResponse.Parse()
+	response, err := ccr.AttestationResponse.Parse()
 	if err != nil {
 		return nil, ErrParsingData.WithDetails("Error parsing attestation response")
 	}
 
-	pcc.Response = *parsedAttestationResponse
+	// TODO: Remove this as it's a backwards compatability layer.
+	if len(response.Transports) == 0 && len(ccr.Transports) != 0 {
+		for _, t := range ccr.Transports {
+			response.Transports = append(response.Transports, AuthenticatorTransport(t))
+		}
+	}
 
-	return &pcc, nil
+	return &ParsedCredentialCreationData{
+		ParsedPublicKeyCredential: ParsedPublicKeyCredential{
+			ParsedCredential: ParsedCredential{
+				ID:   ccr.ID,
+				Type: ccr.Type,
+			},
+			RawID:                  ccr.RawID,
+			ClientExtensionResults: ccr.ClientExtensionResults,
+		},
+		Response: *response,
+		Raw:      ccr,
+	}, nil
 }
 
-// Verifies the Client and Attestation data as laid out by §7.1. Registering a new credential
-// https://www.w3.org/TR/webauthn/#registering-a-new-credential
+// Verify the Client and Attestation data.
+//
+// From: §7.1. Registering a New Credential
+//
+// See: https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential
 func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUser bool, relyingPartyID string, relyingPartyOrigins []string) error {
 
 	// Handles steps 3 through 6 - Verifying the Client Data against the Relying Party's stored data
@@ -122,7 +133,7 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUs
 	// attestation statement attStmt. is handled while
 
 	// We do the above step while parsing and decoding the CredentialCreationResponse
-	// Handle steps 9 through 14 - This verifies the attestaion object and
+	// Handle steps 9 through 14 - This verifies the attestation object and
 	verifyError = pcc.Response.AttestationObject.Verify(relyingPartyID, clientDataHash[:], verifyUser)
 	if verifyError != nil {
 		return verifyError
@@ -131,7 +142,7 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUs
 	// Step 15. If validation is successful, obtain a list of acceptable trust anchors (attestation root
 	// certificates or ECDAA-Issuer public keys) for that attestation type and attestation statement
 	// format fmt, from a trusted source or from policy. For example, the FIDO Metadata Service provides
-	// one way to obtain such information, using the aaguid in the attestedCredentialData in authData.
+	// one way to obtain such information, using the AAGUID in the attestedCredentialData in authData.
 	// [https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-metadata-service-v2.0-id-20180227.html]
 
 	// TODO: There are no valid AAGUIDs yet or trust sources supported. We could implement policy for the RP in

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -50,9 +50,8 @@ type CredentialCreationResponse struct {
 
 type ParsedCredentialCreationData struct {
 	ParsedPublicKeyCredential
-	Response   ParsedAttestationResponse
-	Transports []AuthenticatorTransport
-	Raw        CredentialCreationResponse
+	Response ParsedAttestationResponse
+	Raw      CredentialCreationResponse
 }
 
 func ParseCredentialCreationResponse(response *http.Request) (*ParsedCredentialCreationData, error) {

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -3,7 +3,7 @@ package protocol
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParseCredentialCreationResponse(t *testing.T) {
-	reqBody := ioutil.NopCloser(bytes.NewReader([]byte(testCredentialRequestBody)))
+	reqBody := io.NopCloser(bytes.NewReader([]byte(testCredentialRequestBody)))
 	httpReq := &http.Request{Body: reqBody}
 	type args struct {
 		response *http.Request
@@ -47,7 +47,6 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 						"appid": true,
 					},
 				},
-				Transports: []AuthenticatorTransport{USB, NFC, "fake"},
 				Response: ParsedAttestationResponse{
 					CollectedClientData: CollectedClientData{
 						Type:      CeremonyType("webauthn.create"),
@@ -68,6 +67,7 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 							},
 						},
 					},
+					Transports: []AuthenticatorTransport{USB, NFC, "fake"},
 				},
 				Raw: CredentialCreationResponse{
 					PublicKeyCredential: PublicKeyCredential{
@@ -103,8 +103,8 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 			if !reflect.DeepEqual(got.ClientExtensionResults, tt.want.ClientExtensionResults) {
 				t.Errorf("Extensions = %v \n want: %v", got.ClientExtensionResults, tt.want.ClientExtensionResults)
 			}
-			if !reflect.DeepEqual(got.Transports, tt.want.Transports) {
-				t.Errorf("Transports = %v \n want: %v", got.Transports, tt.want.Transports)
+			if !reflect.DeepEqual(got.Response.Transports, tt.want.Response.Transports) {
+				t.Errorf("Transports = %v \n want: %v", got.Response.Transports, tt.want.Response.Transports)
 			}
 			if !reflect.DeepEqual(got.ID, tt.want.ID) {
 				t.Errorf("ID = %v \n want: %v", got, tt.want)

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -4,18 +4,16 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
-	"net/http"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
 )
 
 func TestParseCredentialCreationResponse(t *testing.T) {
-	reqBody := io.NopCloser(bytes.NewReader([]byte(testCredentialRequestBody)))
-	httpReq := &http.Request{Body: reqBody}
 	type args struct {
-		response *http.Request
+		responseName string
 	}
 
 	byteID, _ := base64.RawURLEncoding.DecodeString("6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g")
@@ -25,18 +23,78 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 	byteAttObject, _ := base64.RawURLEncoding.DecodeString("o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw")
 	byteClientDataJSON, _ := base64.RawURLEncoding.DecodeString("eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ")
 
-	tests := []struct {
-		name    string
-		args    args
-		want    *ParsedCredentialCreationData
-		wantErr bool
+	testCases := []struct {
+		name      string
+		args      args
+		expected  *ParsedCredentialCreationData
+		errString string
 	}{
 		{
-			name: "Successful Credential Request Parsing",
+			name: "ShouldParseCredentialRequest",
 			args: args{
-				response: httpReq,
+				responseName: "success",
 			},
-			want: &ParsedCredentialCreationData{
+			expected: &ParsedCredentialCreationData{
+				ParsedPublicKeyCredential: ParsedPublicKeyCredential{
+					ParsedCredential: ParsedCredential{
+						ID:   "6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+						Type: "public-key",
+					},
+					RawID: byteID,
+					ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+						"appid": true,
+					},
+				},
+				Response: ParsedAttestationResponse{
+					CollectedClientData: CollectedClientData{
+						Type:      CeremonyType("webauthn.create"),
+						Challenge: "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE",
+						Origin:    "https://webauthn.io",
+					},
+					AttestationObject: AttestationObject{
+						Format:      "none",
+						RawAuthData: byteAuthData,
+						AuthData: AuthenticatorData{
+							RPIDHash: byteRPIDHash,
+							Counter:  0,
+							Flags:    0x041,
+							AttData: AttestedCredentialData{
+								AAGUID:              make([]byte, 16),
+								CredentialID:        byteID,
+								CredentialPublicKey: byteCredentialPubKey,
+							},
+						},
+					},
+					Transports: []AuthenticatorTransport{USB, NFC, "fake"},
+				},
+				Raw: CredentialCreationResponse{
+					PublicKeyCredential: PublicKeyCredential{
+						Credential: Credential{
+							Type: "public-key",
+							ID:   "6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+						},
+						RawID: byteID,
+						ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+							"appid": true,
+						},
+					},
+					AttestationResponse: AuthenticatorAttestationResponse{
+						AuthenticatorResponse: AuthenticatorResponse{
+							ClientDataJSON: byteClientDataJSON,
+						},
+						AttestationObject: byteAttObject,
+						Transports:        []string{"usb", "nfc", "fake"},
+					},
+				},
+			},
+			errString: "",
+		},
+		{
+			name: "ShouldParseCredentialRequestDeprecatedTransports",
+			args: args{
+				responseName: "successDeprecatedTransports",
+			},
+			expected: &ParsedCredentialCreationData{
 				ParsedPublicKeyCredential: ParsedPublicKeyCredential{
 					ParsedCredential: ParsedCredential{
 						ID:   "6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
@@ -89,60 +147,106 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 					Transports: []string{"usb", "nfc", "fake"},
 				},
 			},
-			wantErr: false,
+			errString: "",
+		},
+		{
+			name: "ShouldParseCredentialRequestDeprecatedTransportsShouldNotOverride",
+			args: args{
+				responseName: "successDeprecatedTransportsAndNew",
+			},
+			expected: &ParsedCredentialCreationData{
+				ParsedPublicKeyCredential: ParsedPublicKeyCredential{
+					ParsedCredential: ParsedCredential{
+						ID:   "6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+						Type: "public-key",
+					},
+					RawID: byteID,
+					ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+						"appid": true,
+					},
+				},
+				Response: ParsedAttestationResponse{
+					CollectedClientData: CollectedClientData{
+						Type:      CeremonyType("webauthn.create"),
+						Challenge: "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE",
+						Origin:    "https://webauthn.io",
+					},
+					AttestationObject: AttestationObject{
+						Format:      "none",
+						RawAuthData: byteAuthData,
+						AuthData: AuthenticatorData{
+							RPIDHash: byteRPIDHash,
+							Counter:  0,
+							Flags:    0x041,
+							AttData: AttestedCredentialData{
+								AAGUID:              make([]byte, 16),
+								CredentialID:        byteID,
+								CredentialPublicKey: byteCredentialPubKey,
+							},
+						},
+					},
+					Transports: []AuthenticatorTransport{USB, NFC},
+				},
+				Raw: CredentialCreationResponse{
+					PublicKeyCredential: PublicKeyCredential{
+						Credential: Credential{
+							Type: "public-key",
+							ID:   "6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+						},
+						RawID: byteID,
+						ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+							"appid": true,
+						},
+					},
+					AttestationResponse: AuthenticatorAttestationResponse{
+						AuthenticatorResponse: AuthenticatorResponse{
+							ClientDataJSON: byteClientDataJSON,
+						},
+						AttestationObject: byteAttObject,
+						Transports:        []string{"usb", "nfc"},
+					},
+					Transports: []string{"usb", "nfc", "fake"},
+				},
+			},
+			errString: "",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseCredentialCreationResponse(tt.args.response)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseCredentialCreationResponse() error = %v, wantErr %v", err, tt.wantErr)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := io.NopCloser(bytes.NewReader([]byte(testCredentialRequestResponses[tc.args.responseName])))
+
+			actual, err := ParseCredentialCreationResponseBody(body)
+
+			if tc.errString != "" {
+				assert.EqualError(t, err, tc.errString)
+
 				return
 			}
-			if !reflect.DeepEqual(got.ClientExtensionResults, tt.want.ClientExtensionResults) {
-				t.Errorf("Extensions = %v \n want: %v", got.ClientExtensionResults, tt.want.ClientExtensionResults)
-			}
-			if !reflect.DeepEqual(got.Response.Transports, tt.want.Response.Transports) {
-				t.Errorf("Transports = %v \n want: %v", got.Response.Transports, tt.want.Response.Transports)
-			}
-			if !reflect.DeepEqual(got.ID, tt.want.ID) {
-				t.Errorf("ID = %v \n want: %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got.ParsedCredential, tt.want.ParsedCredential) {
-				t.Errorf("ParsedCredential = %v \n want: %v", got.ParsedCredential, tt.want.ParsedCredential)
-			}
-			if !reflect.DeepEqual(got.ParsedPublicKeyCredential, tt.want.ParsedPublicKeyCredential) {
-				t.Errorf("ParsedPublicKeyCredential = %v \n want: %v", got.ParsedPublicKeyCredential, tt.want.ParsedPublicKeyCredential)
-			}
-			if !reflect.DeepEqual(got.Raw, tt.want.Raw) {
-				t.Errorf("Raw = %v \n want: %v", got.Raw, tt.want.Raw)
-			}
-			if !reflect.DeepEqual(got.RawID, tt.want.RawID) {
-				t.Errorf("RawID = %v \n want: %v", got.RawID, tt.want.RawID)
-			}
+
+			assert.Equal(t, tc.expected.ClientExtensionResults, actual.ClientExtensionResults)
+			assert.Equal(t, tc.expected.ID, actual.ID)
+			assert.Equal(t, tc.expected.Type, actual.Type)
+			assert.Equal(t, tc.expected.ParsedCredential, actual.ParsedCredential)
+			assert.Equal(t, tc.expected.ParsedPublicKeyCredential, actual.ParsedPublicKeyCredential)
+			assert.Equal(t, tc.expected.ParsedPublicKeyCredential, actual.ParsedPublicKeyCredential)
+			assert.Equal(t, tc.expected.Raw, actual.Raw)
+			assert.Equal(t, tc.expected.RawID, actual.RawID)
+			assert.Equal(t, tc.expected.Response.Transports, actual.Response.Transports)
+			assert.Equal(t, tc.expected.Response.CollectedClientData, actual.Response.CollectedClientData)
+			assert.Equal(t, tc.expected.Response.AttestationObject.AuthData.AttData.CredentialID, actual.Response.AttestationObject.AuthData.AttData.CredentialID)
+			assert.Equal(t, tc.expected.Response.AttestationObject.Format, actual.Response.AttestationObject.Format)
+
 			// Unmarshall CredentialPublicKey
-			var pkWant interface{}
-			keyBytesWant := tt.want.Response.AttestationObject.AuthData.AttData.CredentialPublicKey
-			webauthncbor.Unmarshal(keyBytesWant, &pkWant)
-			var pkGot interface{}
-			keyBytesGot := got.Response.AttestationObject.AuthData.AttData.CredentialPublicKey
-			webauthncbor.Unmarshal(keyBytesGot, &pkGot)
-			if !reflect.DeepEqual(pkGot, pkWant) {
-				t.Errorf("Response = %+v \n want: %+v", pkGot, pkWant)
-			}
-			if !reflect.DeepEqual(got.Type, tt.want.Type) {
-				t.Errorf("Type = %v \n want: %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got.Response.CollectedClientData, tt.want.Response.CollectedClientData) {
-				t.Errorf("CollectedClientData = %v \n want: %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got.Response.AttestationObject.Format, tt.want.Response.AttestationObject.Format) {
-				t.Errorf("Format = %v \n want: %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got.Response.AttestationObject.AuthData.AttData.CredentialID, tt.want.Response.AttestationObject.AuthData.AttData.CredentialID) {
-				t.Errorf("CredentialID = %v \n want: %v", got, tt.want)
-			}
+			var pkExpected, pkActual interface{}
+
+			pkBytesExpected := tc.expected.Response.AttestationObject.AuthData.AttData.CredentialPublicKey
+			assert.NoError(t, webauthncbor.Unmarshal(pkBytesExpected, &pkExpected))
+
+			pkBytesActual := actual.Response.AttestationObject.AuthData.AttData.CredentialPublicKey
+			assert.NoError(t, webauthncbor.Unmarshal(pkBytesActual, &pkActual))
+
+			assert.Equal(t, pkExpected, pkActual)
 		})
 	}
 }
@@ -243,7 +347,24 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 	}
 }
 
-var testCredentialRequestBody = `{
+var testCredentialRequestResponses = map[string]string{
+	`success`: `
+{
+	"id":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+	"rawId":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+	"type":"public-key",
+	"clientExtensionResults":{
+		"appid":true
+	},
+	"response":{
+		"attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw",
+		"clientDataJSON":"eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ",
+		"transports":["usb","nfc","fake"]
+	}
+}
+`,
+	`successDeprecatedTransports`: `
+{
 	"id":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
 	"rawId":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
 	"type":"public-key",
@@ -254,5 +375,23 @@ var testCredentialRequestBody = `{
 	"response":{
 		"attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw",
 		"clientDataJSON":"eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ"
-		}
-	}`
+	}
+}
+`,
+	`successDeprecatedTransportsAndNew`: `
+{
+	"id":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+	"rawId":"6xrtBhJQW6QU4tOaB4rrHaS2Ks0yDDL_q8jDC16DEjZ-VLVf4kCRkvl2xp2D71sTPYns-exsHQHTy3G-zJRK8g",
+	"type":"public-key",
+	"transports":["usb","nfc","fake"],
+	"clientExtensionResults":{
+		"appid":true
+	},
+	"response":{
+		"attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEdKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBBAAAAAAAAAAAAAAAAAAAAAAAAAAAAQOsa7QYSUFukFOLTmgeK6x2ktirNMgwy_6vIwwtegxI2flS1X-JAkZL5dsadg-9bEz2J7PnsbB0B08txvsyUSvKlAQIDJiABIVggLKF5xS0_BntttUIrm2Z2tgZ4uQDwllbdIfrrBMABCNciWCDHwin8Zdkr56iSIh0MrB5qZiEzYLQpEOREhMUkY6q4Vw",
+		"clientDataJSON":"eyJjaGFsbGVuZ2UiOiJXOEd6RlU4cEdqaG9SYldyTERsYW1BZnFfeTRTMUNaRzFWdW9lUkxBUnJFIiwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdXRobi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5jcmVhdGUifQ",
+		"transports":["usb","nfc"]
+	}
+}
+`,
+}

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -31,7 +31,7 @@ var (
 		Details: "Error validating the authenticator response",
 	}
 	ErrAttestation = &Error{
-		Type:    "attesation_error",
+		Type:    "attestation_error",
 		Details: "Error validating the attestation data provided",
 	}
 	ErrInvalidAttestation = &Error{

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -37,7 +37,7 @@ func MakeNewCredential(c *protocol.ParsedCredentialCreationData) (*Credential, e
 		ID:              c.Response.AttestationObject.AuthData.AttData.CredentialID,
 		PublicKey:       c.Response.AttestationObject.AuthData.AttData.CredentialPublicKey,
 		AttestationType: c.Response.AttestationObject.Format,
-		Transport:       c.Transports,
+		Transport:       c.Response.Transports,
 		Authenticator: Authenticator{
 			AAGUID:    c.Response.AttestationObject.AuthData.AttData.AAGUID,
 			SignCount: c.Response.AttestationObject.AuthData.Counter,


### PR DESCRIPTION
The transports JSON path as far as the Webauthn level 3 spec is concerned is response.transports i.e. within the response object with response.clientDataJSON and response.attestationObject. This fixes this location and allows for backwards temporary compatibility for anyone implementing the previous method. See the typedef https://w3c.github.io/webauthn/#typedefdef-publickeycredentialjson for more information.