### PR TITLE
feat!: tighten cross-origin defaults

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -145,14 +145,14 @@ func (car CredentialAssertionResponse) Parse() (par *ParsedCredentialAssertionDa
 // documentation. It's important to note that the credentialBytes field is the CBOR representation of the credential.
 //
 // Specification: §7.2 Verifying an Authentication Assertion (https://www.w3.org/TR/webauthn/#sctn-verifying-assertion)
-func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, appID string, verifyUser bool, verifyUserPresence bool, credentialBytes []byte) error {
+func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPartyID, appID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, credentialBytes []byte) error {
 	// Steps 4 through 6 in verifying the assertion data (https://www.w3.org/TR/webauthn/#verifying-assertion) are
 	// "assertive" steps, i.e. "Let JSONtext be the result of running UTF-8 decode on the value of cData."
 	// We handle these steps in part as we verify but also beforehand
 	//
 	// Handle steps 7 through 10 of assertion by verifying stored data against the Collected Client Data
 	// returned by the authenticator.
-	validError := p.Response.CollectedClientData.Verify(storedChallenge, AssertCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify)
+	validError := p.Response.CollectedClientData.Verify(storedChallenge, AssertCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin)
 	if validError != nil {
 		return validError
 	}

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -337,7 +337,7 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := par.Verify(tc.challenge, tc.relyingPartyID, tc.rpOrigins, nil, TopOriginIgnoreVerificationMode, tc.appID, false, true, tc.credentialBytes)
+			err := par.Verify(tc.challenge, tc.relyingPartyID, tc.appID, tc.rpOrigins, nil, TopOriginExplicitVerificationMode, false, false, true, tc.credentialBytes)
 
 			if tc.err == "" {
 				assert.NoError(t, err)

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -60,7 +60,7 @@ func TestAttestationVerify(t *testing.T) {
 
 			pcc.Response = *parsedAttestationResponse
 
-			_, err = pcc.Verify(options.Response.Challenge.String(), false, false, options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginIgnoreVerificationMode, nil, options.Response.Parameters)
+			_, err = pcc.Verify(options.Response.Challenge.String(), options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginExplicitVerificationMode, false, false, false, nil, options.Response.Parameters)
 
 			require.NoError(t, err)
 		})

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -112,7 +112,7 @@ func FullyQualifiedOrigin(rawOrigin string) (fqOrigin string, err error) {
 // TopOriginDefaultVerificationMode as it's expected this value is updated by the config validation process.
 //
 //nolint:gocyclo
-func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyType, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode) (err error) {
+func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyType, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin bool) (err error) {
 	// Registration Step 3. Verify that the value of C.type is webauthn.create.
 
 	// Assertion Step 7. Verify that the value of C.type is the string webauthn.get.
@@ -143,35 +143,41 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 			WithInfo(fmt.Sprintf("Expected Values: %s, Received: %s", rpOrigins, c.Origin))
 	}
 
-	if rpTopOriginsVerify != TopOriginIgnoreVerificationMode {
-		switch len(c.TopOrigin) {
-		case 0:
-			break
+	if !allowCrossOrigin && c.CrossOrigin {
+		return ErrVerification.
+			WithDetails("Error validating cross origin flag").
+			WithInfo("The cross origin flag is invalid due to the configuration.")
+	}
+
+	switch len(c.TopOrigin) {
+	case 0:
+		break
+	default:
+		if !c.CrossOrigin {
+			return ErrVerification.
+				WithDetails("Error validating topOrigin").
+				WithInfo("The topOrigin can't have values unless crossOrigin is true.")
+		}
+
+		var possibleTopOrigins []string
+
+		switch rpTopOriginsVerify {
+		case TopOriginExplicitVerificationMode:
+			possibleTopOrigins = rpTopOrigins
+		case TopOriginAutoVerificationMode:
+			possibleTopOrigins = make([]string, 0, len(rpTopOrigins)+len(rpOrigins))
+			possibleTopOrigins = append(possibleTopOrigins, rpTopOrigins...)
+			possibleTopOrigins = append(possibleTopOrigins, rpOrigins...)
+		case TopOriginImplicitVerificationMode:
+			possibleTopOrigins = rpOrigins
 		default:
-			if !c.CrossOrigin {
-				return ErrVerification.
-					WithDetails("Error validating topOrigin").
-					WithInfo("The topOrigin can't have values unless crossOrigin is true.")
-			}
+			return ErrNotImplemented.WithDetails("Error handling unknown Top Origin verification mode")
+		}
 
-			var possibleTopOrigins []string
-
-			switch rpTopOriginsVerify {
-			case TopOriginExplicitVerificationMode:
-				possibleTopOrigins = rpTopOrigins
-			case TopOriginAutoVerificationMode:
-				possibleTopOrigins = append(rpTopOrigins, rpOrigins...) //nolint:gocritic // This is intentional.
-			case TopOriginImplicitVerificationMode:
-				possibleTopOrigins = rpOrigins
-			default:
-				return ErrNotImplemented.WithDetails("Error handling unknown Top Origin verification mode")
-			}
-
-			if !IsOriginInHaystack(c.TopOrigin, possibleTopOrigins) {
-				return ErrVerification.
-					WithDetails("Error validating top origin").
-					WithInfo(fmt.Sprintf("Expected Values: %s, Received: %s", possibleTopOrigins, c.TopOrigin))
-			}
+		if !IsOriginInHaystack(c.TopOrigin, possibleTopOrigins) {
+			return ErrVerification.
+				WithDetails("Error validating top origin").
+				WithInfo(fmt.Sprintf("Expected Values: %s, Received: %s", possibleTopOrigins, c.TopOrigin))
 		}
 	}
 
@@ -203,25 +209,25 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 type TopOriginVerificationMode int
 
 const (
-	// TopOriginDefaultVerificationMode represents the default verification mode for the Top Origin. At this time this
-	// mode is the same as TopOriginIgnoreVerificationMode until such a time as the specification becomes stable. This
-	// value is intended as a fallback value and implementers should very intentionally pick another option if they want
-	// stability.
+	// TopOriginDefaultVerificationMode is the zero value of [TopOriginVerificationMode] and has no matching rule in
+	// the verifier; passing it directly to [CollectedClientData.Verify] returns an "unknown Top Origin verification
+	// mode" error. High-level callers using [webauthn.Config] have this value coerced to
+	// [TopOriginExplicitVerificationMode] by config validation, which is the recommended default.
 	TopOriginDefaultVerificationMode TopOriginVerificationMode = iota
 
-	// TopOriginIgnoreVerificationMode ignores verification entirely.
-	TopOriginIgnoreVerificationMode
-
-	// TopOriginAutoVerificationMode represents the automatic verification mode for the Top Origin. In this mode the
-	// If the Top Origins parameter has values it checks against this, otherwise it checks against the Origins parameter.
+	// TopOriginAutoVerificationMode accepts the Top Origin if it matches any entry in either the allowed Top Origins
+	// list or the allowed Origins list. The two lists are unioned (RPTopOrigins ∪ RPOrigins). This is the most
+	// permissive of the three active modes and should only be used when an RP deliberately wants cross-origin and
+	// same-origin embeddings to share an allow-list.
 	TopOriginAutoVerificationMode
 
-	// TopOriginImplicitVerificationMode represents the implicit verification mode for the Top Origin. In this mode the
-	// Top Origin is verified against the allowed Origins values.
+	// TopOriginImplicitVerificationMode accepts the Top Origin only if it matches an entry in the allowed Origins
+	// list (RPOrigins). The RPTopOrigins list is ignored in this mode.
 	TopOriginImplicitVerificationMode
 
-	// TopOriginExplicitVerificationMode represents the explicit verification mode for the Top Origin. In this mode the
-	// Top Origin is verified against the allowed Top Origins values.
+	// TopOriginExplicitVerificationMode accepts the Top Origin only if it matches an entry in the allowed Top Origins
+	// list (RPTopOrigins). The RPOrigins list is ignored in this mode. This is the strictest mode and the one
+	// [webauthn.Config] coerces the zero value to.
 	TopOriginExplicitVerificationMode
 )
 

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -8,161 +8,193 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupCollectedClientData(challenge URLEncodedBase64, origin, topOrigin string, crossOrigin bool) *CollectedClientData { //nolint:unparam
-	ccd := &CollectedClientData{
-		Type:        CreateCeremony,
-		Origin:      origin,
-		TopOrigin:   topOrigin,
-		CrossOrigin: crossOrigin,
-		Challenge:   challenge.String(),
+func TestVerifyCollectedClientData(t *testing.T) {
+	testCases := []struct {
+		name            string
+		origin          string
+		topOrigin       string
+		crossOrigin     bool
+		rpOrigins       []string
+		rpTopOrigins    []string
+		topOriginMode   TopOriginVerificationMode
+		allowCrossOrign bool
+		ceremony        CeremonyType
+		err             string
+		errType         string
+		errDetails      string
+		errInfo         string
+	}{
+		{
+			name:            "ShouldSucceed",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			allowCrossOrign: true,
+		},
+		{
+			name:            "ShouldSucceedNoTopOrigin",
+			origin:          "http://example.com",
+			crossOrigin:     true,
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			allowCrossOrign: true,
+		},
+		{
+			name:            "ShouldSucceedTopOriginDifferentFromOrigin",
+			origin:          "http://example.com",
+			topOrigin:       "http://example2.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			topOriginMode:   TopOriginExplicitVerificationMode,
+		},
+		{
+			name:            "ShouldFailTopOriginMismatch",
+			origin:          "http://example.com",
+			topOrigin:       "http://example2.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpTopOrigins:    []string{"https://example3.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			err:             "Error validating top origin",
+		},
+		{
+			name:            "ShouldSucceedTopOriginImplicit",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			topOriginMode:   TopOriginImplicitVerificationMode,
+		},
+		{
+			name:            "ShouldSucceedTopOriginAuto",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginAutoVerificationMode,
+		},
+		{
+			name:            "ShouldSucceedMultipleExpectedOrigins",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpOrigins:       []string{"https://exmaple.com", "9C:B4:AE:EF:05:53:6E:73:0E:C4:B8:02:E7:67:F6:7D:A4:E7:BC:26:D7:42:B5:27:FF:01:7D:68:2A:EB:FA:1D", "http://example.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+		},
+		{
+			name:            "ShouldFailTopOriginInvalidMode",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   -1,
+			errType:       "not_implemented",
+			errDetails:    "Error handling unknown Top Origin verification mode",
+		},
+		{
+			name:            "ShouldFailCrossOriginNotAllowed",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: false,
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			errType:         "verification_error",
+			errDetails:      "Error validating cross origin flag",
+			errInfo:         "The cross origin flag is invalid due to the configuration.",
+		},
+		{
+			name:            "ShouldFailUnexpectedOrigin",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpOrigins:       []string{"http://different.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			errType:       "verification_error",
+			errDetails:    "Error validating origin",
+			errInfo:       "Expected Values: [http://different.com], Received: http://example.com",
+		},
+		{
+			name:          "ShouldFailTopOriginWithoutCrossOrigin",
+			origin:        "http://example.com",
+			topOrigin:     "http://example2.com",
+			crossOrigin:   false,
+			topOriginMode: TopOriginExplicitVerificationMode,
+			errType:       "verification_error",
+			errDetails:    "Error validating topOrigin",
+			errInfo:       "The topOrigin can't have values unless crossOrigin is true.",
+		},
+		{
+			name:            "ShouldFailUnexpectedTopOrigin",
+			origin:          "http://example.com",
+			topOrigin:       "http://example.com",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpOrigins:       []string{"http://example.com"},
+			rpTopOrigins:    []string{"http://different.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			err:             "Error validating top origin",
+		},
+		{
+			name:          "ShouldFailCeremonyMismatch",
+			origin:        "http://example.com",
+			crossOrigin:   false,
+			topOriginMode: TopOriginExplicitVerificationMode,
+			ceremony:      AssertCeremony,
+			errType:       "verification_error",
+			errDetails:    "Error validating ceremony type",
+			errInfo:       fmt.Sprintf("Expected Value: %s, Received: %s", AssertCeremony, CreateCeremony),
+		},
 	}
 
-	return ccd
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			challenge, err := CreateChallenge()
+			require.NoError(t, err)
+
+			ccd := setupCollectedClientData(challenge, tc.origin, tc.topOrigin, tc.crossOrigin)
+
+			rpOrigins := tc.rpOrigins
+			if rpOrigins == nil {
+				rpOrigins = []string{ccd.Origin}
+			}
+
+			rpTopOrigins := tc.rpTopOrigins
+			if rpTopOrigins == nil {
+				rpTopOrigins = []string{ccd.TopOrigin}
+			}
+
+			ceremony := tc.ceremony
+			if ceremony == "" {
+				ceremony = ccd.Type
+			}
+
+			err = ccd.Verify(challenge.String(), ceremony, rpOrigins, rpTopOrigins, tc.topOriginMode, tc.allowCrossOrign)
+
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+			} else if tc.errType != "" {
+				AssertIsProtocolError(t, err, tc.errType, tc.errDetails, tc.errInfo)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
-func TestVerifyCollectedClientData(t *testing.T) {
-	newChallenge, err := CreateChallenge()
+func TestVerifyCollectedClientData_IncorrectChallenge(t *testing.T) {
+	challenge, err := CreateChallenge()
 	require.NoError(t, err)
 
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-
-	var storedChallenge = newChallenge
-
-	require.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode))
-}
-
-func TestVerifyCollectedClientDataNoTopOrigin(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "", true)
-
-	var storedChallenge = newChallenge
-
-	require.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode))
-}
-
-func TestVerifyCollectedClientDataTopOrigin(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example2.com", true)
-
-	var storedChallenge = newChallenge
-
-	require.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode))
-}
-
-func TestVerifyCollectedClientDataTopOriginIgnore(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example2.com", true)
-
-	var storedChallenge = newChallenge
-
-	require.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{"https://example3.com"}, TopOriginIgnoreVerificationMode))
-}
-
-func TestVerifyCollectedClientDataTopOriginImplicit(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-
-	var storedChallenge = newChallenge
-
-	require.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, nil, TopOriginImplicitVerificationMode))
-}
-
-func TestVerifyCollectedClientDataTopOriginAuto(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-
-	var storedChallenge = newChallenge
-
-	require.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{"https://example.com"}, TopOriginAutoVerificationMode))
-}
-
-func TestVerifyCollectedClientDataTopOriginInvalidValue(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-
-	var storedChallenge = newChallenge
-
-	AssertIsProtocolError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{"https://example.com"}, -1), "not_implemented", "Error handling unknown Top Origin verification mode", "")
-}
-
-func TestVerifyCollectedClientDataIncorrectChallenge(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
+	ccd := setupCollectedClientData(challenge, "http://example.com", "http://example.com", true)
 
 	bogusChallenge, err := CreateChallenge()
 	require.NoError(t, err)
 
-	AssertIsProtocolError(t, ccd.Verify(bogusChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode), "verification_error", "Error validating challenge", fmt.Sprintf("Expected b Value: \"%s\"\nReceived b: \"%s\"\n", bogusChallenge.String(), newChallenge.String()))
-}
-
-func TestVerifyCollectedClientDataUnexpectedOrigin(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-	storedChallenge := newChallenge
-	expectedOrigins := []string{"http://different.com"}
-
-	AssertIsProtocolError(t, ccd.Verify(storedChallenge.String(), ccd.Type, expectedOrigins, nil, TopOriginExplicitVerificationMode), "verification_error", "Error validating origin", "Expected Values: [http://different.com], Received: http://example.com")
-}
-
-func TestVerifyCollectedClientDataUnexpectedTopOriginCrossOrigin(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example2.com", false)
-	storedChallenge := newChallenge
-
-	AssertIsProtocolError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode), "verification_error", "Error validating topOrigin", "The topOrigin can't have values unless crossOrigin is true.")
-}
-
-func TestVerifyCollectedClientDataUnexpectedTopOrigin(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-	storedChallenge := newChallenge
-	expectedOrigins := []string{"http://different.com"}
-
-	assert.EqualError(t, ccd.Verify(storedChallenge.String(), ccd.Type, []string{ccd.TopOrigin}, expectedOrigins, TopOriginExplicitVerificationMode), "Error validating top origin")
-}
-
-func TestVerifyCollectedClientDataWithMultipleExpectedOrigins(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "http://example.com", true)
-
-	var storedChallenge = newChallenge
-
-	expectedOrigins := []string{"https://exmaple.com", "9C:B4:AE:EF:05:53:6E:73:0E:C4:B8:02:E7:67:F6:7D:A4:E7:BC:26:D7:42:B5:27:FF:01:7D:68:2A:EB:FA:1D", ccd.Origin}
-
-	assert.NoError(t, ccd.Verify(storedChallenge.String(), ccd.Type, expectedOrigins, nil, TopOriginIgnoreVerificationMode))
-}
-
-func TestVerifyCollectedClientData_CeremonyMismatch(t *testing.T) {
-	newChallenge, err := CreateChallenge()
-	require.NoError(t, err)
-
-	ccd := setupCollectedClientData(newChallenge, "http://example.com", "", false)
-
-	err = ccd.Verify(newChallenge.String(), AssertCeremony, []string{ccd.Origin}, nil, TopOriginIgnoreVerificationMode)
-	assert.EqualError(t, err, "Error validating ceremony type")
-	AssertIsProtocolError(t, err, "verification_error", "Error validating ceremony type", fmt.Sprintf("Expected Value: %s, Received: %s", AssertCeremony, ccd.Type))
+	AssertIsProtocolError(t, ccd.Verify(bogusChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode, true), "verification_error", "Error validating challenge", fmt.Sprintf("Expected b Value: \"%s\"\nReceived b: \"%s\"\n", bogusChallenge.String(), challenge.String()))
 }
 
 func TestVerifyCollectedClientData_TokenBinding(t *testing.T) {
@@ -207,7 +239,7 @@ func TestVerifyCollectedClientData_TokenBinding(t *testing.T) {
 			ccd := setupCollectedClientData(newChallenge, "http://example.com", "", false)
 			ccd.TokenBinding = tc.tokenBinding
 
-			err = ccd.Verify(newChallenge.String(), CreateCeremony, []string{ccd.Origin}, nil, TopOriginIgnoreVerificationMode)
+			err = ccd.Verify(newChallenge.String(), CreateCeremony, []string{ccd.Origin}, nil, TopOriginExplicitVerificationMode, false)
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
 			} else {
@@ -402,4 +434,16 @@ func TestIsOriginInHaystack(t *testing.T) {
 			assert.Equal(t, tc.expected, IsOriginInHaystack(tc.origin, tc.haystack))
 		})
 	}
