### PR TITLE
feat(protocol): enhance rpid validation

### DIFF
--- a/protocol/utils_test.go
+++ b/protocol/utils_test.go
@@ -1,0 +1,112 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRPID(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+		err   string
+	}{
+		{
+			name:  "ValidRPIDDomain",
+			value: "example.com",
+		},
+		{
+			name:  "ValidRPIDLocalHost",
+			value: "localhost",
+		},
+		{
+			name:  "ValidRPIDUsingIPv4",
+			value: "127.0.0.1",
+		},
+		{
+			name:  "ValidRPIDUsingIPv4Alt",
+			value: "1.1.1.1",
+		},
+		{
+			name:  "ValidRPIDUsingIPv6",
+			value: "2001:DB8:0:0:8:800:200C:417A",
+		},
+		{
+			name:  "ValidRPIDUsingIPv6Alt",
+			value: "::1",
+		},
+		{
+			name:  "InvalidRPIDNotDomain",
+			value: "example",
+			err:   "the domain component must actually be a domain",
+		},
+		{
+			name:  "InvalidRPIDScheme",
+			value: "https://example.com",
+			err:   "the scheme component must be empty",
+		},
+		{
+			name:  "InvalidRPIDPort",
+			value: "example.com:1234",
+			err:   "the port component must be empty",
+		},
+		{
+			name:  "InvalidRPIDPortWithScheme",
+			value: "https://example.com:1234",
+			err:   "the port component must be empty",
+		},
+		{
+			name:  "InvalidRPIDPath",
+			value: "example.com/example",
+			err:   "the path component must be empty",
+		},
+		{
+			name:  "InvalidRPIDQuery",
+			value: "example.com?abc=123",
+			err:   "the query component must be empty",
+		},
+		{
+			name:  "InvalidRPIDFragment",
+			value: "example.com#abc=123",
+			err:   "the fragment component must be empty",
+		},
+		{
+			name:  "InvalidRPIDPathWithScheme",
+			value: "https://example.com/example",
+			err:   "the path component must be empty",
+		},
+		{
+			name:  "InvalidRPIDQueryWithScheme",
+			value: "https://example.com?abc=123",
+			err:   "the query component must be empty",
+		},
+		{
+			name:  "InvalidRPIDFragmentWithScheme",
+			value: "https://example.com#abc=123",
+			err:   "the fragment component must be empty",
+		},
+		{
+			name:  "InvalidEmpty",
+			value: "",
+			err:   "empty value provided",
+		},
+		{
+			name:  "InvalidURI",
+			value: "https://example\x00.com",
+			err:   "parse \"https://example\\x00.com\": net/url: invalid control character in URL",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRPID(tc.value)
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+		})
+	}
+}

