### PR TITLE
fix(protocol): previous unmarshal functionality broken

### DIFF
--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -321,16 +321,14 @@ func (a *AuthenticatorData) unmarshalAttestedData(rawAuthData []byte) (err error
 }
 
 // Unmarshall the credential's Public Key into CBOR encoding.
-func unmarshalCredentialPublicKey(keyBytes []byte) ([]byte, error) {
+func unmarshalCredentialPublicKey(keyBytes []byte) (rawBytes []byte, err error) {
 	var m interface{}
 
-	err := webauthncbor.Unmarshal(keyBytes, &m)
-	if err != nil {
+	if err = webauthncbor.Unmarshal(keyBytes, &m); err != nil {
 		return nil, err
 	}
 
-	rawBytes, err := webauthncbor.Marshal(m)
-	if err != nil {
+	if rawBytes, err = webauthncbor.Marshal(m); err != nil {
 		return nil, err
 	}
 

--- a/protocol/webauthncbor/webauthncbor.go
+++ b/protocol/webauthncbor/webauthncbor.go
@@ -19,7 +19,10 @@ var ctap2CBOREncMode, _ = cbor.CTAP2EncOptions().EncMode()
 // following the CTAP2 canonical CBOR encoding form.
 // (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding)
 func Unmarshal(data []byte, v interface{}) error {
-	return ctap2CBORDecMode.Unmarshal(data, v)
+	// TODO (james-d-elliott): investigate the specific use case for Unmarshal vs UnmarshalFirst to determine the edge cases where this may be useful.
+	_, err := ctap2CBORDecMode.UnmarshalFirst(data, v)
+
+	return err
 }
 
 // Marshal encodes the value pointed to by v

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -180,6 +180,7 @@ func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) func() hash.Hash {
 // ParsePublicKey figures out what kind of COSE material was provided and create the data for the new key.
 func ParsePublicKey(keyBytes []byte) (interface{}, error) {
 	pk := PublicKeyData{}
+	// TODO (james-d-elliott): investigate the ignored errors.
 	webauthncbor.Unmarshal(keyBytes, &pk)
 
 	switch COSEKeyType(pk.KeyType) {


### PR DESCRIPTION
This fixes an CBOR unmarshalling issue that was caused without properly reading the upgrade notes for a dependency upgrade. We added a note to ensure we investigate the specific use case for the new unmarshal method later.