### PR TITLE
fix(protocol): safetynet validation steps

### DIFF
--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -39,8 +39,6 @@ import (
 // Specification: §8.5. Android SafetyNet Attestation Statement Format
 //
 // See: https://www.w3.org/TR/webauthn/#sctn-android-safetynet-attestation
-//
-//nolint:gocyclo
 func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (attestationType string, x5cs []any, err error) {
 	// The syntax of an Android Attestation statement is defined as follows:
 	//     $$attStmtType //= (
@@ -76,8 +74,14 @@ func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, c
 
 	var token *jwt.Token
 
-	if token, err = jwt.Parse(string(response), keyFuncSafetyNetJWT, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()})); err != nil {
-		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error finding cert issued to correct hostname: %+v", err)).WithError(err)
+	// §8.5.2 and §8.5.4 Verify that response is a valid SafetyNet response of version ver, and that it actually came
+	// from the SafetyNet service, by following the steps indicated by the SafetyNet online documentation. Those steps
+	// require the certificate chain in the JWS header be validated and the leaf matched to the SafetyNet hostname
+	// before the signature is verified with it, which the verifier below performs as part of supplying the key.
+	verifier := &safetyNetJWTVerifier{}
+
+	if token, err = jwt.Parse(string(response), verifier.keyFunc, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()})); err != nil {
+		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error verifying the SafetyNet response signature: %+v", err)).WithError(err)
 	}
 
 	// marshall the JWT payload into the safetynet response json.
@@ -96,33 +100,8 @@ func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, c
 		return "", nil, ErrInvalidAttestation.WithDetails("Invalid nonce for in SafetyNet response").WithError(err)
 	}
 
-	// §8.5.4 Let attestationCert be the attestation certificate (https://www.w3.org/TR/webauthn/#attestation-certificate)
-	certChain, ok := token.Header[stmtX5C].([]any)
-	if !ok || len(certChain) == 0 {
-		return "", nil, ErrInvalidAttestation.WithDetails("Error getting certificate from JWT header x5c")
-	}
-
-	first, ok := certChain[0].(string)
-	if !ok || first == "" {
-		return "", nil, ErrInvalidAttestation.WithDetails("Error getting first certificate from JWT header x5c")
-	}
-
-	l := make([]byte, base64.StdEncoding.DecodedLen(len(first)))
-
-	n, err := base64.StdEncoding.Decode(l, []byte(first))
-	if err != nil {
-		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error finding cert issued to correct hostname: %+v", err)).WithError(err)
-	}
-
-	attestationCert, err := x509.ParseCertificate(l[:n])
-	if err != nil {
-		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error finding cert issued to correct hostname: %+v", err)).WithError(err)
-	}
-
-	// §8.5.5 Verify that attestationCert is issued to the hostname "attest.android.com".
-	if err = attestationCert.VerifyHostname(attStatementAndroidSafetyNetHostname); err != nil {
-		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error finding cert issued to correct hostname: %+v", err)).WithError(err)
-	}
+	// §8.5.5 Verify that attestationCert is issued to the hostname "attest.android.com". This is performed by the
+	// verifier above as part of the chain validation rather than against a certificate nothing has vouched for.
 
 	// §8.5.6 Verify that the ctsProfileMatch attribute in the payload of response is true.
 	if !safetyNetResponse.CtsProfileMatch {
@@ -144,14 +123,22 @@ func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, c
 	return string(metadata.BasicFull), nil, nil
 }
 
