### PR TITLE
fix(protocol): display name omitted incorrectly

### DIFF
--- a/protocol/entities.go
+++ b/protocol/entities.go
@@ -45,7 +45,7 @@ type UserEntity struct {
 	// A human-palatable name for the user account, intended only for display.
 	// For example, "Alex P. Müller" or "田中 倫". The Relying Party SHOULD let
 	// the user choose this, and SHOULD NOT restrict the choice more than necessary.
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName string `json:"displayName"`
 
 	// ID is the user handle of the user account entity. To ensure secure operation,
 	// authentication and authorization decisions MUST be made on the basis of this id

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -35,8 +35,8 @@ func TestEntityEncoding(t *testing.T) {
 		b64            bool
 		have, expected string
 	}{
-		{"ShouldEncodeBase64", true, "abc", "{\"name\":\"\",\"id\":\"YWJj\"}"},
-		{"ShouldEncodeString", false, "abc", "{\"name\":\"\",\"id\":\"abc\"}"},
+		{"ShouldEncodeBase64", true, "abc", `{"name":"","displayName":"","id":"YWJj"}`},
+		{"ShouldEncodeString", false, "abc", `{"name":"","displayName":"","id":"abc"}`},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This fixes an issue where the displayName value for a user entity was omitted in error. See https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-user and https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialuserentity (and the same links for level 2).

Fixes #183