### PR TITLE
fix(webauthn): session expiration not enforced

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -300,6 +300,10 @@ func (webauthn *WebAuthn) ValidatePasskeyLogin(handler DiscoverableUserHandler, 
 		return nil, nil, protocol.ErrBadRequest.WithDetails("Session was not initiated as a client-side discoverable login")
 	}
 
+	if !session.Expires.IsZero() && session.Expires.Before(time.Now()) {
+		return nil, nil, protocol.ErrBadRequest.WithDetails("Session has Expired")
+	}
+
 	if len(parsedResponse.Response.UserHandle) == 0 {
 		return nil, nil, protocol.ErrBadRequest.WithDetails("Client-side Discoverable Assertion was attempted with a blank User Handle")
 	}


### PR DESCRIPTION
This fixes an issue where discoverable logins did not have the session expiration enforced.

Fixes #552