### PR TITLE
Fix lint and style errors

### DIFF
--- a/metadata/decode.go
+++ b/metadata/decode.go
@@ -109,7 +109,7 @@ func (d *Decoder) DecodeBytes(bytes []byte) (payload *PayloadJSON, err error) {
 
 		if x5c, ok = token.Header[HeaderX509Certificate].([]any); !ok {
 			// If that attribute is missing as well, Metadata TOC signing trust anchor is considered the TOC signing certificate chain.
-			chain[0] = d.root
+			chain = []any{d.root}
 		} else {
 			chain = x5c
 		}

--- a/protocol/attestation_androidkey_test.go
+++ b/protocol/attestation_androidkey_test.go
@@ -57,9 +57,11 @@ func TestVerifyAndroidKeyFormat(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("verifyAndroidKeyFormat() got = %v, want %v", got, tt.want)
 			}
-			//if !reflect.DeepEqual(got1, tt.want1) {
-			//	t.Errorf("verifySafetyNetFormat() got1 = %v, want %v", got1, tt.want1)
-			//}
+			/*
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("verifySafetyNetFormat() got1 = %v, want %v", got1, tt.want1)
+			}
+			*/
 		})
 	}
 }

--- a/protocol/attestation_apple.go
+++ b/protocol/attestation_apple.go
@@ -77,7 +77,7 @@ func verifyAppleFormat(att AttestationObject, clientDataHash []byte, _ metadata.
 		return "", nil, ErrAttestationFormat.WithDetails("Unable to parse apple attestation certificate extensions")
 	}
 
-	if !bytes.Equal(decoded.Nonce, nonce[:]) || err != nil {
+	if !bytes.Equal(decoded.Nonce, nonce[:]) {
 		return "", nil, ErrInvalidAttestation.WithDetails("Attestation certificate does not contain expected nonce")
 	}
 

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -16,7 +16,7 @@ type CollectedClientData struct {
 	// Type the string "webauthn.create" when creating new credentials,
 	// and "webauthn.get" when getting an assertion from an existing credential. The
 	// purpose of this member is to prevent certain types of signature confusion attacks
-	//(where an attacker substitutes one legitimate signature for another).
+	// (where an attacker substitutes one legitimate signature for another).
 	Type         CeremonyType  `json:"type"`
 	Challenge    string        `json:"challenge"`
 	Origin       string        `json:"origin"`

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -194,7 +194,7 @@ type AttestationFormat string
 const (
 	// AttestationFormatPacked is the "packed" attestation statement format is a WebAuthn-optimized format for
 	// attestation. It uses a very compact but still extensible encoding method. This format is implementable by
-	//authenticators with limited resources (e.g., secure elements).
+	// authenticators with limited resources (e.g., secure elements).
 	AttestationFormatPacked AttestationFormat = "packed"
 
 	// AttestationFormatTPM is the TPM attestation statement format returns an attestation statement in the same format


### PR DESCRIPTION
Found minor lint errors.
* `metadata/decode.go`
  * chain is nil when accessing its 0 index item. Create a new slice to avoid nil access.
* `protocol/attestation_apple.go`
  * `err` has been checked not `nil` in the preceding if statement, and cannot be nil again.
* Some style errors, need a space after `//` comment.