### PR TITLE
fix(protocol): missing tpm steps

### DIFF
--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"bytes"
 	"crypto/x509"
-	"encoding/asn1"
 	"fmt"
 	"strings"
 	"time"
@@ -157,33 +156,22 @@ func handleBasicAttestation(sig, clientDataHash, authData, aaguid []byte, alg in
 	// Step 2.2.3 (from §8.2.1) If the related attestation root certificate is used for multiple authenticator models,
 	// the Extension OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) MUST be present, containing the
 	// AAGUID as a 16-byte OCTET STRING. The extension MUST NOT be marked as critical.
-	var foundAAGUID []byte
+	//
+	// We validate the AAGUID as mentioned above. This is not well defined in §8.2.1 but mentioned in step 2.3: we
+	// validate the AAGUID if it is present within the certificate and make sure it matches the auth data AAGUID.
+	var (
+		certAAGUID []byte
+		critical   bool
+	)
 
-	for _, extension := range attestnCert.Extensions {
-		if extension.Id.Equal(oidFIDOGenCeAAGUID) {
-			if extension.Critical {
-				return "", x5c, ErrInvalidAttestation.WithDetails("Attestation certificate FIDO extension marked as critical")
-			}
-
-			foundAAGUID = extension.Value
-		}
+	if certAAGUID, critical, _, err = attestationCertAAGUID(attestnCert); critical {
+		return "", x5c, ErrInvalidAttestation.WithDetails("Attestation certificate FIDO extension marked as critical")
+	} else if err != nil {
+		return "", x5c, ErrInvalidAttestation.WithDetails("Error unmarshalling AAGUID from certificate")
 	}
 
-	// We validate the AAGUID as mentioned above
-	// This is not well defined in§8.2.1 but mentioned in step 2.3: we validate the AAGUID if it is present within the certificate
-	// and make sure it matches the auth data AAGUID
-	// Note that an X.509 Extension encodes the DER-encoding of the value in an OCTET STRING. Thus, the
-	// AAGUID MUST be wrapped in two OCTET STRINGS to be valid.
-	if len(foundAAGUID) > 0 {
-		var unMarshalledAAGUID []byte
-
-		if _, err = asn1.Unmarshal(foundAAGUID, &unMarshalledAAGUID); err != nil {
-			return "", x5c, ErrInvalidAttestation.WithDetails("Error unmarshalling AAGUID from certificate")
-		}
-
-		if !bytes.Equal(aaguid, unMarshalledAAGUID) {
-			return "", x5c, ErrInvalidAttestation.WithDetails("Certificate AAGUID does not match Auth Data certificate")
-		}
+	if len(certAAGUID) > 0 && !bytes.Equal(aaguid, certAAGUID) {
+		return "", x5c, ErrInvalidAttestation.WithDetails("Certificate AAGUID does not match Auth Data certificate")
 	}
 
 	// Step 2.2.4 The Basic Constraints extension MUST have the CA component set to false.

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -2,12 +2,10 @@ package protocol
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/subtle"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -208,6 +206,7 @@ func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash
 	var (
 		manufacturer, model, version string
 		ekuValid                     = false
+		constraintsValid             = false
 		eku                          []asn1.ObjectIdentifier
 		constraints                  tpmBasicConstraints
 		rest                         []byte
@@ -246,6 +245,8 @@ func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash
 			} else if len(rest) != 0 {
 				return "", nil, ErrAttestationFormat.WithDetails("AIK certificate basic constraints contains extra data")
 			}
+
+			constraintsValid = true
 		}
 	}
 
@@ -263,11 +264,27 @@ func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash
 		return "", nil, ErrAttestationFormat.WithDetails("AIK certificate missing EKU")
 	}
 
+	// 5/6 The Basic Constraints extension MUST have the CA component set to false. An absent extension can't have the
+	// CA component set to false so it's rejected in the same way as one which asserts CA is true.
+	//
 	// 6/6 An Authority Information Access (AIA) extension with entry id-ad-ocsp and a CRL Distribution Point
 	// extension [RFC5280] are both OPTIONAL as the status of many attestation certificates is available
 	// through metadata services. See, for example, the FIDO Metadata Service.
