### PR TITLE
Update finish loging example

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,14 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+
+	// Handle credential.Authenticator.CloneWarning
+
+	// If login was successful, update the credential object
+	// Pseudocode to update the user credential.
+	user.UpdateCredential(credential)
+	datastore.SaveUser(user)
 	
-	// If login was successful, handle next steps
 	JSONResponse(w, "Login Success", http.StatusOK)
 }
 ```


### PR DESCRIPTION
I think it is important to note that `credential.Authenticator.CloneWarning` should be checked (or willfully ignored). And also credential should be stored, otherwise counter checking does not really work?

Is it safe to just overwrite the credential or are there values in registration credential which are missing from the logic credential object?

Is there anything else which should be validated in business logic and is missing from the example?