### PR TITLE
fix(protocol): short-circuit apple attestation extension lookup

### DIFF
--- a/protocol/attestation_apple.go
+++ b/protocol/attestation_apple.go
@@ -61,6 +61,8 @@ func attestationFormatValidationHandlerAppleAnonymous(att AttestationObject, cli
 	for _, ext := range credCert.Extensions {
 		if ext.Id.Equal(oidExtensionAppleAnonymousAttestation) {
 			attExtBytes = ext.Value
+
+			break
 		}
 	}
 


### PR DESCRIPTION
The Apple Anonymous attestation OID (1.2.840.113635.100.8.2) appears exactly once per conformant Apple attestation certificate, so the extension-search loop in attestationFormatValidationHandlerAppleAnonymou breaks on the first match rather than iterating the remaining extensions. This fixes these semantics being ignored and the exits the loop as soon as it's found.