-	if constraints.IsCA {
+	if !constraintsValid || constraints.IsCA {
 		return "", nil, ErrAttestationFormat.WithDetails("AIK certificate basic constraints missing or CA is true")
+	}
+
+	// If aikCert contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) verify that the value
+	// of this extension matches the aaguid in authenticatorData.
+	var (
+		aaguid []byte
+		found  bool
+	)
+
+	if aaguid, _, found, err = attestationCertAAGUID(aikCert); err != nil {
+		return "", nil, ErrInvalidAttestation.WithDetails("Error unmarshalling AAGUID from certificate").WithError(err)
+	} else if found && !bytes.Equal(aaguid, att.AuthData.AttData.AAGUID) {
+		return "", nil, ErrInvalidAttestation.WithDetails("Certificate AAGUID does not match Auth Data certificate")
 	}
 
 	// 4/4 Verify that attested contains a TPMS_CERTIFY_INFO structure as specified in
@@ -320,34 +337,6 @@ func tpm2NameMatch(certInfo *tpm2.TPMSAttest, pubArea *tpm2.TPMTPublic) (match b
 	// See: https://w3c.github.io/webauthn/#sctn-tpm-attestation
 
 	return subtle.ConstantTimeCompare(certifyInfo.Name.Buffer, name.Buffer) == 1, nil
-}
-
-func tpm2NameDigest(name tpm2.TPM2BName) (alg tpm2.TPMIAlgHash, digest []byte, err error) {
-	buf := name.Buffer
-
-	if len(buf) < 3 {
-		return 0, nil, fmt.Errorf("name too short")
-	}
-
-	alg = tpm2.TPMIAlgHash(binary.BigEndian.Uint16(buf[:2]))
-
-	var hash crypto.Hash
-
-	if hash, err = alg.Hash(); err != nil {
-		return 0, nil, fmt.Errorf("invalid hash algorithm: %w", err)
-	}
-
-	digest = buf[2:]
-
-	if len(digest) == 0 {
-		return 0, nil, fmt.Errorf("name digest is empty")
-	}
-
-	if len(digest) != hash.Size() {
-		return 0, nil, fmt.Errorf("invalid name digest length: %d", len(digest))
-	}
-
-	return alg, digest, nil
 }
 
 type tpm2AttStatement struct {
@@ -507,72 +496,29 @@ type tpmManufacturer struct {
 	code string
 }
 
-// See https://trustedcomputinggroup.org/resource/vendor-id-registry/ for registry contents.
-var (
-	tpmManufacturers = []tpmManufacturer{
-		{"414D4400", "AMD", "AMD"},
-		{"414E5400", "Ant Group", "ANT"},
-		{"41544D4C", "Atmel", "ATML"},
-		{"4252434D", "Broadcom", "BRCM"},
-		{"4353434F", "Cisco", "CSCO"},
-		{"464C5953", "Flyslice Technologies", "FLYS"},
-		{"524F4343", "Fuzhou Rockchip", "ROCC"},
-		{"474F4F47", "Google", "GOOG"},
-		{"48504900", "HPI", "HPI"},
-		{"48504500", "HPE", "HPE"},
-		{"48495349", "Huawei", "HISI"},
-		{"49424d00", "IBM", "IBM"},
-		{"49424D00", "IBM", "IBM"},
-		{"49465800", "Infineon", "IFX"},
-		{"494E5443", "Intel", "INTC"},
-		{"4C454E00", "Lenovo", "LEN"},
-		{"4D534654", "Microsoft", "MSFT"},
-		{"4E534D20", "National Semiconductor", "NSM"},
-		{"4E545A00", "Nationz", "NTZ"},
-		{"4E534700", "NSING", "NSG"},
-		{"4E544300", "Nuvoton Technology", "NTC"},
-		{"51434F4D", "Qualcomm", "QCOM"},
-		{"534D534E", "Samsung", "SECE"},
-		{"53454345", "SecEdge", "SecEdge"},
-		{"534E5300", "Sinosun", "SNS"},
-		{"534D5343", "SMSC", "SMSC"},
-		{"53544D20", "ST Microelectronics", "STM"},
-		{"54584E00", "Texas Instruments", "TXN"},
-		{"57454300", "Winbond", "WEC"},
-		{"5345414C", "Wisekey", "SEAL"},
-		{"FFFFF1D0", "FIDO Alliance Conformance Testing", "FIDO"},
-	}
-)
-
-func isValidTPMManufacturer(id string) bool {
-	for _, m := range tpmManufacturers {
-		if m.id == id {
-			return true
-		}
+func tpmParseAIKAttCA(x5c *x509.Certificate, x5cis []*x509.Certificate) (leaf *x509.Certificate, parents []*x509.Certificate, protoErr *Error) {
+	if leaf, protoErr = tpmParseSANExtension(x5c); protoErr != nil {
+		return nil, nil, protoErr
 	}
 
-	return false
+	var hasAIK bool
+
+	// The AIK Extended Key Usage is only required on the attestation certificate itself per §8.3.1. TPM vendor
+	// intermediates generally don't carry it so it must not be required of them.
+	if leaf, hasAIK = tpmRemoveEKU(leaf); !hasAIK {
+		return nil, nil, ErrAttestationFormat.WithDetails("Attestation Identity Key certificate missing required Extended Key Usage.")
+	}
+
+	for _, x5ci := range x5cis {
+		parent, _ := tpmRemoveEKU(x5ci)
+
+		parents = append(parents, parent)
+	}
+
+	return leaf, parents, nil
 }
 
-func tpmParseAIKAttCA(x5c *x509.Certificate, x5cis []*x509.Certificate) (err *Error) {
-	if err = tpmParseSANExtension(x5c); err != nil {
-		return err
-	}
-
-	if err = tpmRemoveEKU(x5c); err != nil {
-		return err
-	}
-
-	for _, parent := range x5cis {
-		if err = tpmRemoveEKU(parent); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func tpmParseSANExtension(attestation *x509.Certificate) (protoErr *Error) {
+func tpmParseSANExtension(attestation *x509.Certificate) (out *x509.Certificate, protoErr *Error) {
 	var (
 		manufacturer, model, version string
 		err                          error
@@ -581,13 +527,13 @@ func tpmParseSANExtension(attestation *x509.Certificate) (protoErr *Error) {
 	for _, ext := range attestation.Extensions {
 		if ext.Id.Equal(oidExtensionSubjectAltName) {
 			if manufacturer, model, version, err = parseSANExtension(ext.Value); err != nil {
-				return ErrInvalidAttestation.WithDetails("Authenticator with invalid Authenticator Identity Key SAN data encountered during attestation validation.").WithInfo(fmt.Sprintf("Error occurred parsing SAN extension: %s", err.Error())).WithError(err)
+				return nil, ErrInvalidAttestation.WithDetails("Authenticator with invalid Authenticator Identity Key SAN data encountered during attestation validation.").WithInfo(fmt.Sprintf("Error occurred parsing SAN extension: %s", err.Error())).WithError(err)
 			}
 		}
 	}
 
 	if manufacturer == "" || model == "" || version == "" {
-		return ErrAttestationFormat.WithDetails("Invalid SAN data in AIK certificate.")
+		return nil, ErrAttestationFormat.WithDetails("Invalid SAN data in AIK certificate.")
 	}
 
 	var unhandled []asn1.ObjectIdentifier
@@ -600,9 +546,11 @@ func tpmParseSANExtension(attestation *x509.Certificate) (protoErr *Error) {
 		unhandled = append(unhandled, uce)
 	}
 
-	attestation.UnhandledCriticalExtensions = unhandled
+	out = new(x509.Certificate)
+	*out = *attestation
+	out.UnhandledCriticalExtensions = unhandled
 
-	return nil
+	return out, nil
 }
 
 type tpmBasicConstraints struct {
@@ -610,12 +558,11 @@ type tpmBasicConstraints struct {
 	MaxPathLen int  `asn1:"optional,default:-1"`
 }
 
-// Remove extension key usage to avoid ExtKeyUsage check failure.
-func tpmRemoveEKU(x5c *x509.Certificate) *Error {
-	var (
-		unknown []asn1.ObjectIdentifier
-		hasAiK  bool
-	)
+// tpmRemoveEKU returns a copy of the certificate with the TCG and Microsoft extension key usages removed to avoid the
+// ExtKeyUsage check failure, and reports whether the certificate carried the AIK extension key usage. The certificate
+// given is never modified as it's owned by the caller.
+func tpmRemoveEKU(x5c *x509.Certificate) (out *x509.Certificate, hasAiK bool) {
+	var unknown []asn1.ObjectIdentifier
 
 	for _, eku := range x5c.UnknownExtKeyUsage {
 		if eku.Equal(oidTCGKpAIKCertificate) {
@@ -631,13 +578,11 @@ func tpmRemoveEKU(x5c *x509.Certificate) *Error {
 		unknown = append(unknown, eku)
 	}
 
-	if !hasAiK {
-		return ErrAttestationFormat.WithDetails("Attestation Identity Key certificate missing required Extended Key Usage.")
-	}
+	out = new(x509.Certificate)
+	*out = *x5c
+	out.UnknownExtKeyUsage = unknown
 
-	x5c.UnknownExtKeyUsage = unknown
-
-	return nil
+	return out, hasAiK
 }
 
 func init() {

--- a/protocol/attestation_tpm_manufacturers.go
+++ b/protocol/attestation_tpm_manufacturers.go
@@ -1,0 +1,65 @@
+package protocol
+
+import (
+	"strings"
+)
+
+// The values below are Table 2 (TPM Capabilities Vendor ID) of the TCG TPM Vendor ID Registry Family 1.2 and 2.0,
+// Version 1.08, July 20, 2026. This is the table which applies as the TPMManufacturer SAN value carries the
+// TPM_PT_MANUFACTURER property, not the 16-bit hardware interface VenID of Table 1.
+//
+// Values in Table 1 with no Table 2 equivalent (i.e. Solidigm), and the simulator and testing values of Table 3, are
+// intentionally excluded as they must not appear in a production attestation.
+//
+// See https://trustedcomputinggroup.org/resource/vendor-id-registry/ for registry contents.
+var (
+	tpmManufacturers = []tpmManufacturer{
+		{"414D4400", "AMD", "AMD"},
+		{"414E5400", "Ant Group", "ANT"},
+		{"41524D00", "Arm", "ARM"},
+		{"41544D4C", "Atmel", "ATML"},
+		{"4252434D", "Broadcom", "BRCM"},
+		{"4353434F", "Cisco", "CSCO"},
+		{"464C5953", "Flyslice Technologies", "FLYS"},
+		{"524F4343", "Fuzhou Rockchip", "ROCC"},
+		{"474F4F47", "Google", "GOOG"},
+		{"48504900", "HPI", "HPI"},
+		{"48504500", "HPE", "HPE"},
+		{"48495349", "Huawei", "HISI"},
+		{"49424D00", "IBM", "IBM"},
+		{"49465800", "Infineon", "IFX"},
+		{"494E5443", "Intel", "INTC"},
+		{"4C454E00", "Lenovo", "LEN"},
+		{"4D534654", "Microsoft", "MSFT"},
+		{"4E534D20", "National Semiconductor", "NSM"},
+		{"4E545A00", "Nationz", "NTZ"},
+		{"4E534700", "NSING", "NSG"},
+		{"4E544300", "Nuvoton Technology", "NTC"},
+		{"51434F4D", "Qualcomm", "QCOM"},
+		{"534D534E", "Samsung", "SMSN"},
+		{"53454345", "SecEdge", "SECE"},
+		{"534E5300", "Sinosun", "SNS"},
+		{"534D5343", "SMSC", "SMSC"},
+		{"53544D20", "STMicroelectronics", "STM"},
+		{"54584E00", "Texas Instruments", "TXN"},
+		{"57454300", "Winbond", "WEC"},
+		{"5345414C", "Wisekey", "SEAL"},
+
+		// The following value is not assigned by the TCG, it's used by the FIDO Alliance conformance tooling.
+		{"FFFFF1D0", "FIDO Alliance Conformance Testing", "FIDO"},
+	}
+)
+
+// isValidTPMManufacturer determines if the given TPM manufacturer id is registered. The comparison is deliberately
+// case-insensitive as the id is the hexadecimal representation of a four byte value rendered as a string by the
+// authenticator, and the case of the hexadecimal digits is not fixed by any specification. The TCG registry itself
+// renders IBM as '0x49 0x42 0x4d 0x00' with a lowercase digit.
+func isValidTPMManufacturer(id string) bool {
+	for _, m := range tpmManufacturers {
+		if strings.EqualFold(m.id, id) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/protocol/attestation_tpm_test.go
+++ b/protocol/attestation_tpm_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -11,10 +12,14 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"math"
+	"math/big"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-tpm/tpm2"
 	"github.com/stretchr/testify/assert"
@@ -180,6 +185,24 @@ func TestIsValidTPMManufacturer(t *testing.T) {
 			id:   "DEADBEEF",
 			want: false,
 		},
+		{
+			// Added to Table 2 of the TCG registry in version 1.08.
+			name: "ShouldReturnTrueForArm",
+			id:   "41524D00",
+			want: true,
+		},
+		{
+			// The TCG registry renders IBM with a lowercase hexadecimal digit and the case of the value rendered by
+			// an authenticator isn't fixed by any specification.
+			name: "ShouldReturnTrueForLowercaseHexadecimal",
+			id:   "49424d00",
+			want: true,
+		},
+		{
+			name: "ShouldReturnTrueForMixedCaseHexadecimal",
+			id:   "414d4400",
+			want: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -187,17 +210,48 @@ func TestIsValidTPMManufacturer(t *testing.T) {
 			assert.Equal(t, tc.want, isValidTPMManufacturer(tc.id))
 		})
 	}
+
+	// The id is the hexadecimal encoding of the four byte value and the code is its ASCII rendering, so the two must
+	// agree for every entry. This catches transcription errors when new vendors are added to the registry. Entries
+	// which aren't an ASCII rendering, such as the FIDO Alliance conformance value, only have their id checked.
+	t.Run("ShouldHaveConsistentEntries", func(t *testing.T) {
+		seen := make(map[string]string, len(tpmManufacturers))
+
+		for _, m := range tpmManufacturers {
+			t.Run(m.name, func(t *testing.T) {
+				require.Len(t, m.id, 8)
+
+				raw, err := hex.DecodeString(m.id)
+				require.NoError(t, err)
+
+				assert.NotContains(t, seen, strings.ToUpper(m.id), "duplicate manufacturer id")
+				seen[strings.ToUpper(m.id)] = m.name
+
+				// A trailing byte is either 0x00 or 0x20 which is the choice of the requestor.
+				ascii := strings.TrimRight(string(raw), "\x00 ")
+
+				if ascii == "" || strings.ContainsFunc(ascii, func(r rune) bool { return r < ' ' || r > '~' }) {
+					return
+				}
+
+				assert.Equal(t, m.code, ascii)
+			})
+		}
+	})
 }
 
 func TestTpmRemoveEKU(t *testing.T) {
-	t.Run("ShouldFailWhenAikEkuMissing", func(t *testing.T) {
+	t.Run("ShouldReportAikEkuMissing", func(t *testing.T) {
 		cert := &x509.Certificate{
 			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
 				{1, 2, 3, 4},
 			},
 		}
 
-		assert.EqualError(t, tpmRemoveEKU(cert), "Attestation Identity Key certificate missing required Extended Key Usage.")
+		out, hasAiK := tpmRemoveEKU(cert)
+
+		assert.False(t, hasAiK)
+		require.Len(t, out.UnknownExtKeyUsage, 1)
 	})
 
 	t.Run("ShouldRemoveAikAndMicrosoftEkuButKeepOtherUnknownEku", func(t *testing.T) {
@@ -211,10 +265,30 @@ func TestTpmRemoveEKU(t *testing.T) {
 			},
 		}
 
-		require.Nil(t, tpmRemoveEKU(cert))
+		out, hasAiK := tpmRemoveEKU(cert)
 
-		require.Len(t, cert.UnknownExtKeyUsage, 1)
-		assert.True(t, cert.UnknownExtKeyUsage[0].Equal(other))
+		assert.True(t, hasAiK)
+
+		require.Len(t, out.UnknownExtKeyUsage, 1)
+		assert.True(t, out.UnknownExtKeyUsage[0].Equal(other))
+	})
+
+	t.Run("ShouldNotModifyTheCertificateGiven", func(t *testing.T) {
+		cert := &x509.Certificate{
+			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
+				oidMicrosoftKpPrivacyCA,
+				oidTCGKpAIKCertificate,
+			},
+		}
+
+		out, hasAiK := tpmRemoveEKU(cert)
+
+		assert.True(t, hasAiK)
+		assert.NotSame(t, cert, out)
+		assert.Empty(t, out.UnknownExtKeyUsage)
+		require.Len(t, cert.UnknownExtKeyUsage, 2)
+		assert.True(t, cert.UnknownExtKeyUsage[0].Equal(oidMicrosoftKpPrivacyCA))
+		assert.True(t, cert.UnknownExtKeyUsage[1].Equal(oidTCGKpAIKCertificate))
 	})
 }
 
@@ -262,9 +336,10 @@ func TestTpmParseSANExtension(t *testing.T) {
 			},
 		}
 
-		protoErr := tpmParseSANExtension(cert)
+		out, protoErr := tpmParseSANExtension(cert)
 		require.EqualError(t, protoErr, "Authenticator with invalid Authenticator Identity Key SAN data encountered during attestation validation.")
 
+		assert.Nil(t, out)
 		assert.Equal(t, ErrInvalidAttestation.Type, protoErr.Type)
 	})
 
@@ -273,7 +348,10 @@ func TestTpmParseSANExtension(t *testing.T) {
 			Extensions: []pkix.Extension{},
 		}
 
-		assert.EqualError(t, tpmParseSANExtension(cert), "Invalid SAN data in AIK certificate.")
+		out, protoErr := tpmParseSANExtension(cert)
+
+		assert.Nil(t, out)
+		assert.EqualError(t, protoErr, "Invalid SAN data in AIK certificate.")
 	})
 
 	t.Run("ShouldRemoveUnhandledCriticalSanExtensionWhenPresent", func(t *testing.T) {
@@ -290,11 +368,13 @@ func TestTpmParseSANExtension(t *testing.T) {
 			},
 		}
 
-		protoErr := tpmParseSANExtension(cert)
+		out, protoErr := tpmParseSANExtension(cert)
 		require.Nil(t, protoErr)
-
-		require.Len(t, cert.UnhandledCriticalExtensions, 1)
-		assert.True(t, cert.UnhandledCriticalExtensions[0].Equal(other))
+		require.Len(t, out.UnhandledCriticalExtensions, 1)
+		assert.True(t, out.UnhandledCriticalExtensions[0].Equal(other))
+		assert.NotSame(t, cert, out)
+		require.Len(t, cert.UnhandledCriticalExtensions, 2)
+		assert.True(t, cert.UnhandledCriticalExtensions[0].Equal(oidExtensionSubjectAltName))
 	})
 }
 
@@ -345,7 +425,7 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 			},
 		}
 
-		err := tpmParseAIKAttCA(leaf, nil)
+		_, _, err := tpmParseAIKAttCA(leaf, nil)
 		require.Error(t, err)
 
 		assert.Equal(t, ErrInvalidAttestation.Type, err.Type)
@@ -353,7 +433,7 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 		assert.Equal(t, "Error occurred parsing SAN extension: asn1: syntax error: data truncated", err.DevInfo)
 	})
 
-	t.Run("ShouldFailWhenParentMissingAikEku", func(t *testing.T) {
+	t.Run("ShouldSucceedWhenParentMissingAikEku", func(t *testing.T) {
 		otherEku := asn1.ObjectIdentifier{1, 2, 3, 4}
 
 		leaf := &x509.Certificate{
@@ -374,11 +454,38 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 			},
 		}
 
-		err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
-		assert.EqualError(t, err, "Attestation Identity Key certificate missing required Extended Key Usage.")
+		outLeaf, outParents, err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
+		require.Nil(t, err)
+
+		require.Len(t, outLeaf.UnknownExtKeyUsage, 1)
+		assert.True(t, outLeaf.UnknownExtKeyUsage[0].Equal(otherEku))
+
+		require.Len(t, outParents, 1)
+		require.Len(t, outParents[0].UnknownExtKeyUsage, 1)
+		assert.True(t, outParents[0].UnknownExtKeyUsage[0].Equal(otherEku))
 	})
 
-	t.Run("ShouldSucceedAndMutateCertificates", func(t *testing.T) {
+	t.Run("ShouldSucceedWhenParentHasNoEkuAtAll", func(t *testing.T) {
+		leaf := &x509.Certificate{
+			Extensions: []pkix.Extension{
+				{Id: oidExtensionSubjectAltName, Value: makeSAN(t, "id:414D4400", "ModelX", "id:00070002")},
+			},
+			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
+				oidTCGKpAIKCertificate,
+			},
+		}
+
+		parent := &x509.Certificate{}
+
+		outLeaf, outParents, err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
+		require.Nil(t, err)
+
+		assert.Empty(t, outLeaf.UnknownExtKeyUsage)
+		require.Len(t, outParents, 1)
+		assert.Empty(t, outParents[0].UnknownExtKeyUsage)
+	})
+
+	t.Run("ShouldSucceedAndNotMutateCertificates", func(t *testing.T) {
 		otherEku := asn1.ObjectIdentifier{1, 2, 3, 4}
 		otherCritical := asn1.ObjectIdentifier{2, 999, 1}
 
@@ -405,17 +512,43 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 			},
 		}
 
-		err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
+		outLeaf, outParents, err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
 		require.Nil(t, err)
 
-		require.Len(t, leaf.UnhandledCriticalExtensions, 1)
-		assert.True(t, leaf.UnhandledCriticalExtensions[0].Equal(otherCritical))
+		require.Len(t, outLeaf.UnhandledCriticalExtensions, 1)
+		assert.True(t, outLeaf.UnhandledCriticalExtensions[0].Equal(otherCritical))
 
-		require.Len(t, leaf.UnknownExtKeyUsage, 1)
-		assert.True(t, leaf.UnknownExtKeyUsage[0].Equal(otherEku))
+		require.Len(t, outLeaf.UnknownExtKeyUsage, 1)
+		assert.True(t, outLeaf.UnknownExtKeyUsage[0].Equal(otherEku))
 
-		require.Len(t, parent.UnknownExtKeyUsage, 1)
-		assert.True(t, parent.UnknownExtKeyUsage[0].Equal(otherEku))
+		require.Len(t, outParents, 1)
+		require.Len(t, outParents[0].UnknownExtKeyUsage, 1)
+		assert.True(t, outParents[0].UnknownExtKeyUsage[0].Equal(otherEku))
+		assert.NotSame(t, leaf, outLeaf)
+		assert.NotSame(t, parent, outParents[0])
+		assert.Len(t, leaf.UnhandledCriticalExtensions, 2)
+		assert.Len(t, leaf.UnknownExtKeyUsage, 3)
+		assert.Len(t, parent.UnknownExtKeyUsage, 3)
+	})
+
+	t.Run("ShouldBeIdempotent", func(t *testing.T) {
+		leaf := &x509.Certificate{
+			Extensions: []pkix.Extension{
+				{Id: oidExtensionSubjectAltName, Value: makeSAN(t, "id:414D4400", "ModelX", "id:00070002")},
+			},
+			UnhandledCriticalExtensions: []asn1.ObjectIdentifier{
+				oidExtensionSubjectAltName,
+			},
+			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
+				oidTCGKpAIKCertificate,
+			},
+		}
+
+		_, _, err := tpmParseAIKAttCA(leaf, nil)
+		require.Nil(t, err)
+
+		_, _, err = tpmParseAIKAttCA(leaf, nil)
+		assert.Nil(t, err)
 	})
 
 	t.Run("ShouldFailWhenLeafMissingAikEku", func(t *testing.T) {
@@ -428,9 +561,104 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 			},
 		}
 
-		err := tpmParseAIKAttCA(leaf, nil)
+		_, _, err := tpmParseAIKAttCA(leaf, nil)
 		assert.EqualError(t, err, "Attestation Identity Key certificate missing required Extended Key Usage.")
 	})