-func keyFuncSafetyNetJWT(token *jwt.Token) (key any, err error) {
+// safetyNetJWTVerifier verifies the certificate chain carried in the JWS x5c header before releasing the leaf public
+// key to the JWT parser, and retains the chain so it can be used as the attestation trust path.
+//
+// The SafetyNet documentation requires the chain be validated and the leaf matched to the SafetyNet hostname before
+// the signature is verified with it. Releasing the leaf public key without doing so allows any self-signed
+// certificate bearing that hostname to sign an entirely forged response.
+type safetyNetJWTVerifier struct {
+	x5c   []any
+	certs []*x509.Certificate
+}
+
+func (v *safetyNetJWTVerifier) keyFunc(token *jwt.Token) (key any, err error) {
 	var (
 		ok    bool
 		raw   any
 		chain []any
-		first string
-		der   []byte
-		cert  *x509.Certificate
 	)
 
 	if raw, ok = token.Header[stmtX5C]; !ok {
@@ -162,23 +149,55 @@ func keyFuncSafetyNetJWT(token *jwt.Token) (key any, err error) {
 		return nil, fmt.Errorf("jwt header x5c is not a non-empty array")
 	}
 
-	if first, ok = chain[0].(string); !ok || first == "" {
-		return nil, fmt.Errorf("jwt header x5c[0] not a base64 string")
-	}
+	certs := make([]*x509.Certificate, len(chain))
 
-	if der, err = base64.StdEncoding.DecodeString(first); err != nil {
-		return nil, fmt.Errorf("decode x5c leaf: %w", err)
-	}
+	for i, element := range chain {
+		var (
+			value string
+			der   []byte
+		)
 
-	if cert, err = x509.ParseCertificate(der); err != nil {
-		if cert != nil {
-			return cert.PublicKey, fmt.Errorf("parse x5c leaf: %w", err)
+		if value, ok = element.(string); !ok || value == "" {
+			return nil, fmt.Errorf("jwt header x5c[%d] is not a base64 string", i)
 		}
 
-		return nil, fmt.Errorf("parse x5c leaf: %w", err)
+		if der, err = base64.StdEncoding.DecodeString(value); err != nil {
+			return nil, fmt.Errorf("decode x5c[%d]: %w", i, err)
+		}
+
+		if certs[i], err = x509.ParseCertificate(der); err != nil {
+			return nil, fmt.Errorf("parse x5c[%d]: %w", i, err)
+		}
 	}
 
-	return cert.PublicKey, nil
+	roots := attStatementAndroidSafetyNetRootsCertPool
+
+	if roots == nil {
+		if roots, err = x509.SystemCertPool(); err != nil {
+			return nil, fmt.Errorf("load system trust store: %w", err)
+		}
+	}
+
+	intermediates := x509.NewCertPool()
+
+	for _, cert := range certs[1:] {
+		intermediates.AddCert(cert)
+	}
+
+	// The leaf is a TLS server certificate so the hostname match of §8.5.5 is performed here as part of the chain
+	// verification, and ExtKeyUsageServerAuth is the applicable usage.
+	if _, err = certs[0].Verify(x509.VerifyOptions{
+		DNSName:       attStatementAndroidSafetyNetHostname,
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		return nil, fmt.Errorf("verify x5c chain: %w", err)
+	}
+
+	v.x5c, v.certs = chain, certs
+
+	return certs[0].PublicKey, nil
 }
 
 type SafetyNetResponse struct {
@@ -190,6 +209,14 @@ type SafetyNetResponse struct {
 	ApkCertificateDigestSha256 []any  `json:"apkCertificateDigestSha256"`
 	BasicIntegrity             bool   `json:"basicIntegrity"`
 }
+
+var (
+	// attStatementAndroidSafetyNetRootsCertPool contains the trust anchors used to verify the certificate chain which
+	// signs a SafetyNet response. A nil pool causes the host system trust store to be used, which is the correct
+	// default as the leaf is an ordinary WebPKI TLS certificate issued to the SafetyNet hostname rather than an
+	// attestation specific root.
+	attStatementAndroidSafetyNetRootsCertPool *x509.CertPool
+)
 
 func init() {
 	RegisterAttestationFormat(AttestationFormatAndroidSafetyNet, attestationFormatValidationHandlerAndroidSafetyNet)

--- a/protocol/attestation_safetynet_test.go
+++ b/protocol/attestation_safetynet_test.go
@@ -53,7 +53,7 @@ func TestSafetyNetFormat_AttStatementErrors(t *testing.T) {
 		{
 			name:         "ShouldFailInvalidJWT",
 			attStatement: map[string]any{stmtVersion: "2.0", "response": []byte("!!!.a.jwt")},
-			err:          "Error finding cert issued to correct hostname: token is malformed: could not base64 decode header: illegal base64 data at input byte 0",
+			err:          "Error verifying the SafetyNet response signature: token is malformed: could not base64 decode header: illegal base64 data at input byte 0",
 		},
 	}
 
@@ -71,8 +71,14 @@ func TestSafetyNetFormat_AttStatementErrors(t *testing.T) {
 }
 
 func TestSafetyNetFormat_JWTValidation(t *testing.T) {
-	key, cert := safetyNetTestGenerateKeyCert(t, "attest.android.com")
-	wrongHostKey, wrongHostCert := safetyNetTestGenerateKeyCert(t, "wrong.example.com")
+	caKey, caCert := safetyNetTestInstallCA(t)
+
+	key, cert := safetyNetTestGenerateKeyCert(t, "attest.android.com", caKey, caCert)
+	wrongHostKey, wrongHostCert := safetyNetTestGenerateKeyCert(t, "wrong.example.com", caKey, caCert)
+
+	// A certificate which asserts the SafetyNet hostname but chains to nothing. Before the response signing chain was
+	// verified this was accepted, allowing an attacker to attest arbitrary authenticator data.
+	forgedKey, forgedCert := safetyNetTestGenerateKeyCert(t, "attest.android.com", nil, nil)
 
 	testCases := []struct {
 		name            string
@@ -147,7 +153,24 @@ func TestSafetyNetFormat_JWTValidation(t *testing.T) {
 			},
 			rawAuthData:    []byte("authdata"),
 			clientDataHash: []byte("clienthash"),
-			err:            `Error finding cert issued to correct hostname: x509: certificate is valid for wrong.example.com, not attest.android.com`,
+			err:            `Error verifying the SafetyNet response signature: token is unverifiable: error while executing keyfunc: verify x5c chain: x509: certificate is valid for wrong.example.com, not attest.android.com`,
+		},
+		{
+			name: "ShouldFailSelfSignedCertificateWithCorrectHostname",
+			buildJWT: func(t *testing.T) []byte {
+				t.Helper()
+
+				nonceHash := sha256.Sum256(append([]byte("authdata"), []byte("clienthash")...))
+
+				return safetyNetTestBuildJWT(t, forgedKey, forgedCert, SafetyNetResponse{
+					Nonce:           base64.StdEncoding.EncodeToString(nonceHash[:]),
+					TimestampMs:     time.Now().UnixMilli(),
+					CtsProfileMatch: true,
+				})
+			},
+			rawAuthData:    []byte("authdata"),
+			clientDataHash: []byte("clienthash"),
+			err:            `Error verifying the SafetyNet response signature: token is unverifiable: error while executing keyfunc: verify x5c chain: x509: certificate signed by unknown authority`,
 		},
 		{
 			name: "ShouldFailOldTimestampWithMDS",
@@ -245,10 +268,11 @@ func TestSafetyNetFormat_JWTValidation(t *testing.T) {
 }
 
 func TestKeyFuncSafetyNetJWT(t *testing.T) {
-	key, cert := safetyNetTestGenerateKeyCert(t, "attest.android.com")
+	caKey, caCert := safetyNetTestInstallCA(t)
 
-	certDER, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
-	require.NoError(t, err)
+	_, certDER := safetyNetTestGenerateKeyCert(t, "attest.android.com", caKey, caCert)
+	_, forgedDER := safetyNetTestGenerateKeyCert(t, "attest.android.com", nil, nil)
+	_, wrongHostDER := safetyNetTestGenerateKeyCert(t, "wrong.example.com", caKey, caCert)
 
 	validB64 := base64.StdEncoding.EncodeToString(certDER)
 
@@ -275,22 +299,39 @@ func TestKeyFuncSafetyNetJWT(t *testing.T) {
 		{
 			name:   "ShouldFailX5CFirstNotString",
 			header: map[string]any{stmtX5C: []any{123}},
-			err:    "jwt header x5c[0] not a base64 string",
+			err:    "jwt header x5c[0] is not a base64 string",
 		},
 		{
 			name:   "ShouldFailX5CFirstEmptyString",
 			header: map[string]any{stmtX5C: []any{""}},
-			err:    "jwt header x5c[0] not a base64 string",
+			err:    "jwt header x5c[0] is not a base64 string",
 		},
 		{
 			name:   "ShouldFailX5CInvalidBase64",
 			header: map[string]any{stmtX5C: []any{"not valid base64!!!"}},
-			err:    "decode x5c leaf: illegal base64 data at input byte 3",
+			err:    "decode x5c[0]: illegal base64 data at input byte 3",
 		},
 		{
 			name:   "ShouldFailX5CInvalidCert",
 			header: map[string]any{stmtX5C: []any{base64.StdEncoding.EncodeToString([]byte("not-a-cert"))}},
-			err:    "parse x5c leaf: x509: malformed certificate",
+			err:    "parse x5c[0]: x509: malformed certificate",
+		},
+		{
+			name:   "ShouldFailX5CIntermediateInvalidCert",
+			header: map[string]any{stmtX5C: []any{validB64, base64.StdEncoding.EncodeToString([]byte("not-a-cert"))}},
+			err:    "parse x5c[1]: x509: malformed certificate",
+		},
+		{
+			// The certificate asserts the SafetyNet hostname but chains to no trust anchor, so the key must not be
+			// released to verify the signature with.
+			name:   "ShouldFailSelfSignedCert",
+			header: map[string]any{stmtX5C: []any{base64.StdEncoding.EncodeToString(forgedDER)}},
+			err:    "verify x5c chain: x509: certificate signed by unknown authority",
+		},
+		{
+			name:   "ShouldFailWrongHostnameCert",
+			header: map[string]any{stmtX5C: []any{base64.StdEncoding.EncodeToString(wrongHostDER)}},
+			err:    "verify x5c chain: x509: certificate is valid for wrong.example.com, not attest.android.com",
 		},
 		{
 			name:   "ShouldSucceedWithValidCert",
@@ -302,17 +343,44 @@ func TestKeyFuncSafetyNetJWT(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			token := &jwt.Token{Header: tc.header}
 
-			result, err := keyFuncSafetyNetJWT(token)
+			verifier := &safetyNetJWTVerifier{}
+
+			result, err := verifier.keyFunc(token)
 
 			if tc.err != "" {
 				assert.Nil(t, result)
+				assert.Nil(t, verifier.x5c)
+				assert.Nil(t, verifier.certs)
 				require.EqualError(t, err, tc.err)
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, result)
+				assert.Len(t, verifier.certs, 1)
 			}
 		})
 	}
+}
+
+// TestKeyFuncSafetyNetJWTSystemRoots asserts that a nil pool falls back to the host trust store rather than trusting
+// anything, as an empty pool and a nil pool must not behave the same way.
+func TestKeyFuncSafetyNetJWTSystemRoots(t *testing.T) {
+	original := attStatementAndroidSafetyNetRootsCertPool
+	attStatementAndroidSafetyNetRootsCertPool = nil
+
+	t.Cleanup(func() {
+		attStatementAndroidSafetyNetRootsCertPool = original
+	})
+
+	_, forgedDER := safetyNetTestGenerateKeyCert(t, "attest.android.com", nil, nil)
+
+	verifier := &safetyNetJWTVerifier{}
+
+	result, err := verifier.keyFunc(&jwt.Token{
+		Header: map[string]any{stmtX5C: []any{base64.StdEncoding.EncodeToString(forgedDER)}},
+	})
+
+	assert.Nil(t, result)
+	require.EqualError(t, err, "verify x5c chain: x509: certificate signed by unknown authority")
 }
 
 func TestSafetyNetFormat_ParseExistingResponse(t *testing.T) {
@@ -331,22 +399,72 @@ func TestSafetyNetFormat_ParseExistingResponse(t *testing.T) {
 
 // Supporting functions and test data.
 
-func safetyNetTestGenerateKeyCert(t *testing.T, hostname string) (*rsa.PrivateKey, *x509.Certificate) {
+// safetyNetTestInstallCA creates a certificate authority for issuing SafetyNet response signing certificates and
+// installs it as the trust anchor for the duration of the test.
+func safetyNetTestInstallCA(t *testing.T) (*rsa.PrivateKey, *x509.Certificate) {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "SafetyNet Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+
+	original := attStatementAndroidSafetyNetRootsCertPool
+	attStatementAndroidSafetyNetRootsCertPool = pool
+
+	t.Cleanup(func() {
+		attStatementAndroidSafetyNetRootsCertPool = original
+	})
+
+	return key, cert
+}
+
+// safetyNetTestGenerateKeyCert issues a SafetyNet response signing certificate for the given hostname from the given
+// certificate authority. A nil caKey produces a self-signed certificate, which is what a forged attestation looks
+// like.
+func safetyNetTestGenerateKeyCert(t *testing.T, hostname string, caKey *rsa.PrivateKey, caCert *x509.Certificate) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
 		Subject:      pkix.Name{CommonName: hostname},
 		DNSNames:     []string{hostname},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
 
-	return key, template
+	parent, signer := caCert, caKey
+
+	if caKey == nil {
+		parent, signer = template, key
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, &key.PublicKey, signer)
+	require.NoError(t, err)
+
+	return key, der
 }
 
 type safetyNetTestMDS struct {
@@ -358,11 +476,8 @@ func (m *safetyNetTestMDS) GetValidateEntry(_ context.Context) bool {
 	return m.validateEntry
 }
 
-func safetyNetTestBuildJWT(t *testing.T, key *rsa.PrivateKey, certTemplate *x509.Certificate, response SafetyNetResponse) []byte {
+func safetyNetTestBuildJWT(t *testing.T, key *rsa.PrivateKey, certDER []byte, response SafetyNetResponse) []byte {
 	t.Helper()
-
-	certDER, err := x509.CreateCertificate(rand.Reader, certTemplate, certTemplate, &key.PublicKey, key)
-	require.NoError(t, err)
 
 	certB64 := base64.StdEncoding.EncodeToString(certDER)
 


### PR DESCRIPTION
This implements the full suite of safetynet validations which were missed in early development of this library. This is unlikely still being used as it's been shut down, but it's worth including it just in case.