### PR TITLE
fix(webauthn): skip mds validation for none format

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ table for more information. We also include JSON mappings for those that wish to
 |           type            |            N/A             |            N/A             |                       This field is always `publicKey` for WebAuthn                       |
 |            id             |             ID             |             id             |                                                                                           |
 |         publicKey         |         PublicKey          |         publicKey          |                                                                                           |
+|     attestationFormat     |      AttestationType       |      attestationType       |           This field is currently named incorrectly and this will be corrected.           |
 |         signCount         |  Authenticator.SignCount   |  authenticator.signCount   |                                                                                           |
 |        transports         |         Transport          |         transport          |                                                                                           |
 |       uvInitialized       |     Flags.UserVerified     |     flags.userVerified     |                                                                                           |

--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -214,7 +214,7 @@ func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadat
 		return nil
 	}
 
-	if e := ValidateMetadata(context.Background(), mds, aaguid, attestationType, x5cs); e != nil {
+	if e := ValidateMetadata(context.Background(), mds, aaguid, attestationType, a.Format, x5cs); e != nil {
 		return ErrInvalidAttestation.WithInfo(fmt.Sprintf("Error occurred validating metadata during attestation validation: %+v", e)).WithDetails(e.DevInfo).WithError(e)
 	}
 

--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -10,8 +10,12 @@ import (
 	"github.com/go-webauthn/webauthn/metadata"
 )
 
-func ValidateMetadata(ctx context.Context, mds metadata.Provider, aaguid uuid.UUID, attestationType string, x5cs []any) (protoErr *Error) {
+func ValidateMetadata(ctx context.Context, mds metadata.Provider, aaguid uuid.UUID, attestationType, attestationFormat string, x5cs []any) (protoErr *Error) {
 	if mds == nil {
+		return nil
+	}
+
+	if AttestationFormat(attestationFormat) == AttestationFormatNone {
 		return nil
 	}
 

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -372,7 +372,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 		err   error
 	)
 
-	// Ensure authenticators with a bad status is not used.
+	// Ensure authenticators with a bad status are not used.
 	if webauthn.Config.MDS != nil {
 		var aaguid uuid.UUID
 
@@ -382,7 +382,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 			return nil, protocol.ErrBadRequest.WithDetails("Failed to decode AAGUID").WithInfo(fmt.Sprintf("Error occurred decoding AAGUID from the credential record: %s", err)).WithError(err)
 		}
 
-		if e := protocol.ValidateMetadata(context.Background(), webauthn.Config.MDS, aaguid, "", nil); e != nil {
+		if e := protocol.ValidateMetadata(context.Background(), webauthn.Config.MDS, aaguid, "", credential.AttestationType, nil); e != nil {
 			return nil, protocol.ErrBadRequest.WithDetails("Failed to validate credential record metadata").WithInfo(e.DevInfo).WithError(e)
 		}
 	}


### PR DESCRIPTION
The attestation format none does not include attestation data and therefore cannot be validated against MDS3 metadata. Previously the login flow attempted to validate it, which caused unnecessary failures for authenticators using the none format. This change ensures that none is explicitly exempt from MDS3 validation, allowing logins with such authenticators to succeed as expected. The registration flow already implements this measure.

Fixes #387