+}
+
+// TestTPMAttestationVerificationBasicConstraints asserts §8.3.1 5/6, i.e. that the Basic Constraints extension has the
+// CA component set to false. An absent extension can't assert that so it must be rejected the same way as one which
+// asserts CA is true.
+func TestTPMAttestationVerificationBasicConstraints(t *testing.T) {
+	testCases := []struct {
+		name string
+		opts tpmAttestationOptions
+		err  string
+	}{
+		{
+			name: "ShouldAcceptWhenBasicConstraintsPresentAndCAIsFalse",
+			opts: tpmAttestationOptions{basicConstraintsValid: true},
+		},
+		{
+			name: "ShouldRejectWhenBasicConstraintsPresentAndCAIsTrue",
+			opts: tpmAttestationOptions{basicConstraintsValid: true, isCA: true},
+			err:  "AIK certificate basic constraints missing or CA is true",
+		},
+		{
+			name: "ShouldRejectWhenBasicConstraintsMissing",
+			opts: tpmAttestationOptions{},
+			err:  "AIK certificate basic constraints missing or CA is true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(makeTPMAttestation(t, tc.opts), nil, nil)
+
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "attca", attestationType)
+			assert.Len(t, x5cs, 1)
+		})
+	}
+}
+
+// TestTPMAttestationVerificationAAGUID asserts the §8.3 step which requires that where the AIK certificate contains an
+// extension with OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) the value of that extension matches the AAGUID in
+// the authenticator data.
+func TestTPMAttestationVerificationAAGUID(t *testing.T) {
+	aaguid := []byte{0x08, 0x98, 0x70, 0x58, 0xca, 0xdc, 0x4b, 0x81, 0xb6, 0xe1, 0x30, 0xde, 0x50, 0xdc, 0xbe, 0x96}
+	other := []byte{0xf8, 0xa0, 0x11, 0xf3, 0x8c, 0x0a, 0x4d, 0x15, 0x80, 0x06, 0x17, 0x11, 0x1f, 0x9e, 0xdc, 0x7d}
+
+	testCases := []struct {
+		name string
+		opts tpmAttestationOptions
+		err  string
+	}{
+		{
+			name: "ShouldAcceptWhenExtensionAbsent",
+			opts: tpmAttestationOptions{basicConstraintsValid: true, authDataAAGUID: aaguid},
+		},
+		{
+			name: "ShouldAcceptWhenExtensionMatchesAuthData",
+			opts: tpmAttestationOptions{basicConstraintsValid: true, certAAGUID: aaguid, authDataAAGUID: aaguid},
+		},
+		{
+			name: "ShouldRejectWhenExtensionDoesNotMatchAuthData",
+			opts: tpmAttestationOptions{basicConstraintsValid: true, certAAGUID: other, authDataAAGUID: aaguid},
+			err:  "Certificate AAGUID does not match Auth Data certificate",
+		},
+		{
+			name: "ShouldRejectWhenExtensionPresentButAuthDataAAGUIDEmpty",
+			opts: tpmAttestationOptions{basicConstraintsValid: true, certAAGUID: aaguid},
+			err:  "Certificate AAGUID does not match Auth Data certificate",
+		},
+		{
+			name: "ShouldAcceptWhenExtensionCriticalAndMatchesAuthData",
+			opts: tpmAttestationOptions{basicConstraintsValid: true, certAAGUID: aaguid, certAAGUIDCritical: true, authDataAAGUID: aaguid},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(makeTPMAttestation(t, tc.opts), nil, nil)
+
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "attca", attestationType)
+			assert.Len(t, x5cs, 1)
+		})
+	}
 }
 
 func TestTpm2Exponent(t *testing.T) {
@@ -456,38 +684,6 @@ func TestTpm2Exponent(t *testing.T) {
 			assert.Equal(t, tc.want, tpm2Exponent(tc.params))
 		})
 	}
