### PR TITLE
fix(metadata): functional opt sets wrong value

### DIFF
--- a/metadata/providers/memory/options.go
+++ b/metadata/providers/memory/options.go
@@ -63,7 +63,7 @@ func WithValidateStatus(validate bool) Option {
 // known types the authenticator can produce. Default is true.
 func WithValidateAttestationTypes(validate bool) Option {
 	return func(provider *Provider) (err error) {
-		provider.status = validate
+		provider.attestation = validate
 
 		return nil
 	}


### PR DESCRIPTION
This fixes an issue where the functional option sets the wrong value.

Fixes #266