### PR TITLE
fix(webauthn): login validates attestation format

### DIFF
--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -36,7 +36,7 @@ func ValidateMetadata(ctx context.Context, mds metadata.Provider, aaguid uuid.UU
 		return nil
 	}
 
-	if mds.GetValidateAttestationTypes(ctx) {
+	if mds.GetValidateAttestationTypes(ctx) && attestationType != "" {
 		found := false
 
 		for _, atype := range entry.MetadataStatement.AttestationTypes {

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -349,7 +349,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 
 		var protoErr *protocol.Error
 
-		if protoErr = protocol.ValidateMetadata(context.Background(), webauthn.Config.MDS, aaguid, credential.AttestationType, nil); protoErr != nil {
+		if protoErr = protocol.ValidateMetadata(context.Background(), webauthn.Config.MDS, aaguid, "", nil); protoErr != nil {
 			return nil, protocol.ErrBadRequest.WithDetails("Failed to validate credential record metadata").WithInfo(protoErr.DevInfo).WithError(protoErr)
 		}
 	}


### PR DESCRIPTION
Instead of validating the attestation type in logins, the attestation format which is saved is checked.