-}
-
-func TestTpm2NameDigest(t *testing.T) {
-	t.Run("ShouldRejectNameTooShort", func(t *testing.T) {
-		_, _, err := tpm2NameDigest(tpm2.TPM2BName{Buffer: []byte{0x00, 0x0B}})
-		assert.EqualError(t, err, "name too short")
-	})
-
-	t.Run("ShouldRejectInvalidHashAlgorithm", func(t *testing.T) {
-		buf := []byte{0xFF, 0xFF, 0x01}
-		_, _, err := tpm2NameDigest(tpm2.TPM2BName{Buffer: buf})
-		assert.EqualError(t, err, "invalid hash algorithm: unsupported hash algorithm: 65535")
-	})
-
-	t.Run("ShouldRejectDigestLengthMismatch", func(t *testing.T) {
-		buf := []byte{0x00, 0x0B, 0xAA}
-		_, _, err := tpm2NameDigest(tpm2.TPM2BName{Buffer: buf})
-		assert.EqualError(t, err, "invalid name digest length: 1")
-	})
-
-	t.Run("ShouldReturnAlgAndDigestWhenValid", func(t *testing.T) {
-		digest := make([]byte, sha256.Size)
-		for i := range digest {
-			digest[i] = byte(i)
-		}
-
-		buf := append([]byte{0x00, 0x0B}, digest...)
-		alg, gotDigest, err := tpm2NameDigest(tpm2.TPM2BName{Buffer: buf})
-		require.NoError(t, err)
-		assert.Equal(t, tpm2.TPMAlgSHA256, alg)
-		assert.Equal(t, digest, gotDigest)
-	})
 }
 
 func TestTPM2NameMatch(t *testing.T) {
@@ -1276,4 +1472,122 @@ func mustConvertPEMToPEMBytes(t *testing.T, in string) []byte {
 	require.Len(t, rest, 0)
 
 	return data.Bytes
+}
+
+type tpmAttestationOptions struct {
+	basicConstraintsValid bool
+	isCA                  bool
+	certAAGUID            []byte
+	certAAGUIDCritical    bool
+	authDataAAGUID        []byte
+}
+
+func makeTPMAttestation(t *testing.T, opts tpmAttestationOptions) AttestationObject {
+	t.Helper()
+
+	nameDER, err := asn1.Marshal(pkix.RDNSequence{
+		{
+			{Type: oidTCGAtTpmManufacturer, Value: "id:414D4400"},
+			{Type: oidTCGAtTpmModel, Value: "ModelX"},
+			{Type: oidTCGAtTPMVersion, Value: "id:00070002"},
+		},
+	})
+	require.NoError(t, err)
+
+	sanDER, err := asn1.Marshal([]asn1.RawValue{
+		{
+			Class:      asn1.ClassContextSpecific,
+			Tag:        nameTypeDN,
+			IsCompound: true,
+			Bytes:      nameDER,
+		},
+	})
+	require.NoError(t, err)
+
+	credKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	aikKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	require.LessOrEqual(t, int64(credKey.E), int64(math.MaxUint32))
+
+	exponent := uint32(credKey.E) //nolint:gosec // Bounds checked above.
+
+	public := makeTPMTPublicRSA(&TPMRSATestParameters{Modulus: credKey.N.Bytes(), Exponent: exponent})
+
+	credentialPublicKey, err := webauthncbor.Marshal(webauthncose.RSAPublicKeyData{
+		PublicKeyData: webauthncose.PublicKeyData{
+			KeyType:   int64(webauthncose.RSAKey),
+			Algorithm: int64(webauthncose.AlgRS256),
+		},
+		Modulus:  credKey.N.Bytes(),
+		Exponent: uint32ToBytes(exponent),
+	})
+	require.NoError(t, err)
+
+	att := AttestationObject{
+		AuthData: AuthenticatorData{
+			AttData: AttestedCredentialData{
+				AAGUID:              opts.authDataAAGUID,
+				CredentialPublicKey: credentialPublicKey,
+			},
+		},
+	}
+
+	name, err := tpm2.ObjectName(&public)
+	require.NoError(t, err)
+
+	extraData := sha256.Sum256(att.RawAuthData)
+
+	certInfo := tpm2.Marshal(tpm2.TPMSAttest{
+		Magic: tpm2.TPMGeneratedValue,
+		Type:  tpm2.TPMSTAttestCertify,
+		Attested: tpm2.NewTPMUAttest[*tpm2.TPMSCertifyInfo](tpm2.TPMSTAttestCertify, &tpm2.TPMSCertifyInfo{
+			Name: *name,
+		}),
+		ExtraData: tpm2.TPM2BData{
+			Buffer: extraData[:],
+		},
+	})
+
+	extensions := []pkix.Extension{
+		{Id: oidExtensionSubjectAltName, Critical: true, Value: sanDER},
+	}
+
+	if len(opts.certAAGUID) > 0 {
+		value, err := asn1.Marshal(opts.certAAGUID)
+		require.NoError(t, err)
+
+		extensions = append(extensions, pkix.Extension{Id: oidFIDOGenCeAAGUID, Critical: opts.certAAGUIDCritical, Value: value})
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: opts.basicConstraintsValid,
+		IsCA:                  opts.isCA,
+		UnknownExtKeyUsage:    []asn1.ObjectIdentifier{oidTCGKpAIKCertificate},
+		ExtraExtensions:       extensions,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &aikKey.PublicKey, aikKey)
+	require.NoError(t, err)
+
+	digest := sha256.Sum256(certInfo)
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, aikKey, crypto.SHA256, digest[:])
+	require.NoError(t, err)
+
+	att.AttStatement = map[string]any{
+		stmtVersion:   versionTPM20,
+		stmtAlgorithm: int64(webauthncose.AlgRS256),
+		stmtSignature: sig,
+		stmtCertInfo:  certInfo,
+		stmtPubArea:   tpm2.Marshal(public),
+		stmtX5C:       []any{der},
+	}
+
+	return att
 }

