### PR TITLE
feat(protocol): cable transport

### DIFF
--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -114,7 +114,11 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (p *ParsedAttestationRespon
 	}
 
 	for _, t := range ccr.Transports {
-		p.Transports = append(p.Transports, AuthenticatorTransport(t))
+		if transport, ok := internalRemappedAuthenticatorTransport[t]; ok {
+			p.Transports = append(p.Transports, transport)
+		} else {
+			p.Transports = append(p.Transports, AuthenticatorTransport(t))
+		}
 	}
 
 	return p, nil

--- a/protocol/const.go
+++ b/protocol/const.go
@@ -9,3 +9,13 @@ const (
 	stmtCertInfo  = "certInfo"
 	stmtPubArea   = "pubArea"
 )
+
+var (
+	// internalRemappedAuthenticatorTransport handles remapping of AuthenticatorTransport values. Specifically it is
+	// intentional on remapping only transports that never made recommendation but are being used in the wild. It
+	// should not be used to handle transports that were ratified.
+	internalRemappedAuthenticatorTransport = map[string]AuthenticatorTransport{
+		// The Authenticator Transport 'hybrid' was previously named 'cable'; even if it was for a short period.
+		"cable": Hybrid,
+	}
+)


### PR DESCRIPTION
This adds a remapping for the cable transport which has been observed in the wild, even though it has not been ratified and only exited for a short while before it was renamed.