### PR TITLE
refactor(protocol): decoder error 'should not be capitalized'

### DIFF
--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -103,7 +103,7 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 			errString:  "Parse error for Assertion",
 			errType:    "invalid_request",
 			errDetails: "Parse error for Assertion",
-			errInfo:    "The body contains trailing data",
+			errInfo:    "the body contains trailing data",
 		},
 	}
 

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -103,7 +103,7 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 			errString:  "Parse error for Registration",
 			errType:    "invalid_request",
 			errDetails: "Parse error for Registration",
-			errInfo:    "The body contains trailing data",
+			errInfo:    "the body contains trailing data",
 		},
 	}
 

--- a/protocol/decoder.go
+++ b/protocol/decoder.go
@@ -16,7 +16,7 @@ func decodeBody(body io.Reader, v any) (err error) {
 	_, err = decoder.Token()
 
 	if !errors.Is(err, io.EOF) {
-		return errors.New("The body contains trailing data")
+		return errors.New("the body contains trailing data")
 	}
 
 	return nil


### PR DESCRIPTION
staticcheck reports:
> protocol/decoder.go:19:10: error strings should not be capitalized (ST1005)