### PR TITLE
refactor(protocol): clear staticcheck warnings on AttestationChallenge check

### DIFF
--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -111,7 +111,7 @@ func verifyAndroidKeyFormat(att AttestationObject, clientDataHash []byte) (strin
 	}
 
 	// Verify that the attestationChallenge field in the attestation certificate extension data is identical to clientDataHash.
-	if 0 != bytes.Compare(decoded.AttestationChallenge, clientDataHash) {
+	if !bytes.Equal(decoded.AttestationChallenge, clientDataHash) {
 		return "", nil, ErrAttestationFormat.WithDetails("Attestation challenge not equal to clientDataHash")
 	}
 


### PR DESCRIPTION
The first warning from `staticcheck` is about Yoda conditions (which hides another warning)

> protocol/attestation_androidkey.go:114:5: don't use Yoda conditions (ST1017)

The hidden warning on the same line with `bytes.Compare(...) != 0` is

> protocol/attestation_androidkey.go:114:5: should use !bytes.Equal(decoded.AttestationChallenge, clientDataHash) instead (S1004)