### PR TITLE
fix(metadata): cached file update fails without write access

### DIFF
--- a/metadata/providers/cached/util.go
+++ b/metadata/providers/cached/util.go
@@ -25,7 +25,7 @@ func doTruncateCopyAndSeekStart(f *os.File, rc io.ReadCloser) (err error) {
 }
 
 func doOpenOrCreate(name string) (f *os.File, created bool, err error) {
-	if f, err = os.Open(name); err == nil {
+	if f, err = os.OpenFile(name, os.O_RDWR, 0); err == nil {
 		return f, false, nil
 	}
 


### PR DESCRIPTION
This fixes an issue where the metadata cached file cannot be updated because the file was opened as read-only.

### Version

0.11.2

### Description

When initializing a `cached.Provider` with `cached.New`, if the cached file already exists and needs to be updated, the `doTruncateCopyAndSeekStart` method will fail because the file was opened as read-only.

The error happens here:

https://github.com/go-webauthn/webauthn/blob/67139112f304e5b9bf38fdc5fe9438b785fe2d56/metadata/providers/cached/util.go#L12-L14

The cached file is opened as read-only using `os.Open` (see [here](https://pkg.go.dev/os#Open)) here:

https://github.com/go-webauthn/webauthn/blob/67139112f304e5b9bf38fdc5fe9438b785fe2d56/metadata/providers/cached/util.go#L28-L30

### How to reproduce

The issue can be reproduced with the following code.

The code will run successfully the first time, when it will download and cache `blob.jwt`, and fail on followup runs, trying to truncate the cached file, with the following log error: `provider init error:truncate blob.jwt: invalid argument`.

```go
package main

import (
	"log"

	"github.com/go-webauthn/webauthn/metadata/providers/cached"
)

func main() {
	_, err := cached.New(
		cached.WithPath("blob.jwt"),
		cached.WithForceUpdate(true))

	if err != nil {
		log.Fatal("provider init error:", err)
	}

	log.Println("provider init success!")
}
```
