### PR TITLE
feat: parse credential bytes

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -73,6 +73,18 @@ func ParseCredentialRequestResponseBody(body io.Reader) (par *ParsedCredentialAs
 	return car.Parse()
 }
 
+// ParseCredentialRequestResponseBytes is an alternative version of ParseCredentialRequestResponseBody that just takes
+// a byte slice.
+func ParseCredentialRequestResponseBytes(data []byte) (par *ParsedCredentialAssertionData, err error) {
+	var car CredentialAssertionResponse
+
+	if err = decodeBytes(data, &car); err != nil {
+		return nil, ErrBadRequest.WithDetails("Parse error for Assertion").WithInfo(err.Error())
+	}
+
+	return car.Parse()
+}
+
 // Parse validates and parses the CredentialAssertionResponse into a ParseCredentialCreationResponseBody. This receiver
 // is unlikely to be expressly guaranteed under the versioning policy. Users looking for this guarantee should see
 // ParseCredentialRequestResponseBody instead, and this receiver should only be used if that function is inadequate

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -85,6 +85,18 @@ func ParseCredentialCreationResponseBody(body io.Reader) (pcc *ParsedCredentialC
 	return ccr.Parse()
 }
 
+// ParseCredentialCreationResponseBytes is an alternative version of ParseCredentialCreationResponseBody that just takes
+// a byte slice.
+func ParseCredentialCreationResponseBytes(data []byte) (pcc *ParsedCredentialCreationData, err error) {
+	var ccr CredentialCreationResponse
+
+	if err = decodeBytes(data, &ccr); err != nil {
+		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo(err.Error())
+	}
+
+	return ccr.Parse()
+}
+
 // Parse validates and parses the CredentialCreationResponse into a ParsedCredentialCreationData. This receiver
 // is unlikely to be expressly guaranteed under the versioning policy. Users looking for this guarantee should see
 // ParseCredentialCreationResponseBody instead, and this receiver should only be used if that function is inadequate

--- a/protocol/decoder.go
+++ b/protocol/decoder.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -8,6 +9,22 @@ import (
 
 func decodeBody(body io.Reader, v any) (err error) {
 	decoder := json.NewDecoder(body)
+
+	if err = decoder.Decode(v); err != nil {
+		return err
+	}
+
+	_, err = decoder.Token()
+
+	if !errors.Is(err, io.EOF) {
+		return errors.New("The body contains trailing data")
+	}
+
+	return nil
+}
+
+func decodeBytes(data []byte, v any) (err error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
 
 	if err = decoder.Decode(v); err != nil {
 		return err


### PR DESCRIPTION
This adds methods to parse raw byte slices instead of an io.Reader via protocol.ParseCredentialCreationResponseBytes and protocol.ParseCredentialRequestResponseBytes.