--- a/webauthn/const.go
+++ b/webauthn/const.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	errFmtFieldNotValidURI = "field '%s' is not a valid URI: %w"
-	errFmtConfigValidate   = "error occurred validating the configuration: %w"
+	errFmtFieldNotValidDomainString = "field '%s' is not a valid domain string: %w"
+	errFmtConfigValidate            = "error occurred validating the configuration: %w"
 )
 
 const (

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -105,8 +104,8 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 
 	if len(assertion.Response.RelyingPartyID) == 0 {
 		return nil, nil, fmt.Errorf("error generating assertion: the relying party id must be provided via the configuration or a functional option for a login")
-	} else if _, err = url.Parse(assertion.Response.RelyingPartyID); err != nil {
-		return nil, nil, fmt.Errorf("error generating assertion: the relying party id failed to validate as it's not a valid uri with error: %w", err)
+	} else if err = protocol.ValidateRPID(assertion.Response.RelyingPartyID); err != nil {
+		return nil, nil, fmt.Errorf("error generating assertion: the relying party id failed to validate as it's not a valid domain string with error: %w", err)
 	}
 
 	if assertion.Response.Timeout == 0 {

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -47,40 +47,40 @@ func TestWithLoginRelyingPartyID(t *testing.T) {
 		{
 			name: "OptionDefinedInConfig",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPDisplayName: "Test Display Name",
 				RPOrigins:     []string{"https://example.com"},
 			},
 			opts:       nil,
-			expectedID: "https://example.com",
+			expectedID: "example.com",
 		},
 		{
 			name: "OptionDefinedInConfigAndOpts",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPDisplayName: "Test Display Name",
 				RPOrigins:     []string{"https://example.com"},
 			},
-			opts:       []LoginOption{WithLoginRelyingPartyID("https://a.example.com")},
-			expectedID: "https://a.example.com",
+			opts:       []LoginOption{WithLoginRelyingPartyID("a.example.com")},
+			expectedID: "a.example.com",
 		},
 		{
 			name: "OptionDefinedInConfigWithNoErrAndInOptsWithError",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPDisplayName: "Test Display Name",
 				RPOrigins:     []string{"https://example.com"},
 			},
 			opts: []LoginOption{WithLoginRelyingPartyID("---::~!!~@#M!@OIK#N!@IOK@@@@@@@@@@")},
-			err:  "error generating assertion: the relying party id failed to validate as it's not a valid uri with error: parse \"---::~!!~@\": first path segment in URL cannot contain colon",
+			err:  "error generating assertion: the relying party id failed to validate as it's not a valid domain string with error: parse \"---::~!!~@\": first path segment in URL cannot contain colon",
 		},
 		{
 			name: "OptionDefinedInOpts",
 			have: &Config{
 				RPOrigins: []string{"https://example.com"},
 			},
-			opts:       []LoginOption{WithLoginRelyingPartyID("https://example.com")},
-			expectedID: "https://example.com",
+			opts:       []LoginOption{WithLoginRelyingPartyID("example.com")},
+			expectedID: "example.com",
 		},
 		{
 			name: "OptionIDNotDefined",
@@ -93,7 +93,7 @@ func TestWithLoginRelyingPartyID(t *testing.T) {
 		{
 			name: "TooShortWithChallengeOption",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPOrigins:     []string{"https://example.com"},
 				RPDisplayName: "Test Display Name",
 			},
@@ -103,12 +103,12 @@ func TestWithLoginRelyingPartyID(t *testing.T) {
 		{
 			name: "WithChallengeOption",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPOrigins:     []string{"https://example.com"},
 				RPDisplayName: "Test Display Name",
 			},
 			opts:              []LoginOption{WithChallenge([]byte("00000000000000000000000000000000"))},
-			expectedID:        "https://example.com",
+			expectedID:        "example.com",
 			expectedChallenge: []byte("00000000000000000000000000000000"),
 		},
 	}

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/go-webauthn/webauthn/protocol"
@@ -75,8 +74,8 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 
 	if len(creation.Response.RelyingParty.ID) == 0 {
 		return nil, nil, fmt.Errorf("error generating credential creation: the relying party id must be provided via the configuration or a functional option for a creation")
-	} else if _, err = url.Parse(creation.Response.RelyingParty.ID); err != nil {
-		return nil, nil, fmt.Errorf("error generating credential creation: the relying party id failed to validate as it's not a valid uri with error: %w", err)
+	} else if err = protocol.ValidateRPID(creation.Response.RelyingParty.ID); err != nil {
+		return nil, nil, fmt.Errorf("error generating credential creation: the relying party id failed to validate as it's not a valid domain string with error: %w", err)
 	}
 
 	if len(creation.Response.RelyingParty.Name) == 0 {

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -22,42 +22,42 @@ func TestWithRegistrationRelyingPartyID(t *testing.T) {
 		{
 			name: "OptionDefinedInConfig",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPDisplayName: "Test Display Name",
 				RPOrigins:     []string{"https://example.com"},
 			},
 			opts:         nil,
-			expectedID:   "https://example.com",
+			expectedID:   "example.com",
 			expectedName: "Test Display Name",
 		},
 		{
 			name: "OptionDefinedInConfigAndOpts",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPDisplayName: "Test Display Name",
 				RPOrigins:     []string{"https://example.com"},
 			},
-			opts:         []RegistrationOption{WithRegistrationRelyingPartyID("https://a.example.com"), WithRegistrationRelyingPartyName("Test Display Name2")},
-			expectedID:   "https://a.example.com",
+			opts:         []RegistrationOption{WithRegistrationRelyingPartyID("a.example.com"), WithRegistrationRelyingPartyName("Test Display Name2")},
+			expectedID:   "a.example.com",
 			expectedName: "Test Display Name2",
 		},
 		{
 			name: "OptionDefinedInConfigWithNoErrAndInOptsWithError",
 			have: &Config{
-				RPID:          "https://example.com",
+				RPID:          "example.com",
 				RPDisplayName: "Test Display Name",
 				RPOrigins:     []string{"https://example.com"},
 			},
 			opts: []RegistrationOption{WithRegistrationRelyingPartyID("---::~!!~@#M!@OIK#N!@IOK@@@@@@@@@@"), WithRegistrationRelyingPartyName("Test Display Name2")},
-			err:  "error generating credential creation: the relying party id failed to validate as it's not a valid uri with error: parse \"---::~!!~@\": first path segment in URL cannot contain colon",
+			err:  "error generating credential creation: the relying party id failed to validate as it's not a valid domain string with error: parse \"---::~!!~@\": first path segment in URL cannot contain colon",
 		},
 		{
 			name: "OptionDefinedInOpts",
 			have: &Config{
-				RPOrigins: []string{"https://example.com"},
+				RPOrigins: []string{"example.com"},
 			},
-			opts:         []RegistrationOption{WithRegistrationRelyingPartyID("https://example.com"), WithRegistrationRelyingPartyName("Test Display Name")},
-			expectedID:   "https://example.com",
+			opts:         []RegistrationOption{WithRegistrationRelyingPartyID("example.com"), WithRegistrationRelyingPartyName("Test Display Name")},
+			expectedID:   "example.com",
 			expectedName: "Test Display Name",
 		},
 		{
@@ -65,7 +65,7 @@ func TestWithRegistrationRelyingPartyID(t *testing.T) {
 			have: &Config{
 				RPOrigins: []string{"https://example.com"},
 			},
-			opts: []RegistrationOption{WithRegistrationRelyingPartyID("https://example.com")},
+			opts: []RegistrationOption{WithRegistrationRelyingPartyID("example.com")},
 			err:  "error generating credential creation: the relying party display name must be provided via the configuration or a functional option for a creation",
 		},
 		{

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -2,7 +2,6 @@ package webauthn
 
 import (
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/go-webauthn/webauthn/metadata"
@@ -102,8 +101,8 @@ func (config *Config) validate() (err error) {
 	}
 
 	if len(config.RPID) != 0 {
-		if _, err = url.Parse(config.RPID); err != nil {
-			return fmt.Errorf(errFmtFieldNotValidURI, "RPID", err)
+		if err = protocol.ValidateRPID(config.RPID); err != nil {
+			return fmt.Errorf(errFmtFieldNotValidDomainString, "RPID", err)
 		}
 	}
 

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -40,7 +40,7 @@ func TestNew(t *testing.T) {
 		{
 			"ShouldPassMinimalConfig",
 			&Config{
-				RPID:      "https://example.com/",
+				RPID:      "example.com",
 				RPOrigins: []string{"https://example.com"},
 			},
 			"",
@@ -51,19 +51,19 @@ func TestNew(t *testing.T) {
 				RPID:      "%%&&",
 				RPOrigins: []string{"https://example.com"},
 			},
-			`error occurred validating the configuration: field 'RPID' is not a valid URI: parse "%%&&": invalid URL escape "%%&"`,
+			"error occurred validating the configuration: field 'RPID' is not a valid domain string: parse \"%%&&\": invalid URL escape \"%%&\"",
 		},
 		{
 			"ShouldFailNoRPOrigins",
 			&Config{
-				RPID: "https://example.com/",
+				RPID: "example.com",
 			},
 			"error occurred validating the configuration: must provide at least one value to the 'RPOrigins' field",
 		},
 		{
 			"ShouldAllowEmptyRPTopOriginsExplicit",
 			&Config{
-				RPID:                        "https://example.com/",
+				RPID:                        "example.com",
 				RPOrigins:                   []string{"https://example.com"},
 				RPTopOriginVerificationMode: protocol.TopOriginExplicitVerificationMode,
 			},


### PR DESCRIPTION
This adjusts the validation of RPID values to be stricter. They will generally be required to adhere to W3C domain string standard.

Closes #553