### PR TITLE
fix(webauthn): fix check for the full allowedCredentials in validateLogin

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -332,6 +332,21 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 		var credentialsOwned bool
 
 		for _, allowedCredentialID := range session.AllowedCredentialIDs {
+			for _, credential = range credentials {
+				if bytes.Equal(credential.ID, allowedCredentialID) {
+					credentialsOwned = true
+
+					break
+				}
+
+				credentialsOwned = false
+			}
+			if !credentialsOwned {
+				return nil, protocol.ErrBadRequest.WithDetails("User does not own all credentials from the allowedCredentialList")
+			}
+		}
+
+		for _, allowedCredentialID := range session.AllowedCredentialIDs {
 			if bytes.Equal(parsedResponse.RawID, allowedCredentialID) {
 				found = true
 

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -332,22 +332,6 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 		var credentialsOwned bool
 
 		for _, allowedCredentialID := range session.AllowedCredentialIDs {
-			for _, credential = range credentials {
-				if bytes.Equal(credential.ID, allowedCredentialID) {
-					credentialsOwned = true
-
-					break
-				}
-
-				credentialsOwned = false
-			}
-		}
-
-		if !credentialsOwned {
-			return nil, protocol.ErrBadRequest.WithDetails("User does not own all credentials from the allowedCredentialList")
-		}
-
-		for _, allowedCredentialID := range session.AllowedCredentialIDs {
 			if bytes.Equal(parsedResponse.RawID, allowedCredentialID) {
 				found = true
 


### PR DESCRIPTION
There is a bug in this check: 
if a credential in the middle of `session.AllowedCredentialIDs` does not exist in `credentials`, `credentialsOwned` will be set to `false`, and `validateLogin` is supposed to return the error "User does not own all credentials from the allowedCredentialList". However, since the outer loop continues, if the last credential in `session.AllowedCredentialIDs` exist in `credentials`, `credentialsOwned` will be overwritten to `True`.


One option is to fix this, but I'd suggest that we remove this check entirely since
1. It's not specified in the webauthn specs
2. It's a bit redundant since both `session.AllowedCredentialIDs` and `credentials` are constructed on the server side