### PR TITLE
refactor(protocol): clean up 'nil != nil' is always false

### DIFF
--- a/protocol/attestation_apple.go
+++ b/protocol/attestation_apple.go
@@ -77,7 +77,7 @@ func verifyAppleFormat(att AttestationObject, clientDataHash []byte) (string, []
 		return "", nil, ErrAttestationFormat.WithDetails("Unable to parse apple attestation certificate extensions")
 	}
 
-	if !bytes.Equal(decoded.Nonce, nonce[:]) || err != nil {
+	if !bytes.Equal(decoded.Nonce, nonce[:]) {
 		return "", nil, ErrInvalidAttestation.WithDetails("Attestation certificate does not contain expected nonce")
 	}
 


### PR DESCRIPTION
`err` is nil after the above `Unmarshal`, so `err` must be `nil` at this point. This warning is via gopls x/tools/go/analysis/passes/nilness "impossible condition: nil != nil nilness(cond)"