### PR TITLE
build(deps): utilize github.com/go-webauthn/x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.0
-	github.com/go-webauthn/revoke v0.1.10
+	github.com/go-webauthn/x v0.1.2
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-tpm v0.3.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,10 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-webauthn/revoke v0.1.10 h1:GSJNJ8NbgeMaINAxMV7D4uBjyQnqCzAfB8ZfgNyTqqA=
-github.com/go-webauthn/revoke v0.1.10/go.mod h1:rwjnIbJHdWgp9jlRU8Y3r7DX8PZ8+ZusDaMVhaMIMrk=
+github.com/go-webauthn/x v0.1.2-0.20230627233425-91f622ae5a3e h1:S+9L3uJSdMcEOzVR16yx3VI/Vau6HEouqe4VC8nmxSU=
+github.com/go-webauthn/x v0.1.2-0.20230627233425-91f622ae5a3e/go.mod h1:4NjxhWb1fISfhyTBEvJKmKa0ytlJeZpvnDtcXqksuTk=
+github.com/go-webauthn/x v0.1.2 h1:PMV340FbgkftsQde75hoZpLkeaRC+1WFSYxJFg5OgeU=
+github.com/go-webauthn/x v0.1.2/go.mod h1:4NjxhWb1fISfhyTBEvJKmKa0ytlJeZpvnDtcXqksuTk=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -7,10 +7,11 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/go-webauthn/revoke"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/go-webauthn/x/revoke"
 
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )


### PR DESCRIPTION
Replaces the revoke library and instead creates a library for purposes like this in the future.