### PR TITLE
fix(protocol): expose ccr/car parse method

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -64,6 +64,14 @@ func ParseCredentialRequestResponseBody(body io.Reader) (par *ParsedCredentialAs
 		return nil, ErrBadRequest.WithDetails("Parse error for Assertion")
 	}
 
+	return car.Parse()
+}
+
+// Parse validates and parses the CredentialAssertionResponse into a ParseCredentialCreationResponseBody. This receiver
+// is unlikely to be expressly guaranteed under the versioning policy. Users looking for this guarantee should see
+// ParseCredentialRequestResponseBody instead, and this receiver should only be used if that function is inadequate
+// for their use case.
+func (car CredentialAssertionResponse) Parse() (par *ParsedCredentialAssertionData, err error) {
 	if car.ID == "" {
 		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with ID missing")
 	}

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -71,6 +71,14 @@ func ParseCredentialCreationResponseBody(body io.Reader) (pcc *ParsedCredentialC
 		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo(err.Error())
 	}
 
+	return ccr.Parse()
+}
+
+// Parse validates and parses the CredentialCreationResponse into a ParsedCredentialCreationData. This receiver
+// is unlikely to be expressly guaranteed under the versioning policy. Users looking for this guarantee should see
+// ParseCredentialCreationResponseBody instead, and this receiver should only be used if that function is inadequate
+// for their use case.
+func (ccr CredentialCreationResponse) Parse() (pcc *ParsedCredentialCreationData, err error) {
 	if ccr.ID == "" {
 		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo("Missing ID")
 	}
@@ -93,7 +101,7 @@ func ParseCredentialCreationResponseBody(body io.Reader) (pcc *ParsedCredentialC
 		return nil, ErrParsingData.WithDetails("Error parsing attestation response")
 	}
 
-	// TODO: Remove this as it's a backwards compatability layer.
+	// TODO: Remove this as it's a backwards compatibility layer.
 	if len(response.Transports) == 0 && len(ccr.Transports) != 0 {
 		for _, t := range ccr.Transports {
 			response.Transports = append(response.Transports, AuthenticatorTransport(t))


### PR DESCRIPTION
This fixes inaccessibility to parsing protocol.CredentialCreationResponse / protocol.CredentialAssertionResponse into a protocol.ParsedCredentialCreationData / protocol.ParsedCredentialAssertionData object which may prevent the use of the library with gRPC for example.