### PR TITLE
fix(metadata): file closed too early

### DIFF
--- a/metadata/decode.go
+++ b/metadata/decode.go
@@ -80,10 +80,8 @@ func (d *Decoder) Parse(payload *PayloadJSON) (metadata *Metadata, err error) {
 	return metadata, nil
 }
 
-// Decode the blob from an io.ReadCloser. This function will close the io.ReadCloser after completing.
-func (d *Decoder) Decode(r io.ReadCloser) (payload *PayloadJSON, err error) {
-	defer r.Close()
-
+// Decode the blob from an io.Reader. This function will close the io.ReadCloser after completing.
+func (d *Decoder) Decode(r io.Reader) (payload *PayloadJSON, err error) {
 	bytes, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err

--- a/metadata/providers/memory/options.go
+++ b/metadata/providers/memory/options.go
@@ -63,7 +63,7 @@ func WithValidateStatus(validate bool) Option {
 // known types the authenticator can produce. Default is true.
 func WithValidateAttestationTypes(validate bool) Option {
 	return func(provider *Provider) (err error) {
-		provider.status = validate
+		provider.attestation = validate
 
 		return nil
 	}


### PR DESCRIPTION
This fixes an issue where the metadata provider closed a file that may still be in use.

Fixes #264