+}
+
+func setupCollectedClientData(challenge URLEncodedBase64, origin, topOrigin string, crossOrigin bool) *CollectedClientData { //nolint:unparam
+	ccd := &CollectedClientData{
+		Type:        CreateCeremony,
+		Origin:      origin,
+		TopOrigin:   topOrigin,
+		CrossOrigin: crossOrigin,
+		Challenge:   challenge.String(),
+	}
+
+	return ccd
 }

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -169,9 +169,9 @@ func (ccr CredentialCreationResponse) Parse() (pcc *ParsedCredentialCreationData
 // Verify the Client and Attestation data.
 //
 // Specification: §7.1. Registering a New Credential (https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential)
-func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, verifyUser bool, verifyUserPresence bool, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, mds metadata.Provider, credParams []CredentialParameter) (clientDataHash []byte, err error) {
+func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, mds metadata.Provider, credParams []CredentialParameter) (clientDataHash []byte, err error) {
 	// Handles steps 3 through 6 - Verifying the Client Data against the Relying Party's stored data.
-	if err = pcc.Response.CollectedClientData.Verify(storedChallenge, CreateCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify); err != nil {
+	if err = pcc.Response.CollectedClientData.Verify(storedChallenge, CreateCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin); err != nil {
 		return nil, err
 	}
 

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -270,7 +270,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				Raw:                       tc.fields.Raw,
 			}
 
-			actual, err := pcc.Verify(tc.args.storedChallenge.String(), tc.args.verifyUser, false, tc.args.relyingPartyID, tc.args.relyingPartyOrigin, nil, TopOriginIgnoreVerificationMode, nil, tc.args.credParams)
+			actual, err := pcc.Verify(tc.args.storedChallenge.String(), tc.args.relyingPartyID, tc.args.relyingPartyOrigin, nil, TopOriginExplicitVerificationMode, false, tc.args.verifyUser, false, nil, tc.args.credParams)
 
 			assert.Equal(t, tc.expected, actual)
 			if tc.err != "" {

--- a/protocol/specification_vectors_e2e_test.go
+++ b/protocol/specification_vectors_e2e_test.go
@@ -39,6 +39,7 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 		credParams                  []CredentialParameter
 		rpTopOrigins                []string
 		rpTopOriginVerificationMode TopOriginVerificationMode
+		allowCrossOrigin            bool
 		mds                         metadata.Provider
 		err                         string
 	}{
@@ -72,6 +73,21 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 		{
 			// §16.4 None Attestation - ES256 - Cross Origin
 			// See: https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-crossOrigin
+			name:                        "NoneES256CrossOriginNotAllowed",
+			attestationObject:           "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b54500000000883f4f6014f19c09d87aa38123be48d000206e1050c0d2ca2f07c755cb2c66a74c64fa43065c18f938354d9915db2bd5ce57a501020326200121582022200a473f90b11078851550d03b4e44a2279f8c4eca27b3153dedfe03e4e97d225820cbd0be95e746ad6f5a8191be11756e4c0420e72f65b466d39bc56b8b123a9c6e",
+			clientDataJSON:              "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a224f2d57717a514e5463554a484930437257576e7951504859647862694332674872434d475666704c4f306b222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a747275652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a207a5a7175457444523944577170573574425754467567227d",
+			credentialID:                "6e1050c0d2ca2f07c755cb2c66a74c64fa43065c18f938354d9915db2bd5ce57",
+			challenge:                   "3be5aacd03537142472340ab5969f240f1d87716e20b6807ac230655fa4b3b49",
+			format:                      "none",
+			credParams:                  []CredentialParameter{{Type: PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            false,
+			err:                         "Error validating cross origin flag",
+		},
+		//nolint:gosec
+		{
+			// §16.4 None Attestation - ES256 - Cross Origin
+			// See: https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-crossOrigin
 			name:                        "NoneES256CrossOrigin",
 			attestationObject:           "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b54500000000883f4f6014f19c09d87aa38123be48d000206e1050c0d2ca2f07c755cb2c66a74c64fa43065c18f938354d9915db2bd5ce57a501020326200121582022200a473f90b11078851550d03b4e44a2279f8c4eca27b3153dedfe03e4e97d225820cbd0be95e746ad6f5a8191be11756e4c0420e72f65b466d39bc56b8b123a9c6e",
 			clientDataJSON:              "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a224f2d57717a514e5463554a484930437257576e7951504859647862694332674872434d475666704c4f306b222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a747275652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a207a5a7175457444523944577170573574425754467567227d",
@@ -80,6 +96,23 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 			format:                      "none",
 			credParams:                  []CredentialParameter{{Type: PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
 			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            true,
+		},
+		//nolint:gosec
+		{
+			// §16.5 None Attestation - ES256 - Top Origin
+			// See: https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-topOrigin
+			name:                        "NoneES256TopOriginNotAllowed",
+			attestationObject:           "a363666d74646e6f6e656761747453746d74a068617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b5410000000097586fd09799a76401c200455099ef2a0020b8ad59b996047ab18e2ceb57206c362da57458793481f4a8ebf101c7ca7cc0f1a5010203262001215820a1c47c1d82da4ebe82cd72207102b380670701993bc35398ae2e5726427fe01d22582086c1080d82987028c7f54ecb1b01185de243b359294a0ed210cd47480f0adc88",
+			clientDataJSON:              "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a225468394d595a68706e6a504254786b68555f53646667364f4e58665672454673587a72636b7151664a2d55222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a747275652c22746f704f726967696e223a2268747470733a2f2f6578616d706c652e636f6d227d",
+			credentialID:                "b8ad59b996047ab18e2ceb57206c362da57458793481f4a8ebf101c7ca7cc0f1",
+			challenge:                   "4e1f4c6198699e33c14f192153f49d7e0e8e3577d5ac416c5f3adc92a41f27e5",
+			format:                      "none",
+			credParams:                  []CredentialParameter{{Type: PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+			rpTopOrigins:                []string{"https://example.com/"},
+			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            false,
+			err:                         "Error validating cross origin flag",
 		},
 		//nolint:gosec
 		{
@@ -94,6 +127,7 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 			credParams:                  []CredentialParameter{{Type: PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
 			rpTopOrigins:                []string{"https://example.com/"},
 			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            true,
 		},
 		//nolint:gosec
 		{
@@ -239,7 +273,7 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 
 			challenge := base64.RawURLEncoding.EncodeToString(specTestDecodeHex(t, tc.challenge))
 
-			_, err = pcc.Verify(challenge, false, true, specTestRPID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.mds, tc.credParams)
+			_, err = pcc.Verify(challenge, specTestRPID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, tc.mds, tc.credParams)
 
 			if tc.err == "" {
 				assert.NoError(t, err)
@@ -263,9 +297,11 @@ func TestSpecVectors_Authentication_E2E(t *testing.T) {
 		credentialID                string
 		challenge                   string
 		credentialPubKey            string
+		appID                       string
 		rpTopOrigins                []string
 		rpTopOriginVerificationMode TopOriginVerificationMode
-		appID                       string
+		allowCrossOrigin            bool
+		err                         string
 	}{
 		//nolint:gosec
 		{
@@ -297,6 +333,21 @@ func TestSpecVectors_Authentication_E2E(t *testing.T) {
 		{
 			// §16.4 None Attestation - ES256 - Cross Origin
 			// See: https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-crossOrigin
+			name:                        "NoneES256CrossOriginNotAllowed",
+			authenticatorData:           "bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b50500000000",
+			clientDataJSON:              "7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a226832716c463771445f65356c5f505f62796b7945377135645650674547685f49584a6b655737736e4d5463222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a747275652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a2039327063545644304162792d713464746d6a36656667227d",
+			signature:                   "3046022100eb12fcf23b12764c0f122e22371fab92e283879fd798f38ee1841c951b6e40e7022100c76237ff9db77b3c56f30837cda6a09acfa2e915544e609c0733b1184036d1cf",
+			credentialID:                "6e1050c0d2ca2f07c755cb2c66a74c64fa43065c18f938354d9915db2bd5ce57",
+			challenge:                   "876aa517ba83fdee65fcffdbca4c84eeae5d54f8041a1fc85c991e5bbb273137",
+			credentialPubKey:            "a501020326200121582022200a473f90b11078851550d03b4e44a2279f8c4eca27b3153dedfe03e4e97d225820cbd0be95e746ad6f5a8191be11756e4c0420e72f65b466d39bc56b8b123a9c6e",
+			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            false,
+			err:                         "Error validating cross origin flag",
+		},
+		//nolint:gosec
+		{
+			// §16.4 None Attestation - ES256 - Cross Origin
+			// See: https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-crossOrigin
 			name:                        "NoneES256CrossOrigin",
 			authenticatorData:           "bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b50500000000",
 			clientDataJSON:              "7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a226832716c463771445f65356c5f505f62796b7945377135645650674547685f49584a6b655737736e4d5463222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a747275652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a2039327063545644304162792d713464746d6a36656667227d",
@@ -305,6 +356,7 @@ func TestSpecVectors_Authentication_E2E(t *testing.T) {
 			challenge:                   "876aa517ba83fdee65fcffdbca4c84eeae5d54f8041a1fc85c991e5bbb273137",
 			credentialPubKey:            "a501020326200121582022200a473f90b11078851550d03b4e44a2279f8c4eca27b3153dedfe03e4e97d225820cbd0be95e746ad6f5a8191be11756e4c0420e72f65b466d39bc56b8b123a9c6e",
 			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            true,
 		},
 		//nolint:gosec
 		{
@@ -319,6 +371,22 @@ func TestSpecVectors_Authentication_E2E(t *testing.T) {
 			credentialPubKey:            "a5010203262001215820a1c47c1d82da4ebe82cd72207102b380670701993bc35398ae2e5726427fe01d22582086c1080d82987028c7f54ecb1b01185de243b359294a0ed210cd47480f0adc88",
 			rpTopOrigins:                []string{"https://example.com/"},
 			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            false,
+			err:                         "Error validating cross origin flag",
+		},
+		{
+			// §16.5 None Attestation - ES256 - Top Origin
+			// See: https://w3c.github.io/webauthn/#sctn-test-vectors-none-es256-topOrigin
+			name:                        "NoneES256TopOrigin",
+			authenticatorData:           "bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b50500000000",
+			clientDataJSON:              "7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22315570636a4b53324b6f34377379486a7372787a68572d466f51465132796b3572426c584f6573656f4759222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a747275652c22746f704f726967696e223a2268747470733a2f2f6578616d706c652e636f6d222c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a205569466f4a4d56525148444146574669347678557051227d",
+			signature:                   "3045022100b5a70c81780d5fcc9a4f2ae9caae99058f8accaf58b91fb59329646c28ac6ffc022012e101c165db3c8e9957f0c54dd6ca9b56bc3bd2f280bd2faa6c1d02c6e5c171",
+			credentialID:                "b8ad59b996047ab18e2ceb57206c362da57458793481f4a8ebf101c7ca7cc0f1",
+			challenge:                   "d54a5c8ca4b62a8e3bb321e3b2bc73856f85a10150db2939ac195739eb1ea066",
+			credentialPubKey:            "a5010203262001215820a1c47c1d82da4ebe82cd72207102b380670701993bc35398ae2e5726427fe01d22582086c1080d82987028c7f54ecb1b01185de243b359294a0ed210cd47480f0adc88",
+			rpTopOrigins:                []string{"https://example.com/"},
+			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
+			allowCrossOrigin:            true,
 		},
 		//nolint:gosec
 		{
@@ -462,7 +530,13 @@ func TestSpecVectors_Authentication_E2E(t *testing.T) {
 			challenge := base64.RawURLEncoding.EncodeToString(specTestDecodeHex(t, tc.challenge))
 			credPubKey := specTestDecodeHex(t, tc.credentialPubKey)
 
-			assert.NoError(t, par.Verify(challenge, specTestRPID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.appID, false, true, credPubKey))
+			err = par.Verify(challenge, specTestRPID, tc.appID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, credPubKey)
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
 		})
 	}
 }

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -363,7 +363,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 	}
 
 	// Handle steps 4 through 16.
-	if err = parsedResponse.Verify(session.Challenge, rpID, rpOrigins, rpTopOrigins, webauthn.Config.RPTopOriginVerificationMode, appID, shouldVerifyUser, shouldVerifyUserPresence, credential.PublicKey); err != nil {
+	if err = parsedResponse.Verify(session.Challenge, rpID, appID, rpOrigins, rpTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, credential.PublicKey); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -149,7 +149,7 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 	var clientDataHash []byte
 
-	if clientDataHash, err = parsedResponse.Verify(session.Challenge, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.MDS, session.CredParams); err != nil {
+	if clientDataHash, err = parsedResponse.Verify(session.Challenge, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -51,10 +51,17 @@ type Config struct {
 	// is utilized to determine equality.
 	RPTopOrigins []string
 
-	// RPTopOriginVerificationMode determines the verification mode for the Top Origin value. By default the
-	// TopOriginIgnoreVerificationMode is used however this is going to change at such a time as WebAuthn Level 3
-	// becomes recommended, implementers should explicitly set this value if they want stability.
+	// RPTopOriginVerificationMode determines the verification mode for the Top Origin value used in cross-origin
+	// ceremonies. When the zero value ([protocol.TopOriginDefaultVerificationMode]) is provided, the config
+	// validator coerces this field to [protocol.TopOriginExplicitVerificationMode] — i.e. any Top Origin supplied
+	// by the client must appear in [Config.RPTopOrigins]. Set this field explicitly to
+	// [protocol.TopOriginAutoVerificationMode] or [protocol.TopOriginImplicitVerificationMode] if you need
+	// different matching semantics; there is no longer a mode that disables verification entirely.
 	RPTopOriginVerificationMode protocol.TopOriginVerificationMode
+
+	// RPAllowCrossOrigin determines whether the RP is allowed to be used in cross-origin contexts. This is disabled
+	// by default.
+	RPAllowCrossOrigin bool
 
 	// AttestationPreference sets the default attestation conveyance preferences.
 	AttestationPreference protocol.ConveyancePreference
@@ -139,7 +146,7 @@ func (config *Config) validate() (err error) {
 	}
 
 	if config.RPTopOriginVerificationMode == protocol.TopOriginDefaultVerificationMode {
-		config.RPTopOriginVerificationMode = protocol.TopOriginIgnoreVerificationMode
+		config.RPTopOriginVerificationMode = protocol.TopOriginExplicitVerificationMode
 	}
 
 	config.validated = true

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-webauthn/webauthn/protocol"
 )
@@ -114,6 +115,68 @@ func TestNew(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfig_Validate_DefaultsRPTopOriginVerificationModeToExplicit(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  protocol.TopOriginVerificationMode
+		expect protocol.TopOriginVerificationMode
+	}{
+		{
+			name:   "ShouldCoerceZeroValueToExplicit",
+			input:  protocol.TopOriginVerificationMode(0),
+			expect: protocol.TopOriginExplicitVerificationMode,
+		},
+		{
+			name:   "ShouldCoerceDefaultToExplicit",
+			input:  protocol.TopOriginDefaultVerificationMode,
+			expect: protocol.TopOriginExplicitVerificationMode,
+		},
+		{
+			name:   "ShouldPreserveExplicit",
+			input:  protocol.TopOriginExplicitVerificationMode,
+			expect: protocol.TopOriginExplicitVerificationMode,
+		},
+		{
+			name:   "ShouldPreserveAuto",
+			input:  protocol.TopOriginAutoVerificationMode,
+			expect: protocol.TopOriginAutoVerificationMode,
+		},
+		{
+			name:   "ShouldPreserveImplicit",
+			input:  protocol.TopOriginImplicitVerificationMode,
+			expect: protocol.TopOriginImplicitVerificationMode,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &Config{
+				RPID:                        "example.com",
+				RPOrigins:                   []string{"https://example.com"},
+				RPTopOriginVerificationMode: tc.input,
+			}
+
+			w, err := New(config)
+			assert.NoError(t, err)
+			assert.NotNil(t, w)
+			assert.Equal(t, tc.expect, config.RPTopOriginVerificationMode,
+				"Config.RPTopOriginVerificationMode should be %v after New(), got %v", tc.expect, config.RPTopOriginVerificationMode)
+			assert.Equal(t, tc.expect, config.GetTopOriginVerificationMode())
+		})
+	}
+
+	t.Run("ShouldCoerceDirectValidateCall", func(t *testing.T) {
+		config := &Config{
+			RPID:                        "example.com",
+			RPOrigins:                   []string{"https://example.com"},
+			RPTopOriginVerificationMode: protocol.TopOriginDefaultVerificationMode,
+		}
+
+		require.NoError(t, config.validate())
+		assert.Equal(t, protocol.TopOriginExplicitVerificationMode, config.RPTopOriginVerificationMode)
+	})
 }
 
 // Supporting test types and functions.


### PR DESCRIPTION
Cross-Origin WebAuthn ceremonies are now rejected by default.
Integrators that need to accept them must opt in by setting the new
[webauthn.Config.RPAllowCrossOrigin] field to true.

The previously-permissive Top Origin handling has also been tightened.
The zero value of [protocol.TopOriginVerificationMode] is now coerced
by [webauthn.Config.validate] to
[protocol.TopOriginExplicitVerificationMode]; the strictest active
mode, which accepts a Top Origin only if it matches an entry in
[webauthn.Config.RPTopOrigins]. The opt-out mode
protocol.TopOriginIgnoreVerificationMode has been removed entirely;
[protocol.CollectedClientData.Verify] returns an "unknown Top Origin
verification mode" error if it is ever encountered.

Together these changes align the library with the W3C WebAuthn Level 3
guidance that Cross-Origin embedding and Top Origin acceptance should
be explicit relying-party decisions rather than defaults.

BREAKING CHANGE: The Cross-Origin verification semantics have changed
significantly due to the stabilization of the WebAuthn Level 3 
specification. It is no longer possible to disable verification, and 
Cross-Origin ceremonies must explicitly be allowed in this release.

- protocol.TopOriginIgnoreVerificationMode has been removed. Code that
  referenced it must switch to one of the other constants as there is
  no longer a mode which disables the Top Origin verification such as:
    - TopOriginExplicitVerificationMode; match against RPTopOrigins only
      (recommended, and the new coerced default)
    - TopOriginAutoVerificationMode; match against the union of
      RPTopOrigins and RPOrigins
    - TopOriginImplicitVerificationMode; match against RPOrigins only

- webauthn.Config.validate now rewrites a zero-valued
  RPTopOriginVerificationMode to TopOriginExplicitVerificationMode.
  Integrators that left the field unset previously got ignore-mode
  semantics (any Top Origin accepted); they now get strict matching
  against RPTopOrigins and must populate that list, or explicitly
  select a different mode; for Cross-Origin flows to succeed.

- Cross-Origin ceremonies (those where the authenticator reports
  crossOrigin = true in the ClientData) are rejected by default.
  Integrators that rely on iframe-embedded or other Cross-Origin WebAuthn
  flows must set webauthn.Config.RPAllowCrossOrigin = true. The library
  continues to enforce Top Origin verification on accepted Cross-Origin
  ceremonies per the configured mode.

- protocol.CollectedClientData.Verify no longer accepts
  TopOriginIgnoreVerificationMode; callers that pass an unknown mode
  receive ErrNotImplemented with detail "unknown Top Origin
  verification mode".