### PR TITLE
fix(webauthn): credential verify attestation

### DIFF
--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -208,6 +208,42 @@ func (c *Credential) Verify(mds metadata.Provider) (err error) {
 	return nil
 }
 
+// VerifyAttestationType is a cutdown version of Verify which only does the minimal verification to update the
+// AttestationType if it's unset. For full verification use Verify.
+func (c *Credential) VerifyAttestationType() (err error) {
+	if c.AttestationType != "" {
+		return nil
+	}
+
+	raw := c.toAuthenticatorAttestationResponse()
+
+	var attestation *protocol.ParsedAttestationResponse
+
+	if attestation, err = raw.Parse(); err != nil {
+		return fmt.Errorf("error verifying credential: error parsing attestation: %w", err)
+	}
+
+	if !bytes.Equal(c.PublicKey, attestation.AttestationObject.AuthData.AttData.CredentialPublicKey) {
+		return fmt.Errorf("error verifying credential: stored public key does not match the credential public key embedded in the attestation object")
+	}
+
+	clientDataHash := c.Attestation.ClientDataHash
+
+	if len(clientDataHash) == 0 {
+		sum := sha256.Sum256(c.Attestation.ClientDataJSON)
+
+		clientDataHash = sum[:]
+	}
+
+	if err = attestation.AttestationObject.VerifyAttestation(clientDataHash, nil); err != nil {
+		return fmt.Errorf("error verifying credential: error verifying attestation: %w", err)
+	}
+
+	c.AttestationType = attestation.AttestationObject.Type
+
+	return nil
+}
+
 func (c *Credential) toAuthenticatorAttestationResponse() *protocol.AuthenticatorAttestationResponse {
 	raw := &protocol.AuthenticatorAttestationResponse{
 		AuthenticatorResponse: protocol.AuthenticatorResponse{

--- a/webauthn/credential_test.go
+++ b/webauthn/credential_test.go
@@ -330,6 +330,126 @@ func TestCredential_Verify_RejectsTamperedPublicKey(t *testing.T) {
 	})
 }
 
+func TestCredential_VerifyAttestationType(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		credential              func(t *testing.T) Credential
+		err                     string
+		expectedAttestationType string
+	}{
+		{
+			name: "ShouldNoOpWhenAttestationTypeAlreadySet",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				credential := testCredentialFromNoneAttestation(t)
+				credential.AttestationType = "caller-set-value"
+				credential.Attestation.Object = []byte("not-valid-cbor")
+
+				return credential
+			},
+			expectedAttestationType: "caller-set-value",
+		},
+		{
+			name: "ShouldRestoreNoneAttestationType",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				credential := testCredentialFromNoneAttestation(t)
+				credential.AttestationType = ""
+
+				return credential
+			},
+			expectedAttestationType: "none",
+		},
+		{
+			name: "ShouldRestorePackedAttestationType",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				credential := testCredentialFromPackedAttestation(t)
+				credential.AttestationType = ""
+
+				return credential
+			},
+			expectedAttestationType: string(metadata.BasicFull),
+		},
+		{
+			name: "ShouldRecomputeClientDataHashWhenEmpty",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				credential := testCredentialFromNoneAttestation(t)
+				credential.AttestationType = ""
+				credential.Attestation.ClientDataHash = nil
+
+				return credential
+			},
+			expectedAttestationType: "none",
+		},
+		{
+			name: "ShouldFailParseError",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				return Credential{
+					Attestation: CredentialAttestation{
+						ClientDataJSON: []byte(`{}`),
+						Object:         []byte("not-valid-cbor"),
+					},
+				}
+			},
+			err: "error verifying credential: error parsing attestation: Error parsing the authenticator response",
+		},
+		{
+			name: "ShouldFailMismatchedPublicKey",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				credential := testCredentialFromNoneAttestation(t)
+				credential.AttestationType = ""
+
+				tampered := make([]byte, len(credential.PublicKey))
+				copy(tampered, credential.PublicKey)
+				tampered[0] ^= 0xFF
+				credential.PublicKey = tampered
+
+				return credential
+			},
+			err: "error verifying credential: stored public key does not match the credential public key embedded in the attestation object",
+		},
+		{
+			name: "ShouldFailEmptyPublicKey",
+			credential: func(t *testing.T) Credential {
+				t.Helper()
+
+				credential := testCredentialFromNoneAttestation(t)
+				credential.AttestationType = ""
+				credential.PublicKey = nil
+
+				return credential
+			},
+			err: "error verifying credential: stored public key does not match the credential public key embedded in the attestation object",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			credential := tc.credential(t)
+
+			err := credential.VerifyAttestationType()
+
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+
+			assert.Equal(t, tc.expectedAttestationType, credential.AttestationType)
+		})
+	}
+}
+
 // testCredentialFromNoneAttestation constructs a Credential with valid "none" format attestation data for testing.
 func testCredentialFromNoneAttestation(t *testing.T) Credential {
 	t.Helper()


### PR DESCRIPTION
This allows updating the AttestationType of a Credential with minimal additional checks provided the attestation is intact.