### PR TITLE
fix(webauthn): empty aaguid fails login

### DIFF
--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -36,7 +36,7 @@ func ValidateMetadata(ctx context.Context, mds metadata.Provider, aaguid uuid.UU
 		return nil
 	}
 
-	if mds.GetValidateAttestationTypes(ctx) && attestationType != "" {
+	if attestationType != "" && mds.GetValidateAttestationTypes(ctx) {
 		found := false
 
 		for _, atype := range entry.MetadataStatement.AttestationTypes {

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -343,7 +343,9 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 	if webauthn.Config.MDS != nil {
 		var aaguid uuid.UUID
 
-		if aaguid, err = uuid.FromBytes(credential.Authenticator.AAGUID); err != nil {
+		if len(credential.Authenticator.AAGUID) == 0 {
+			aaguid = uuid.Nil
+		} else if aaguid, err = uuid.FromBytes(credential.Authenticator.AAGUID); err != nil {
 			return nil, protocol.ErrBadRequest.WithDetails("Failed to decode AAGUID").WithInfo(fmt.Sprintf("Error occurred decoding AAGUID from the credential record: %s", err)).WithError(err)
 		}
 


### PR DESCRIPTION
This fixes an issue where an empty AAGUID would cause a failed login when it should be left to metadata validation.