### PR TITLE
feat!: backup flag validation

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -288,6 +288,11 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 		return nil, protocol.ErrBadRequest.WithDetails("BackupEligible flag inconsistency detected during login validation")
 	}
 
+	// Check for the invalid combination BE=0 and BS=1.
+	if !parsedResponse.Response.AuthenticatorData.Flags.HasBackupEligible() && parsedResponse.Response.AuthenticatorData.Flags.HasBackupState() {
+		return nil, protocol.ErrBadRequest.WithDetails("Invalid flag combination: BE=0 and BS=1")
+	}
+
 	// Update flags from response data.
 	loginCredential.Flags.UserPresent = parsedResponse.Response.AuthenticatorData.Flags.HasUserPresent()
 	loginCredential.Flags.UserVerified = parsedResponse.Response.AuthenticatorData.Flags.HasUserVerified()

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -285,7 +285,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 	loginCredential.Authenticator.UpdateCounter(parsedResponse.Response.AuthenticatorData.Counter)
 	// Check if the BackupEligible flag has changed.
 	if loginCredential.Flags.BackupEligible != parsedResponse.Response.AuthenticatorData.Flags.HasBackupEligible() {
-		return nil, protocol.ErrBadRequest.WithDetails("BackupEligible flag should not change")
+		return nil, protocol.ErrBadRequest.WithDetails("BackupEligible flag inconsistency detected during login validation")
 	}
 
 	// Update flags from response data.

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -283,8 +283,11 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 
 	// Handle step 17.
 	loginCredential.Authenticator.UpdateCounter(parsedResponse.Response.AuthenticatorData.Counter)
+	// Check if the BackupEligible flag has changed.
+	if loginCredential.Flags.BackupEligible != parsedResponse.Response.AuthenticatorData.Flags.HasBackupEligible() {
+		return nil, protocol.ErrBadRequest.WithDetails("BackupEligible flag should not change")
+	}
 
-	// TODO: The backup eligible flag shouldn't change. Should decide if we want to error if it does.
 	// Update flags from response data.
 	loginCredential.Flags.UserPresent = parsedResponse.Response.AuthenticatorData.Flags.HasUserPresent()
 	loginCredential.Flags.UserVerified = parsedResponse.Response.AuthenticatorData.Flags.HasUserVerified()


### PR DESCRIPTION
This pull request addresses an issue where the BackupEligible flag could be inadvertently altered during the login validation process. The following changes have been made:

- Added a check in the validateLogin function to ensure that the BackupEligible flag remains consistent.
- If the BackupEligible flag is found to be altered, an error is returned.
- Updated the validateLogin function to handle this validation step appropriately.