### PR TITLE
fix(webauthn): empty top origins not allowed

### DIFF
--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -130,13 +130,8 @@ func (config *Config) validate() (err error) {
 		return fmt.Errorf("must provide at least one value to the 'RPOrigins' field")
 	}
 
-	switch config.RPTopOriginVerificationMode {
-	case protocol.TopOriginDefaultVerificationMode:
+	if config.RPTopOriginVerificationMode == protocol.TopOriginDefaultVerificationMode {
 		config.RPTopOriginVerificationMode = protocol.TopOriginIgnoreVerificationMode
-	case protocol.TopOriginExplicitVerificationMode:
-		if len(config.RPTopOrigins) == 0 {
-			return fmt.Errorf("must provide at least one value to the 'RPTopOrigins' field when 'RPTopOriginVerificationMode' field is set to protocol.TopOriginExplicitVerificationMode")
-		}
 	}
 
 	config.validated = true

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -3,9 +3,8 @@ package webauthn
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/stretchr/testify/assert"
 )
 
 type defaultUser struct {
@@ -61,13 +60,13 @@ func TestNew(t *testing.T) {
 			"error occurred validating the configuration: must provide at least one value to the 'RPOrigins' field",
 		},
 		{
-			"ShouldFailBadTopOrigins",
+			"ShouldAllowEmptyRPTopOriginsExplicit",
 			&Config{
 				RPID:                        "https://example.com/",
 				RPOrigins:                   []string{"https://example.com"},
 				RPTopOriginVerificationMode: protocol.TopOriginExplicitVerificationMode,
 			},
-			"error occurred validating the configuration: must provide at least one value to the 'RPTopOrigins' field when 'RPTopOriginVerificationMode' field is set to protocol.TopOriginExplicitVerificationMode",
+			"",
 		},
 	}
 


### PR DESCRIPTION
This fixes a config validation issue where empty top origins are not allowed. By allowing this we ensure when set to explicit that no top origins are permitted.

Fixes #537