### PR TITLE
feat(webauthncose): add mldsa support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.1
 require (
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/go-viper/mapstructure/v2 v2.5.0
-	github.com/go-webauthn/x v0.2.2
+	github.com/go-webauthn/x v0.2.3-0.20260403140929-a24bfe17cec1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-tpm v0.9.8
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-webauthn/x v0.2.2 h1:zIiipvMbr48CXi5RG0XdBJR94kd8I5LfzHPb/q+YYmk=
 github.com/go-webauthn/x v0.2.2/go.mod h1:IpJ5qyWB9NRhLX3C7gIfjTU7RZLXEP6kzFkoVSE7Fz4=
+github.com/go-webauthn/x v0.2.3-0.20260403140929-a24bfe17cec1 h1:Acwk6lUm2y8Zno/GsZsBK9qS0OvmEkJhdWrfPht9vnM=
+github.com/go-webauthn/x v0.2.3-0.20260403140929-a24bfe17cec1/go.mod h1:IpJ5qyWB9NRhLX3C7gIfjTU7RZLXEP6kzFkoVSE7Fz4=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-tpm v0.9.8 h1:slArAR9Ft+1ybZu0lBwpSmpwhRXaa85hWtMinMyRAWo=

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 
 	"github.com/go-webauthn/x/encoding/asn1"
+	"github.com/go-webauthn/x/mldsa"
 
 	"github.com/google/go-tpm/tpm2"
 
@@ -69,6 +70,34 @@ type OKPPublicKeyData struct {
 
 	// A byte string that holds the x coordinate of the key.
 	XCoord []byte `cbor:"-2,keyasint,omitempty" json:"x"`
+}
+
+// AKPPublicKeyData represents an Algorithm Key Pair (AKP) public key, used for ML-DSA keys.
+type AKPPublicKeyData struct {
+	PublicKeyData
+
+	// The encoded public key.
+	PubKey []byte `cbor:"-1,keyasint,omitempty" json:"pub"`
+}
+
+// Verify Algorithm Key Pair (AKP) Public Key Signature.
+func (k *AKPPublicKeyData) Verify(data []byte, sig []byte) (bool, error) {
+	if err := validateAKPPublicKey(k); err != nil {
+		return false, err
+	}
+
+	params := mldsaAlgParams(k.Algorithm)
+
+	pub, err := mldsa.NewPublicKey(params, k.PubKey)
+	if err != nil {
+		return false, ErrUnsupportedKey.WithDetails(fmt.Sprintf("AKP key is invalid: %v", err))
+	}
+
+	if err = mldsa.Verify(pub, data, sig, nil); err != nil {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // Verify Octet Key Pair (OKP) Public Key Signature.
@@ -216,6 +245,20 @@ func ParsePublicKey(keyBytes []byte) (publicKey any, err error) {
 		}
 
 		return r, nil
+	case AKP:
+		var a AKPPublicKeyData
+
+		if err = webauthncbor.Unmarshal(keyBytes, &a); err != nil {
+			return nil, err
+		}
+
+		a.PublicKeyData = pk
+
+		if err = validateAKPPublicKey(&a); err != nil {
+			return nil, err
+		}
+
+		return a, nil
 	default:
 		return nil, ErrUnsupportedKey
 	}
@@ -249,6 +292,8 @@ func VerifySignature(key any, data []byte, sig []byte) (bool, error) {
 	case EC2PublicKeyData:
 		return k.Verify(data, sig)
 	case RSAPublicKeyData:
+		return k.Verify(data, sig)
+	case AKPPublicKeyData:
 		return k.Verify(data, sig)
 	default:
 		return false, ErrUnsupportedKey
@@ -418,6 +463,32 @@ func (passedError *Error) WithDetails(details string) *Error {
 	err.Details = details
 
 	return &err
+}
+
+func mldsaAlgParams(coseAlg int64) *mldsa.Parameters {
+	switch COSEAlgorithmIdentifier(coseAlg) {
+	case AlgMLDSA44:
+		return mldsa.MLDSA44()
+	case AlgMLDSA65:
+		return mldsa.MLDSA65()
+	case AlgMLDSA87:
+		return mldsa.MLDSA87()
+	default:
+		return nil
+	}
+}
+
+func validateAKPPublicKey(k *AKPPublicKeyData) error {
+	params := mldsaAlgParams(k.Algorithm)
+	if params == nil {
+		return ErrUnsupportedAlgorithm.WithDetails("Unsupported AKP algorithm")
+	}
+
+	if len(k.PubKey) != params.PublicKeySize() {
+		return ErrUnsupportedKey.WithDetails(fmt.Sprintf("AKP public key has invalid length %d, expected %d", len(k.PubKey), params.PublicKeySize()))
+	}
+
+	return nil
 }
 
 func validateOKPPublicKey(k *OKPPublicKeyData) error {


### PR DESCRIPTION
This adds support for ML-DSA-44, ML-DSA-65, and ML-DSA-87.

TODO:
- [ ] Add E2E test vectors.