### PR TITLE
feat(protocol): verify alg param during registration

### DIFF
--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-webauthn/webauthn/metadata"
 	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )
 
 // AuthenticatorAttestationResponse is the initial unpacked 'response' object received by the relying party. This
@@ -119,16 +120,33 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (p *ParsedAttestationRespon
 	return p, nil
 }
 
-// Verify performs Steps 9 through 14 of registration verification.
+// Verify performs Steps 13 through 19 of registration verification.
 //
-// Steps 9 through 12 are verified against the auth data. These steps are identical to 11 through 14 for assertion so we
+// Steps 13 through 15 are verified against the auth data. These steps are identical to 15 through 18 for assertion so we
 // handle them with AuthData.
-func (a *AttestationObject) Verify(relyingPartyID string, clientDataHash []byte, userVerificationRequired bool, mds metadata.Provider) (err error) {
+func (a *AttestationObject) Verify(relyingPartyID string, clientDataHash []byte, userVerificationRequired bool, mds metadata.Provider, credParams []CredentialParameter) (err error) {
 	rpIDHash := sha256.Sum256([]byte(relyingPartyID))
 
-	// Begin Step 9 through 12. Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the RP.
+	// Begin Step 13 through 15. Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the RP.
 	if err = a.AuthData.Verify(rpIDHash[:], nil, userVerificationRequired); err != nil {
 		return err
+	}
+
+	// Step 16. Verify that the "alg" parameter in the credential public key in
+	// authData matches the alg attribute of one of the items in options.pubKeyCredParams.
+	pk := webauthncose.PublicKeyData{}
+	if err = webauthncbor.Unmarshal(a.AuthData.AttData.CredentialPublicKey, &pk); err != nil {
+		return err
+	}
+	found := false
+	for _, credParam := range credParams {
+		if int(pk.Algorithm) == int(credParam.Algorithm) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrAttestationFormat.WithInfo("Credential public key algorithm not supported")
 	}
 
 	return a.VerifyAttestation(clientDataHash, mds)
@@ -137,7 +155,7 @@ func (a *AttestationObject) Verify(relyingPartyID string, clientDataHash []byte,
 // VerifyAttestation only verifies the attestation object excluding the AuthData values. If you wish to also verify the
 // AuthData values you should use Verify.
 func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadata.Provider) (err error) {
-	// Step 13. Determine the attestation statement format by performing a
+	// Step 18. Determine the attestation statement format by performing a
 	// USASCII case-sensitive match on fmt against the set of supported
 	// WebAuthn Attestation Statement Format Identifier values. The up-to-date
 	// list of registered WebAuthn Attestation Statement Format Identifier
@@ -172,7 +190,7 @@ func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadat
 		x5cs            []any
 	)
 
-	// Step 14. Verify that attStmt is a correct attestation statement, conveying a valid attestation signature, by using
+	// Step 19. Verify that attStmt is a correct attestation statement, conveying a valid attestation signature, by using
 	// the attestation statement format fmt’s verification procedure given attStmt, authData and the hash of the serialized
 	// client data computed in step 7.
 	if attestationType, x5cs, err = handler(*a, clientDataHash, mds); err != nil {

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -29,7 +29,7 @@ func TestAttestationVerify(t *testing.T) {
 
 			pcc.Response = *parsedAttestationResponse
 
-			_, err = pcc.Verify(options.Response.Challenge.String(), false, options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginIgnoreVerificationMode, nil)
+			_, err = pcc.Verify(options.Response.Challenge.String(), false, options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginIgnoreVerificationMode, nil, options.Response.Parameters)
 
 			require.NoError(t, err)
 		})

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -383,31 +383,31 @@ func ResidentKeyNotRequired() *bool {
 	return &required
 }
 
-// Verify on AuthenticatorData handles Steps 9 through 12 for Registration
-// and Steps 11 through 14 for Assertion.
+// Verify on AuthenticatorData handles Steps 13 through 15 & 17 for Registration
+// and Steps 15 through 18 for Assertion.
 func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerificationRequired bool) error {
 
-	// Registration Step 9 & Assertion Step 11
+	// Registration Step 13 & Assertion Step 15
 	// Verify that the RP ID hash in authData is indeed the SHA-256
 	// hash of the RP ID expected by the RP.
 	if !bytes.Equal(a.RPIDHash[:], rpIdHash) && !bytes.Equal(a.RPIDHash[:], appIDHash) {
 		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x", a.RPIDHash, rpIdHash))
 	}
 
-	// Registration Step 10 & Assertion Step 12
+	// Registration Step 14 & Assertion Step 16
 	// Verify that the User Present bit of the flags in authData is set.
 	if !a.Flags.UserPresent() {
 		return ErrVerification.WithInfo(fmt.Sprintln("User presence flag not set by authenticator"))
 	}
 
-	// Registration Step 11 & Assertion Step 13
+	// Registration Step 15 & Assertion Step 17
 	// If user verification is required for this assertion, verify that
 	// the User Verified bit of the flags in authData is set.
 	if userVerificationRequired && !a.Flags.UserVerified() {
 		return ErrVerification.WithInfo(fmt.Sprintln("User verification required but flag not set by authenticator"))
 	}
 
-	// Registration Step 12 & Assertion Step 14
+	// Registration Step 17 & Assertion Step 18
 	// Verify that the values of the client extension outputs in clientExtensionResults
 	// and the authenticator extension outputs in the extensions in authData are as
 	// expected, considering the client extension input values that were given as the

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -145,7 +145,7 @@ func (ccr CredentialCreationResponse) Parse() (pcc *ParsedCredentialCreationData
 // Verify the Client and Attestation data.
 //
 // Specification: §7.1. Registering a New Credential (https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential)
-func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUser bool, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, mds metadata.Provider) (clientDataHash []byte, err error) {
+func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUser bool, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, mds metadata.Provider, credParams []CredentialParameter) (clientDataHash []byte, err error) {
 	// Handles steps 3 through 6 - Verifying the Client Data against the Relying Party's stored data
 	if err = pcc.Response.CollectedClientData.Verify(storedChallenge, CreateCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify); err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUs
 
 	// We do the above step while parsing and decoding the CredentialCreationResponse
 	// Handle steps 9 through 14 - This verifies the attestation object.
-	if err = pcc.Response.AttestationObject.Verify(relyingPartyID, clientDataHash, verifyUser, mds); err != nil {
+	if err = pcc.Response.AttestationObject.Verify(relyingPartyID, clientDataHash, verifyUser, mds, credParams); err != nil {
 		return clientDataHash, err
 	}
 

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )
 
 func TestParseCredentialCreationResponse(t *testing.T) {
@@ -168,6 +169,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 		verifyUser         bool
 		relyingPartyID     string
 		relyingPartyOrigin []string
+		credParams         []CredentialParameter
 	}
 
 	tests := []struct {
@@ -228,6 +230,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				verifyUser:         false,
 				relyingPartyID:     `webauthn.io`,
 				relyingPartyOrigin: []string{`https://webauthn.io`},
+				credParams:         []CredentialParameter{{Type: "public-key", Algorithm: webauthncose.AlgES256}},
 			},
 			wantErr: false,
 		},
@@ -240,7 +243,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				Response:                  tt.fields.Response,
 				Raw:                       tt.fields.Raw,
 			}
-			if _, err := pcc.Verify(tt.args.storedChallenge.String(), tt.args.verifyUser, tt.args.relyingPartyID, tt.args.relyingPartyOrigin, nil, TopOriginIgnoreVerificationMode, nil); (err != nil) != tt.wantErr {
+			if _, err := pcc.Verify(tt.args.storedChallenge.String(), tt.args.verifyUser, tt.args.relyingPartyID, tt.args.relyingPartyOrigin, nil, TopOriginIgnoreVerificationMode, nil, tt.args.credParams); (err != nil) != tt.wantErr {
 				t.Errorf("ParsedCredentialCreationData.Verify() error = %+v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -100,6 +100,7 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		RelyingPartyID:   creation.Response.RelyingParty.ID,
 		UserID:           user.WebAuthnID(),
 		UserVerification: creation.Response.AuthenticatorSelection.UserVerification,
+		CredParams:       creation.Response.Parameters,
 	}
 
 	if webauthn.Config.Timeouts.Registration.Enforce {
@@ -233,7 +234,7 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 	var clientDataHash []byte
 
-	if clientDataHash, err = parsedResponse.Verify(session.Challenge, shouldVerifyUser, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.MDS); err != nil {
+	if clientDataHash, err = parsedResponse.Verify(session.Challenge, shouldVerifyUser, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.MDS, session.CredParams); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -211,4 +211,5 @@ type SessionData struct {
 
 	UserVerification protocol.UserVerificationRequirement `json:"userVerification"`
 	Extensions       protocol.AuthenticationExtensions    `json:"extensions,omitempty"`
+	CredParams       []protocol.CredentialParameter       `json:"credParams,omitempty"`
 }


### PR DESCRIPTION
feat(protocol): verify alg param during registration

This PR adds a check that is in the [webauthn spec 7.2](https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential) 
> 16. Verify that the "alg" parameter in the credential public key in authData matches the alg attribute of one of the items in options.pubKeyCredParams.

- Store `[]CredentialParameter` in session data 
- Add the verification logic into `AttestationObject.Verify()`
- Update step numbers in the comments to reflect the new values in the spec
