### PR TITLE
refactor(webauthncose): to make it more readable and usable.

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -141,7 +141,7 @@ func (car CredentialAssertionResponse) Parse() (par *ParsedCredentialAssertionDa
 // Specification: §7.2 Verifying an Authentication Assertion (https://www.w3.org/TR/webauthn/#sctn-verifying-assertion)
 func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, appID string, verifyUser bool, credentialBytes []byte) error {
 	// Steps 4 through 6 in verifying the assertion data (https://www.w3.org/TR/webauthn/#verifying-assertion) are
-	// "assertive" steps, i.e "Let JSONtext be the result of running UTF-8 decode on the value of cData."
+	// "assertive" steps, i.e. "Let JSONtext be the result of running UTF-8 decode on the value of cData."
 	// We handle these steps in part as we verify but also beforehand
 
 	// Handle steps 7 through 10 of assertion by verifying stored data against the Collected Client Data

--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -69,9 +69,7 @@ func verifyAndroidKeyFormat(att AttestationObject, clientDataHash []byte, _ meta
 	}
 
 	coseAlg := webauthncose.COSEAlgorithmIdentifier(alg)
-	sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg)
-
-	if err = attCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), signatureData, sig); err != nil {
+	if err = attCert.CheckSignature(webauthncose.SigAlgFromCOSEAlg(coseAlg), signatureData, sig); err != nil {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
 	}
 

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -104,9 +104,7 @@ func handleBasicAttestation(signature, clientDataHash, authData, aaguid []byte, 
 	}
 
 	coseAlg := webauthncose.COSEAlgorithmIdentifier(alg)
-	sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg)
-
-	if err = attCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), signatureData, signature); err != nil {
+	if err = attCert.CheckSignature(webauthncose.SigAlgFromCOSEAlg(coseAlg), signatureData, signature); err != nil {
 		return "", x5c, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
 	}
 

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -150,9 +150,7 @@ func verifyTPMFormat(att AttestationObject, clientDataHash []byte, _ metadata.Pr
 			return "", nil, ErrAttestationFormat.WithDetails("Error parsing certificate from ASN.1")
 		}
 
-		sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg)
-
-		err = aikCert.CheckSignature(x509.SignatureAlgorithm(sigAlg), certInfoBytes, sigBytes)
+		err = aikCert.CheckSignature(webauthncose.SigAlgFromCOSEAlg(coseAlg), certInfoBytes, sigBytes)
 		if err != nil {
 			return "", nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Signature validation error: %+v\n", err))
 		}

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -113,9 +113,7 @@ func verifyTPMFormat(att AttestationObject, clientDataHash []byte, _ metadata.Pr
 	}
 
 	// 3/4 Verify that extraData is set to the hash of attToBeSigned using the hash algorithm employed in "alg".
-	f := webauthncose.HasherFromCOSEAlg(coseAlg)
-	h := f()
-
+	h := webauthncose.HasherFromCOSEAlg(coseAlg)
 	h.Write(attToBeSigned)
 	if !bytes.Equal(certInfo.ExtraData, h.Sum(nil)) {
 		return "", nil, ErrAttestationFormat.WithDetails("ExtraData is not set to hash of attToBeSigned")

--- a/protocol/attestation_tpm_test.go
+++ b/protocol/attestation_tpm_test.go
@@ -407,8 +407,7 @@ func TestTPMAttestationVerificationFailCertInfo(t *testing.T) {
 		},
 	}
 
-	f := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
-	h := f()
+	h := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
 	h.Write(att.RawAuthData)
 	extraData := h.Sum(nil)
 
@@ -522,8 +521,7 @@ func TestTPMAttestationVerificationFailX5c(t *testing.T) {
 		},
 	}
 
-	f := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
-	h := f()
+	h := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
 	h.Write(att.RawAuthData)
 	extraData := h.Sum(nil)
 

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -36,6 +36,8 @@ type PublicKeyData struct {
 	Algorithm int64 `cbor:"3,keyasint" json:"alg"`
 }
 
+const ecCoordSize = 32
+
 type EC2PublicKeyData struct {
 	PublicKeyData
 
@@ -180,8 +182,8 @@ func ParseFIDOPublicKey(keyBytes []byte) (data EC2PublicKeyData, err error) {
 		PublicKeyData: PublicKeyData{
 			Algorithm: int64(AlgES256),
 		},
-		XCoord: x.Bytes(),
-		YCoord: y.Bytes(),
+		XCoord: x.FillBytes(make([]byte, ecCoordSize)),
+		YCoord: y.FillBytes(make([]byte, ecCoordSize)),
 	}, nil
 }
 

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -400,10 +400,10 @@ func ec2AlgCurve(coseAlg int64) elliptic.Curve {
 }
 
 // SigAlgFromCOSEAlg return which signature algorithm is being used from the COSE Key.
-func SigAlgFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) SignatureAlgorithm {
+func SigAlgFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) x509.SignatureAlgorithm {
 	d, ok := COSESignatureAlgorithmDetails[coseAlg]
 	if !ok {
-		return UnknownSignatureAlgorithm
+		return x509.UnknownSignatureAlgorithm
 	}
 	return d.sigAlg
 }
