### PR TITLE
feat(config): allow rpid to be defined at execution time

### DIFF
--- a/webauthn/const.go
+++ b/webauthn/const.go
@@ -5,7 +5,6 @@ import (
 )
 
 const (
-	errFmtFieldEmpty       = "the field '%s' must be configured but it is empty"
 	errFmtFieldNotValidURI = "field '%s' is not a valid URI: %w"
 	errFmtConfigValidate   = "error occurred validating the configuration: %w"
 )

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -3,6 +3,9 @@ package webauthn
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-webauthn/webauthn/protocol"
 )
 
@@ -24,5 +27,84 @@ func TestLogin_FinishLoginFailure(t *testing.T) {
 
 	if credential != nil {
 		t.Errorf("FinishLogin() credential = %v, want nil", credential)
+	}
+}
+
+func TestWithLoginRelyingPartyID(t *testing.T) {
+	testCases := []struct {
+		name       string
+		have       *Config
+		opts       []LoginOption
+		expectedID string
+		err        string
+	}{
+		{
+			name: "OptionDefinedInConfig",
+			have: &Config{
+				RPID:          "https://example.com",
+				RPDisplayName: "Test Display Name",
+				RPOrigins:     []string{"https://example.com"},
+			},
+			opts:       nil,
+			expectedID: "https://example.com",
+		},
+		{
+			name: "OptionDefinedInConfigAndOpts",
+			have: &Config{
+				RPID:          "https://example.com",
+				RPDisplayName: "Test Display Name",
+				RPOrigins:     []string{"https://example.com"},
+			},
+			opts:       []LoginOption{WithLoginRelyingPartyID("https://a.example.com")},
+			expectedID: "https://a.example.com",
+		},
+		{
+			name: "OptionDefinedInConfigWithNoErrAndInOptsWithError",
+			have: &Config{
+				RPID:          "https://example.com",
+				RPDisplayName: "Test Display Name",
+				RPOrigins:     []string{"https://example.com"},
+			},
+			opts: []LoginOption{WithLoginRelyingPartyID("---::~!!~@#M!@OIK#N!@IOK@@@@@@@@@@")},
+			err:  "error generating assertion: the relying party id failed to validate as it's not a valid uri with error: parse \"---::~!!~@\": first path segment in URL cannot contain colon",
+		},
+		{
+			name: "OptionDefinedInOpts",
+			have: &Config{
+				RPOrigins: []string{"https://example.com"},
+			},
+			opts:       []LoginOption{WithLoginRelyingPartyID("https://example.com")},
+			expectedID: "https://example.com",
+		},
+		{
+			name: "OptionIDNotDefined",
+			have: &Config{
+				RPOrigins: []string{"https://example.com"},
+			},
+			opts: nil,
+			err:  "error generating assertion: the relying party id must be provided via the configuration or a functional option for a login",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(tc.have)
+			assert.NoError(t, err)
+
+			user := &defaultUser{
+				credentials: []Credential{
+					{},
+				},
+			}
+
+			creation, _, err := w.BeginLogin(user, tc.opts...)
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+				require.NotNil(t, creation)
+				assert.Equal(t, tc.expectedID, creation.Response.RelyingPartyID)
+			}
+		})
 	}
 }

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/go-webauthn/webauthn/protocol"
@@ -67,6 +68,16 @@ func (webauthn *WebAuthn) BeginRegistration(user User, opts ...RegistrationOptio
 
 	for _, opt := range opts {
 		opt(&creation.Response)
+	}
+
+	if len(creation.Response.RelyingParty.ID) == 0 {
+		return nil, nil, fmt.Errorf("error generating credential creation: the relying party id must be provided via the configuration or a functional option for a creation")
+	} else if _, err = url.Parse(creation.Response.RelyingParty.ID); err != nil {
+		return nil, nil, fmt.Errorf("error generating credential creation: the relying party id failed to validate as it's not a valid uri with error: %w", err)
+	}
+
+	if len(creation.Response.RelyingParty.Name) == 0 {
+		return nil, nil, fmt.Errorf("error generating credential creation: the relying party display name must be provided via the configuration or a functional option for a creation")
 	}
 
 	if creation.Response.Timeout == 0 {
@@ -173,6 +184,20 @@ func WithAppIdExcludeExtension(appid string) RegistrationOption {
 				cco.Extensions[protocol.ExtensionAppIDExclude] = appid
 			}
 		}
+	}
+}
+
+// WithRegistrationRelyingPartyID sets the relying party id for the registration.
+func WithRegistrationRelyingPartyID(id string) RegistrationOption {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+		cco.RelyingParty.ID = id
+	}
+}
+
+// WithRegistrationRelyingPartyName sets the relying party name for the registration.
+func WithRegistrationRelyingPartyName(name string) RegistrationOption {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+		cco.RelyingParty.Name = name
 	}
 }
 

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -91,18 +91,12 @@ func (config *Config) validate() error {
 		return nil
 	}
 
-	if len(config.RPDisplayName) == 0 {
-		return fmt.Errorf(errFmtFieldEmpty, "RPDisplayName")
-	}
-
-	if len(config.RPID) == 0 {
-		return fmt.Errorf(errFmtFieldEmpty, "RPID")
-	}
-
 	var err error
 
-	if _, err = url.Parse(config.RPID); err != nil {
-		return fmt.Errorf(errFmtFieldNotValidURI, "RPID", err)
+	if len(config.RPID) != 0 {
+		if _, err = url.Parse(config.RPID); err != nil {
+			return fmt.Errorf(errFmtFieldNotValidURI, "RPID", err)
+		}
 	}
 
 	defaultTimeoutConfig := defaultTimeout

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -1,8 +1,8 @@
 package webauthn
 
-// TODO: move this to a _test.go file.
 type defaultUser struct {
-	id []byte
+	id          []byte
+	credentials []Credential
 }
 
 var _ User = (*defaultUser)(nil)
@@ -19,10 +19,6 @@ func (user *defaultUser) WebAuthnDisplayName() string {
 	return "New User"
 }
 
-func (user *defaultUser) WebAuthnIcon() string {
-	return "https://pics.com/avatar.png"
-}
-
 func (user *defaultUser) WebAuthnCredentials() []Credential {
-	return []Credential{}
+	return user.credentials
 }


### PR DESCRIPTION
This allows the Relying Party ID and Name to be configured at runtime rather than at configuration time.

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added validation for Relying Party ID in the login and registration processes.
	- Introduced functions to set Relying Party ID and name for registration.
- **Bug Fixes**
	- Adjusted error formatting for invalid URIs and configuration validation.
- **Tests**
	- Added new test cases for login and registration processes focusing on Relying Party ID and name validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->