### PR TITLE
fix: validate configuration on all begin funcs

### DIFF
--- a/webauthn/const.go
+++ b/webauthn/const.go
@@ -1,0 +1,10 @@
+package webauthn
+
+const (
+	errFmtEmptyField     = "the field '%s' must be configured but it is empty"
+	errFmtConfigValidate = "error occurred validating the configuration: %w"
+)
+
+const (
+	defaultTimeout = 60000
+)


### PR DESCRIPTION
This adjusts the BeginLogin, BeginDiscoverableLogin, and BeginRegistration methods to invoke the Config.validate() function ensuring implementers who create a new Config manually still go through the validation process. This has potential to be a breaking change as validation can no longer be skipped but it's preferable that we account for those specific use cases in our validations. This allows us to make it easy to ensure deprecated options to be properly remapped.