### PR TITLE
fix(protocol): remove unnecessary guard

### DIFF
--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -235,10 +235,6 @@ func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadat
 
 	a.Type = attestationType
 
-	if attestationType == string(AttestationFormatCompound) {
-		return nil
-	}
-
 	if len(a.AuthData.AttData.AAGUID) != 0 {
 		if aaguid, err = uuid.FromBytes(a.AuthData.AttData.AAGUID); err != nil {
 			return ErrInvalidAttestation.WithInfo("Error occurred parsing AAGUID during attestation validation").WithDetails(err.Error()).WithError(err)
@@ -249,7 +245,7 @@ func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadat
 		return nil
 	}
 
-	if e := ValidateMetadata(context.Background(), mds, aaguid, attestationType, a.Format, x5cs); e != nil {
+	if e := ValidateMetadata(context.Background(), mds, aaguid, a.Type, a.Format, x5cs); e != nil {
 		return ErrInvalidAttestation.WithInfo(fmt.Sprintf("Error occurred validating metadata during attestation validation: %+v", e)).WithDetails(e.DevInfo).WithError(e)
 	}
 


### PR DESCRIPTION
This fixes an issue where the compound format appeared to not be validated but actually was. The check is not necessary.