### PR TITLE
fix(webauthn): missing user display name from session

### DIFF
--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -58,6 +58,7 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 	newSessionData := SessionData{
 		Challenge:        challenge.String(),
 		UserID:           user.WebAuthnID(),
+		UserDisplayName:  user.WebAuthnDisplayName(),
 		UserVerification: creationOptions.AuthenticatorSelection.UserVerification,
 	}
 

--- a/webauthn/session.go
+++ b/webauthn/session.go
@@ -7,6 +7,7 @@ import "github.com/go-webauthn/webauthn/protocol"
 type SessionData struct {
 	Challenge            string                               `json:"challenge"`
 	UserID               []byte                               `json:"user_id"`
+	UserDisplayName      string                               `json:"user_display_name"`
 	AllowedCredentialIDs [][]byte                             `json:"allowed_credentials,omitempty"`
 	UserVerification     protocol.UserVerificationRequirement `json:"userVerification"`
 	Extensions           protocol.AuthenticationExtensions    `json:"extensions,omitempty"`


### PR DESCRIPTION
This includes the missing user display name value from the session data so if a relying party desires they can easily save the value during the finish registration stage for later to easily show the user. This is because the display name value should be set by the user and not the relying party.