@@ -418,44 +418,22 @@ func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) hash.Hash {
 	return d.hash.New()
 }
 
-// SignatureAlgorithm represents algorithm enumerations used for COSE signatures.
-type SignatureAlgorithm int
-
-const (
-	UnknownSignatureAlgorithm SignatureAlgorithm = iota
-	MD2WithRSA
-	MD5WithRSA
-	SHA1WithRSA
-	SHA256WithRSA
-	SHA384WithRSA
-	SHA512WithRSA
-	DSAWithSHA1
-	DSAWithSHA256
-	ECDSAWithSHA1
-	ECDSAWithSHA256
-	ECDSAWithSHA384
-	ECDSAWithSHA512
-	SHA256WithRSAPSS
-	SHA384WithRSAPSS
-	SHA512WithRSAPSS
-)
-
 var COSESignatureAlgorithmDetails = map[COSEAlgorithmIdentifier]struct {
 	name   string
 	hash   crypto.Hash
-	sigAlg SignatureAlgorithm
+	sigAlg x509.SignatureAlgorithm
 }{
-	AlgRS1:   {"SHA1-RSA", crypto.SHA1, SHA1WithRSA},
-	AlgRS256: {"SHA256-RSA", crypto.SHA256, SHA256WithRSA},
-	AlgRS384: {"SHA384-RSA", crypto.SHA384, SHA384WithRSA},
-	AlgRS512: {"SHA512-RSA", crypto.SHA512, SHA512WithRSA},
-	AlgPS256: {"SHA256-RSAPSS", crypto.SHA256, SHA256WithRSAPSS},
-	AlgPS384: {"SHA384-RSAPSS", crypto.SHA384, SHA384WithRSAPSS},
-	AlgPS512: {"SHA512-RSAPSS", crypto.SHA512, SHA512WithRSAPSS},
-	AlgES256: {"ECDSA-SHA256", crypto.SHA256, ECDSAWithSHA256},
-	AlgES384: {"ECDSA-SHA384", crypto.SHA384, ECDSAWithSHA384},
-	AlgES512: {"ECDSA-SHA512", crypto.SHA512, ECDSAWithSHA512},
-	AlgEdDSA: {"EdDSA", crypto.SHA512, UnknownSignatureAlgorithm},
+	AlgRS1:   {"SHA1-RSA", crypto.SHA1, x509.SHA1WithRSA},
+	AlgRS256: {"SHA256-RSA", crypto.SHA256, x509.SHA256WithRSA},
+	AlgRS384: {"SHA384-RSA", crypto.SHA384, x509.SHA384WithRSA},
+	AlgRS512: {"SHA512-RSA", crypto.SHA512, x509.SHA512WithRSA},
+	AlgPS256: {"SHA256-RSAPSS", crypto.SHA256, x509.SHA256WithRSAPSS},
+	AlgPS384: {"SHA384-RSAPSS", crypto.SHA384, x509.SHA384WithRSAPSS},
+	AlgPS512: {"SHA512-RSAPSS", crypto.SHA512, x509.SHA512WithRSAPSS},
+	AlgES256: {"ECDSA-SHA256", crypto.SHA256, x509.ECDSAWithSHA256},
+	AlgES384: {"ECDSA-SHA384", crypto.SHA384, x509.ECDSAWithSHA384},
+	AlgES512: {"ECDSA-SHA512", crypto.SHA512, x509.ECDSAWithSHA512},
+	AlgEdDSA: {"EdDSA", crypto.SHA512, x509.PureEd25519},
 }
 
 type Error struct {


### PR DESCRIPTION
The cause was a concern found in `func (k *RSAPublicKeyData) Verify`.

The [`hasher hash.Hash`](https://github.com/go-webauthn/webauthn/blob/master/protocol/webauthncose/webauthncose.go#L126) and [`hash crypto.Hash`](https://github.com/go-webauthn/webauthn/blob/master/protocol/webauthncose/webauthncose.go#L130) come from different source, whose type can be unmatched, if the list of struct `SignatureAlgorithmDetails` is misconfigured.

So I did a little bit refactor to
1. Use `crypto.Hash` as the representation for a hash algorithm in this package, and call `New()` to generate new `hash.Hash`er once needed. To avoid the mismatch issue mentioned above.
2. Use `big.Int.FillBytes()` to ensure the parsed ec Coord is 32-byte.
3. Make `SignatureAlgorithmDetails` into a map, to provide easier way to query COSE algorithm detail.
4. Remove the redundant `SignatureAlgorithm` definition, which is a duplication of `x509.SignatureAlgorithm`. I don't think anyone is using this, since `webauthn` package itself is using `x509` instead in [other places](https://github.com/go-webauthn/webauthn/blob/90441ec9ce635a1da703c7b0763d4b2b4560cb7e/protocol/attestation_packed.go#L109), which should be safe to remove.
5. A breaking change to the API `webauthncose.HasherFromCOSEAlg`, from returning `func() hash.Hash` to `hash.Hash`. There is few repo using this API directly, instead they relying on the `Parsing` and `Verify` extensively. It may break someone, but is easy to fix, given this package is still `v0`. But I won't insist on this. If you think this is unsafe, I can revert this piece.