--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -93,7 +93,7 @@ func ValidateMetadata(ctx context.Context, mds metadata.Provider, aaguid uuid.UU
 		}
 
 		if attestationType == string(metadata.AttCA) {
-			if protoErr = tpmParseAIKAttCA(x5c, x5cis); protoErr != nil {
+			if x5c, x5cis, protoErr = tpmParseAIKAttCA(x5c, x5cis); protoErr != nil {
 				return ErrMetadata.WithDetails(protoErr.Details).WithInfo(protoErr.DevInfo).WithError(protoErr)
 			}
 		}

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -47,6 +48,40 @@ func attStatementParseX5CS(attStatement map[string]any, key string) (x5c []any, 
 	}
 
 	return x5c, x5cs, nil
+}
+
+// attestationCertAAGUID extracts the AAGUID from the id-fido-gen-ce-aaguid extension of an attestation certificate. The
+// found return indicates the extension was present, and critical indicates it was marked as critical which some
+// attestation statement formats explicitly forbid.
+//
+// Note that an X.509 Extension encodes the DER-encoding of the value in an OCTET STRING. Thus, the AAGUID is wrapped in
+// two OCTET STRINGS to be valid.
+func attestationCertAAGUID(cert *x509.Certificate) (aaguid []byte, critical, found bool, err error) {
+	var raw []byte
+
+	for _, extension := range cert.Extensions {
+		if !extension.Id.Equal(oidFIDOGenCeAAGUID) {
+			continue
+		}
+
+		found = true
+
+		if extension.Critical {
+			critical = true
+		}
+
+		raw = extension.Value
+	}
+
+	if len(raw) == 0 {
+		return nil, critical, found, nil
+	}
+
+	if _, err = asn1.Unmarshal(raw, &aaguid); err != nil {
+		return nil, critical, found, err
+	}
+
+	return aaguid, critical, found, nil
 }
 
 func parseX5C(x5c []any) (x5cs []*x509.Certificate, err error) {


### PR DESCRIPTION
This fixes a number of missing steps in the TPM attestation process. Specifically, the id-fido-gen-ce-aaguid check in certInfo step, the missing check of basic constraints, and missing manufacturer checks.