### PR TITLE
fix(protocol): mark transports field as deprecated

### DIFF
--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -48,7 +48,8 @@ type CredentialCreationResponse struct {
 	PublicKeyCredential
 	AttestationResponse AuthenticatorAttestationResponse `json:"response"`
 
-	// Deprecated: Use the Transports field of AuthenticatorAttestationResponse
+	// Deprecated: Transports is deprecated due to upstream changes to the API. 
+	// Use the Transports field of AuthenticatorAttestationResponse
 	// instead. Transports is kept for backward compatibility, and should not
 	// be used by new clients.
 	Transports []string `json:"transports,omitempty"`

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -47,7 +47,11 @@ type ParsedPublicKeyCredential struct {
 type CredentialCreationResponse struct {
 	PublicKeyCredential
 	AttestationResponse AuthenticatorAttestationResponse `json:"response"`
-	Transports          []string                         `json:"transports,omitempty"`
+
+	// Deprecated: Use the Transports field of AuthenticatorAttestationResponse
+	// instead. Transports is kept for backward compatibility, and should not
+	// be used by new clients.
+	Transports []string `json:"transports,omitempty"`
 }
 
 type ParsedCredentialCreationData struct {


### PR DESCRIPTION
Mark `CredentialCreationResponse.Transports` as deprecated with doc-comments. This field was effectively deprecated in #113, but without any comments making that clear to consumers of the library.