### PR TITLE
fix(webauthn): ensure challenge length is valid

### DIFF
--- a/protocol/challenge.go
+++ b/protocol/challenge.go
@@ -5,7 +5,7 @@ import (
 )
 
 // ChallengeLength - Length of bytes to generate for a challenge.
-const ChallengeLength = 32
+const ChallengeLength = DefaultChallengeLength
 
 // CreateChallenge creates a new challenge that should be signed and returned by the authenticator. The spec recommends
 // using at least 16 bytes with 100 bits of entropy. We use 32 bytes.

--- a/protocol/const.go
+++ b/protocol/const.go
@@ -24,6 +24,14 @@ const (
 	attStatementAndroidSafetyNetHostname = "attest.android.com"
 )
 
+const (
+	// MinimumChallengeLength defines the minimum length of the challenge.
+	MinimumChallengeLength = 16
+
+	// DefaultChallengeLength defines the default length of the challenge.
+	DefaultChallengeLength = 32
+)
+
 var (
 	// internalRemappedAuthenticatorTransport handles remapping of AuthenticatorTransport values. Specifically it is
 	// intentional on remapping only transports that never made recommendation but are being used in the wild. It

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -103,7 +103,7 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 		assertion.Response.Challenge = challenge
 	}
 
-	if len(assertion.Response.Challenge) < 16 {
+	if len(assertion.Response.Challenge) < protocol.MinimumChallengeLength {
 		return nil, nil, fmt.Errorf("error generating assertion: the challenge must be at least 16 bytes")
 	}
 

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -27,12 +27,14 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		return nil, nil, fmt.Errorf(errFmtConfigValidate, err)
 	}
 
-	challenge, err := protocol.CreateChallenge()
-	if err != nil {
+	var (
+		challenge    protocol.URLEncodedBase64
+		entityUserID any
+	)
+
+	if challenge, err = protocol.CreateChallenge(); err != nil {
 		return nil, nil, err
 	}
-
-	var entityUserID any
 
 	if webauthn.Config.EncodeUserIDAsString {
 		entityUserID = string(user.WebAuthnID())
@@ -83,6 +85,10 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		return nil, nil, fmt.Errorf("error generating credential creation: the relying party display name must be provided via the configuration or a functional option for a creation")
 	}
 
+	if len(creation.Response.Challenge) < protocol.MinimumChallengeLength {
+		return nil, nil, fmt.Errorf("error generating credential creation: the challenge must be at least 16 bytes")
+	}
+
 	if creation.Response.Timeout == 0 {
 		switch creation.Response.AuthenticatorSelection.UserVerification {
 		case protocol.VerificationDiscouraged:
@@ -93,7 +99,7 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 	}
 
 	session = &SessionData{
-		Challenge:        challenge.String(),
+		Challenge:        creation.Response.Challenge.String(),
 		RelyingPartyID:   creation.Response.RelyingParty.ID,
 		UserID:           user.WebAuthnID(),
 		UserVerification: creation.Response.AuthenticatorSelection.UserVerification,

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -295,6 +295,92 @@ func TestBeginRegistration_EncodeUserIDAsString(t *testing.T) {
 	}
 }
 
+func TestBeginMediatedRegistration_ChallengeLength(t *testing.T) {
+	// withTestChallenge is a test-only RegistrationOption that overrides the generated challenge. It mirrors the
+	// WithChallenge login option; no equivalent is exported for registration, so we synthesise one here to exercise
+	// the minimum-length guard.
+	withTestChallenge := func(challenge []byte) RegistrationOption {
+		return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+			cco.Challenge = challenge
+		}
+	}
+
+	config := &Config{
+		RPID:          "example.com",
+		RPDisplayName: "Test Display Name",
+		RPOrigins:     []string{"https://example.com"},
+	}
+
+	testCases := []struct {
+		name   string
+		opts   []RegistrationOption
+		expLen int
+		err    string
+	}{
+		{
+			name:   "ShouldSucceedWithDefaultChallenge",
+			opts:   nil,
+			expLen: 32,
+		},
+		{
+			name: "ShouldFailNilChallenge",
+			opts: []RegistrationOption{withTestChallenge(nil)},
+			err:  "error generating credential creation: the challenge must be at least 16 bytes",
+		},
+		{
+			name: "ShouldFailEmptyChallenge",
+			opts: []RegistrationOption{withTestChallenge([]byte{})},
+			err:  "error generating credential creation: the challenge must be at least 16 bytes",
+		},
+		{
+			name: "ShouldFailEightByteChallenge",
+			opts: []RegistrationOption{withTestChallenge(bytes.Repeat([]byte{0xab}, 8))},
+			err:  "error generating credential creation: the challenge must be at least 16 bytes",
+		},
+		{
+			name: "ShouldFailFifteenByteChallenge",
+			opts: []RegistrationOption{withTestChallenge(bytes.Repeat([]byte{0xab}, 15))},
+			err:  "error generating credential creation: the challenge must be at least 16 bytes",
+		},
+		{
+			name:   "ShouldSucceedSixteenByteChallenge",
+			opts:   []RegistrationOption{withTestChallenge(bytes.Repeat([]byte{0xab}, 16))},
+			expLen: 16,
+		},
+		{
+			name:   "ShouldSucceedThirtyTwoByteChallenge",
+			opts:   []RegistrationOption{withTestChallenge(bytes.Repeat([]byte{0xab}, 32))},
+			expLen: 32,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(config)
+			require.NoError(t, err)
+
+			user := &defaultUser{id: []byte("123")}
+
+			creation, session, err := w.BeginMediatedRegistration(user, protocol.MediationDefault, tc.opts...)
+
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+				assert.Nil(t, creation)
+				assert.Nil(t, session)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, creation)
+			require.NotNil(t, session)
+			assert.Len(t, []byte(creation.Response.Challenge), tc.expLen)
+			assert.NotEmpty(t, session.Challenge)
+			assert.Equal(t, creation.Response.Challenge.String(), session.Challenge)
+		})
+	}
+}
+
 func TestBeginMediatedRegistration_EnforceTimeout(t *testing.T) {
 	config := &Config{
 		RPID:          "example.com",


### PR DESCRIPTION
This enforces the minimum challenge length on registration. While implementers cannot modify this themselves today, this adds a defense-in-depth check to ensure the future is secure.