### PR TITLE
fix(webauthn): validate discoverable login with handle = nil

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -167,10 +167,6 @@ func (webauthn *WebAuthn) ValidateDiscoverableLogin(handler DiscoverableUserHand
 		return nil, protocol.ErrBadRequest.WithDetails("Session was not initiated as a client-side discoverable login")
 	}
 
-	if parsedResponse.Response.UserHandle == nil {
-		return nil, protocol.ErrBadRequest.WithDetails("Client-side Discoverable Assertion was attempted with a blank User Handle")
-	}
-
 	user, err := handler(parsedResponse.RawID, parsedResponse.Response.UserHandle)
 	if err != nil {
 		return nil, protocol.ErrBadRequest.WithDetails(fmt.Sprintf("Failed to lookup Client-side Discoverable Credential: %s", err))


### PR DESCRIPTION
I ran into an issue while trying to use the credentials over the phone where the signed response does not contain a user handle.

Digging into this, I found https://w3c.github.io/webauthn/#user-handle

>[Discoverable credentials](https://w3c.github.io/webauthn/#discoverable-credential) store this identifier and MUST return it as [response](https://w3c.github.io/webauthn/#dom-publickeycredential-response).[userHandle](https://w3c.github.io/webauthn/#dom-authenticatorassertionresponse-userhandle) in [authentication ceremonies](https://w3c.github.io/webauthn/#authentication-ceremony) started with an [empty](https://infra.spec.whatwg.org/#list-empty) [allowCredentials](https://w3c.github.io/webauthn/#dom-publickeycredentialrequestoptions-allowcredentials) argument.

and

>The main use of the [user handle](https://w3c.github.io/webauthn/#user-handle) is to identify the [user account](https://w3c.github.io/webauthn/#user-account) in such [authentication ceremonies](https://w3c.github.io/webauthn/#authentication-ceremony), but the [credential ID](https://w3c.github.io/webauthn/#credential-id) could be used instead.

I suppose this means that the user handle can be absent in case the ceremony is started with specific allowed credentials?

Seems like there has been some relvant discussions [here](https://github.com/w3c/webauthn/issues/1892) and [here](https://github.com/w3c/webauthn/pull/558#issuecomment-330317134)

The implementation should then, at least
```
if len(session.AllowedCredentialIDs) > 0 {
    ...
}
```

Or perhaps save the intended user handle in session with the help of another LoginOption and in ValidateDiscoverableLogin just use the handle from the session (if present), as the whole issue seems to be about indexing?

In any case, to me, it looks like it's valid with a UserHandle == nil response.

To add, apparently, I could not use the phone to do login with no AllowedCredentials specified from some reason which i don't fully understand yet (Yubikey works fine though).

Edit:
The credentials for the RP just wasn't listed by default having AllowedCredentials = nil. There was another button `more options -> this device` that listed the usable credentials.
