### PR TITLE
revert: fix(webauthn): missing user display name from session

### DIFF
--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -60,7 +60,6 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 	session := SessionData{
 		Challenge:        challenge.String(),
 		UserID:           user.WebAuthnID(),
-		UserDisplayName:  user.WebAuthnDisplayName(),
 		UserVerification: creationOptions.AuthenticatorSelection.UserVerification,
 	}
 

--- a/webauthn/session.go
+++ b/webauthn/session.go
@@ -7,7 +7,6 @@ import "github.com/go-webauthn/webauthn/protocol"
 type SessionData struct {
 	Challenge            string                               `json:"challenge"`
 	UserID               []byte                               `json:"user_id"`
-	UserDisplayName      string                               `json:"user_display_name"`
 	AllowedCredentialIDs [][]byte                             `json:"allowed_credentials,omitempty"`
 	UserVerification     protocol.UserVerificationRequirement `json:"userVerification"`
 	Extensions           protocol.AuthenticationExtensions    `json:"extensions,omitempty"`


### PR DESCRIPTION
Turns out this was the incorrect method to handle this.