### PR TITLE
feat!: allow empty modality values

### DIFF
--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -131,14 +131,6 @@ func (config *Config) validate() error {
 		}
 	}
 
-	if config.AuthenticatorSelection.RequireResidentKey == nil {
-		config.AuthenticatorSelection.RequireResidentKey = protocol.ResidentKeyNotRequired()
-	}
-
-	if config.AuthenticatorSelection.UserVerification == "" {
-		config.AuthenticatorSelection.UserVerification = protocol.VerificationPreferred
-	}
-
 	config.validated = true
 
 	return nil


### PR DESCRIPTION
This allows setting empty require resident key and user verification values for the selection criteria.

BREAKING CHANGE: This change will change default behaviour. Previously the required resident key value was set to false, and the user verification option was set to 'preferred'.