### PR TITLE
feat(webauthn): add partial unsupported json v2 compat

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -211,11 +211,11 @@ func (webauthn *WebAuthn) ValidateDiscoverableLogin(handler DiscoverableUserHand
 
 // ValidatePasskeyLogin is an overloaded version of ValidateLogin that allows for passkey credentials.
 func (webauthn *WebAuthn) ValidatePasskeyLogin(handler DiscoverableUserHandler, session SessionData, parsedResponse *protocol.ParsedCredentialAssertionData) (user User, credential *Credential, err error) {
-	if session.UserID != nil {
+	if len(session.UserID) != 0 {
 		return nil, nil, protocol.ErrBadRequest.WithDetails("Session was not initiated as a client-side discoverable login")
 	}
 
-	if parsedResponse.Response.UserHandle == nil {
+	if len(parsedResponse.Response.UserHandle) == 0 {
 		return nil, nil, protocol.ErrBadRequest.WithDetails("Client-side Discoverable Assertion was attempted with a blank User Handle")
 	}
 


### PR DESCRIPTION
Using the candidate json/v2 encoder
https://github.com/go-json-experiment/json SessionData doesn't roundtrip properly through json as an empty []byte is encoded as "". Mark compatible fields as omitempty, and use len(field) == 0 instead of nil checks to be more resilient.