### PR TITLE
fix(protocol): androidkey missing authorization list member

### DIFF
--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -122,23 +122,33 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 		return "", nil, ErrAttestationFormat.WithDetails("Attestation challenge not equal to clientDataHash")
 	}
 
+	if protoErr := androidKeyValidateAuthorizationLists(&decoded); protoErr != nil {
+		return "", nil, protoErr
+	}
+
+	return string(metadata.BasicFull), x5c, err
+}
+
+// androidKeyValidateAuthorizationLists performs the §8.4 verification steps which apply to the authorization lists of
+// the Android key attestation certificate extension.
+func androidKeyValidateAuthorizationLists(decoded *keyDescription) *Error {
 	// The AuthorizationList.allApplications field is not present on either authorization list (softwareEnforced nor teeEnforced), since PublicKeyCredential MUST be scoped to the RP ID.
-	if decoded.SoftwareEnforced.AllApplications != nil || decoded.TeeEnforced.AllApplications != nil {
-		return "", nil, ErrAttestationFormat.WithDetails("Attestation certificate extensions contains all applications field")
+	if len(decoded.SoftwareEnforced.AllApplications.FullBytes) != 0 || len(decoded.TeeEnforced.AllApplications.FullBytes) != 0 {
+		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains all applications field")
 	}
 
 	// For the following, use only the teeEnforced authorization list if the RP wants to accept only keys from a trusted execution environment, otherwise use the union of teeEnforced and softwareEnforced.
 	// The value in the AuthorizationList.origin field is equal to KM_ORIGIN_GENERATED (which == 0).
 	if decoded.SoftwareEnforced.Origin != KM_ORIGIN_GENERATED || decoded.TeeEnforced.Origin != KM_ORIGIN_GENERATED {
-		return "", nil, ErrAttestationFormat.WithDetails("Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED")
+		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED")
 	}
 
 	// The value in the AuthorizationList.purpose field is equal to KM_PURPOSE_SIGN (which == 2).
 	if !contains(decoded.SoftwareEnforced.Purpose, KM_PURPOSE_SIGN) && !contains(decoded.TeeEnforced.Purpose, KM_PURPOSE_SIGN) {
-		return "", nil, ErrAttestationFormat.WithDetails("Attestation certificate extensions contains authorization list with purpose not equal KM_PURPOSE_SIGN")
+		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains authorization list with purpose not equal KM_PURPOSE_SIGN")
 	}
 
-	return string(metadata.BasicFull), x5c, err
+	return nil
 }
 
 func contains(s []int, e int) bool {
@@ -163,49 +173,49 @@ type keyDescription struct {
 }
 
 type authorizationList struct {
-	Purpose                     []int       `asn1:"tag:1,explicit,set,optional"`
-	Algorithm                   int         `asn1:"tag:2,explicit,optional"`
-	KeySize                     int         `asn1:"tag:3,explicit,optional"`
-	Digest                      []int       `asn1:"tag:5,explicit,set,optional"`
-	Padding                     []int       `asn1:"tag:6,explicit,set,optional"`
-	EcCurve                     int         `asn1:"tag:10,explicit,optional"`
-	RsaPublicExponent           int         `asn1:"tag:200,explicit,optional"`
-	RollbackResistance          any         `asn1:"tag:303,explicit,optional"`
-	ActiveDateTime              int         `asn1:"tag:400,explicit,optional"`
-	OriginationExpireDateTime   int         `asn1:"tag:401,explicit,optional"`
-	UsageExpireDateTime         int         `asn1:"tag:402,explicit,optional"`
-	NoAuthRequired              any         `asn1:"tag:503,explicit,optional"`
-	UserAuthType                int         `asn1:"tag:504,explicit,optional"`
-	AuthTimeout                 int         `asn1:"tag:505,explicit,optional"`
-	AllowWhileOnBody            any         `asn1:"tag:506,explicit,optional"`
-	TrustedUserPresenceRequired any         `asn1:"tag:507,explicit,optional"`
-	TrustedConfirmationRequired any         `asn1:"tag:508,explicit,optional"`
-	UnlockedDeviceRequired      any         `asn1:"tag:509,explicit,optional"`
-	AllApplications             any         `asn1:"tag:600,explicit,optional"`
-	ApplicationID               any         `asn1:"tag:601,explicit,optional"`
-	CreationDateTime            int         `asn1:"tag:701,explicit,optional"`
-	Origin                      int         `asn1:"tag:702,explicit,optional"`
-	RootOfTrust                 rootOfTrust `asn1:"tag:704,explicit,optional"`
-	OsVersion                   int         `asn1:"tag:705,explicit,optional"`
-	OsPatchLevel                int         `asn1:"tag:706,explicit,optional"`
-	AttestationApplicationID    []byte      `asn1:"tag:709,explicit,optional"`
-	AttestationIDBrand          []byte      `asn1:"tag:710,explicit,optional"`
-	AttestationIDDevice         []byte      `asn1:"tag:711,explicit,optional"`
-	AttestationIDProduct        []byte      `asn1:"tag:712,explicit,optional"`
-	AttestationIDSerial         []byte      `asn1:"tag:713,explicit,optional"`
-	AttestationIDImei           []byte      `asn1:"tag:714,explicit,optional"`
-	AttestationIDMeid           []byte      `asn1:"tag:715,explicit,optional"`
-	AttestationIDManufacturer   []byte      `asn1:"tag:716,explicit,optional"`
-	AttestationIDModel          []byte      `asn1:"tag:717,explicit,optional"`
-	VendorPatchLevel            int         `asn1:"tag:718,explicit,optional"`
-	BootPatchLevel              int         `asn1:"tag:719,explicit,optional"`
+	Purpose                     []int         `asn1:"tag:1,explicit,set,optional"`
+	Algorithm                   int           `asn1:"tag:2,explicit,optional"`
+	KeySize                     int           `asn1:"tag:3,explicit,optional"`
+	Digest                      []int         `asn1:"tag:5,explicit,set,optional"`
+	Padding                     []int         `asn1:"tag:6,explicit,set,optional"`
+	EcCurve                     int           `asn1:"tag:10,explicit,optional"`
+	RsaPublicExponent           int           `asn1:"tag:200,explicit,optional"`
+	RollbackResistance          asn1.RawValue `asn1:"tag:303,explicit,optional"`
+	ActiveDateTime              int           `asn1:"tag:400,explicit,optional"`
+	OriginationExpireDateTime   int           `asn1:"tag:401,explicit,optional"`
+	UsageExpireDateTime         int           `asn1:"tag:402,explicit,optional"`
+	NoAuthRequired              asn1.RawValue `asn1:"tag:503,explicit,optional"`
+	UserAuthType                int           `asn1:"tag:504,explicit,optional"`
+	AuthTimeout                 int           `asn1:"tag:505,explicit,optional"`
+	AllowWhileOnBody            asn1.RawValue `asn1:"tag:506,explicit,optional"`
+	TrustedUserPresenceRequired asn1.RawValue `asn1:"tag:507,explicit,optional"`
+	TrustedConfirmationRequired asn1.RawValue `asn1:"tag:508,explicit,optional"`
+	UnlockedDeviceRequired      asn1.RawValue `asn1:"tag:509,explicit,optional"`
+	AllApplications             asn1.RawValue `asn1:"tag:600,explicit,optional"`
+	ApplicationID               asn1.RawValue `asn1:"tag:601,explicit,optional"`
+	CreationDateTime            int           `asn1:"tag:701,explicit,optional"`
+	Origin                      int           `asn1:"tag:702,explicit,optional"`
+	RootOfTrust                 rootOfTrust   `asn1:"tag:704,explicit,optional"`
+	OsVersion                   int           `asn1:"tag:705,explicit,optional"`
+	OsPatchLevel                int           `asn1:"tag:706,explicit,optional"`
+	AttestationApplicationID    []byte        `asn1:"tag:709,explicit,optional"`
+	AttestationIDBrand          []byte        `asn1:"tag:710,explicit,optional"`
+	AttestationIDDevice         []byte        `asn1:"tag:711,explicit,optional"`
+	AttestationIDProduct        []byte        `asn1:"tag:712,explicit,optional"`
+	AttestationIDSerial         []byte        `asn1:"tag:713,explicit,optional"`
+	AttestationIDImei           []byte        `asn1:"tag:714,explicit,optional"`
+	AttestationIDMeid           []byte        `asn1:"tag:715,explicit,optional"`
+	AttestationIDManufacturer   []byte        `asn1:"tag:716,explicit,optional"`
+	AttestationIDModel          []byte        `asn1:"tag:717,explicit,optional"`
+	VendorPatchLevel            int           `asn1:"tag:718,explicit,optional"`
+	BootPatchLevel              int           `asn1:"tag:719,explicit,optional"`
 }
 
 type rootOfTrust struct {
-	verifiedBootKey   []byte            //nolint:unused
-	deviceLocked      bool              //nolint:unused
-	verifiedBootState verifiedBootState //nolint:unused
-	verifiedBootHash  []byte            //nolint:unused
+	VerifiedBootKey   []byte
+	DeviceLocked      bool
+	VerifiedBootState asn1.Enumerated
+	VerifiedBootHash  []byte `asn1:"optional"`
 }
 
 type verifiedBootState int

--- a/protocol/attestation_androidkey_test.go
+++ b/protocol/attestation_androidkey_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -317,6 +318,118 @@ func TestAndroidKeyFormat_ExtensionValidationErrors(t *testing.T) {
 
 	// Verify the decoded challenge matches the clientDataHash as a sanity check.
 	assert.Equal(t, successClientDataHash[:], decoded.AttestationChallenge)
+}
+
+func TestAndroidKeyAuthorizationListDecoding(t *testing.T) {
+	att := attestationTestUnpackResponse(t, androidKeyTestResponse2["success"]).Response.AttestationObject
+
+	raw, ok := att.AttStatement["x5c"].([]any)
+	require.True(t, ok)
+
+	der, ok := raw[0].([]byte)
+	require.True(t, ok)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	var ext []byte
+
+	for _, e := range cert.Extensions {
+		if e.Id.Equal(oidExtensionAndroidKeystore) {
+			ext = e.Value
+		}
+	}
+
+	require.NotEmpty(t, ext)
+
+	decoded := keyDescription{}
+
+	rest, err := asn1.Unmarshal(ext, &decoded)
+	require.NoError(t, err)
+	assert.Empty(t, rest)
+
+	// The rootOfTrust element was previously consumed by a preceding interface typed field, leaving it zero valued
+	// for every attestation which carried one.
+	assert.Len(t, decoded.TeeEnforced.RootOfTrust.VerifiedBootKey, 32)
+	assert.True(t, decoded.TeeEnforced.RootOfTrust.DeviceLocked)
+	assert.Len(t, decoded.TeeEnforced.RootOfTrust.VerifiedBootHash, 32)
+
+	assert.Equal(t, []int{KM_PURPOSE_SIGN}, decoded.TeeEnforced.Purpose)
+	assert.Equal(t, KM_ORIGIN_GENERATED, decoded.TeeEnforced.Origin)
+
+	assert.Empty(t, decoded.TeeEnforced.AllApplications.FullBytes)
+	assert.Empty(t, decoded.SoftwareEnforced.AllApplications.FullBytes)
+}
+
+func TestAndroidKeyAuthorizationListAllApplicationsDER(t *testing.T) {
+	// SEQUENCE { [1] EXPLICIT SET { INTEGER 2 }, [702] EXPLICIT INTEGER 0 }
+	// purpose = KM_PURPOSE_SIGN, origin = KM_ORIGIN_GENERATED.
+	withoutAllApplications, err := hex.DecodeString("300e" + "a1053103020102" + "bf853e03020100")
+	require.NoError(t, err)
+
+	// The same list with [600] EXPLICIT { NULL } spliced in, which is the allApplications tag.
+	withAllApplications, err := hex.DecodeString("3014" + "a1053103020102" + "bf8458020500" + "bf853e03020100")
+	require.NoError(t, err)
+
+	var absent authorizationList
+
+	rest, err := asn1.Unmarshal(withoutAllApplications, &absent)
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	var present authorizationList
+
+	rest, err = asn1.Unmarshal(withAllApplications, &present)
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	// Both lists must otherwise be identical, so a failure below is attributable to allApplications alone.
+	require.Equal(t, []int{KM_PURPOSE_SIGN}, absent.Purpose)
+	require.Equal(t, []int{KM_PURPOSE_SIGN}, present.Purpose)
+	require.Equal(t, KM_ORIGIN_GENERATED, absent.Origin)
+	require.Equal(t, KM_ORIGIN_GENERATED, present.Origin)
+
+	assert.Empty(t, absent.AllApplications.FullBytes)
+	assert.NotEmpty(t, present.AllApplications.FullBytes, "allApplications must be detectable in the decoded list")
+
+	testCases := []struct {
+		name    string
+		decoded keyDescription
+		err     string
+	}{
+		{
+			name:    "ShouldAcceptWhenAbsentFromBothLists",
+			decoded: keyDescription{SoftwareEnforced: absent, TeeEnforced: absent},
+		},
+		{
+			name:    "ShouldRejectWhenPresentInSoftwareEnforced",
+			decoded: keyDescription{SoftwareEnforced: present, TeeEnforced: absent},
+			err:     "Attestation certificate extensions contains all applications field",
+		},
+		{
+			name:    "ShouldRejectWhenPresentInTeeEnforced",
+			decoded: keyDescription{SoftwareEnforced: absent, TeeEnforced: present},
+			err:     "Attestation certificate extensions contains all applications field",
+		},
+		{
+			name:    "ShouldRejectWhenPresentInBothLists",
+			decoded: keyDescription{SoftwareEnforced: present, TeeEnforced: present},
+			err:     "Attestation certificate extensions contains all applications field",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			protoErr := androidKeyValidateAuthorizationLists(&tc.decoded)
+
+			if tc.err != "" {
+				require.NotNil(t, protoErr)
+				assert.EqualError(t, protoErr, tc.err)
+			} else {
+				assert.Nil(t, protoErr)
+			}
+		})
+	}
 }
 
 var androidKeyTestResponse0 = map[string]string{

--- a/protocol/authenticator_oob_test.go
+++ b/protocol/authenticator_oob_test.go
@@ -57,10 +57,10 @@ func TestAuthenticatorData_Unmarshal_TrailingBytesRejected(t *testing.T) {
 func buildAuthData(flags byte, credentialID, rawPublicKey []byte) []byte {
 	data := make([]byte, 0, 55+len(credentialID)+len(rawPublicKey))
 
-	data = append(data, make([]byte, 32)...)    // RPIDHash.
-	data = append(data, flags)                  // Flags.
-	data = append(data, 0x00, 0x00, 0x00, 0x01) // Counter.
-	data = append(data, make([]byte, 16)...)    // AAGUID.
+	data = append(data, make([]byte, 32)...)                                 // RPIDHash.
+	data = append(data, flags)                                               // Flags.
+	data = append(data, 0x00, 0x00, 0x00, 0x01)                              // Counter.
+	data = append(data, make([]byte, 16)...)                                 // AAGUID.
 	data = append(data, byte(len(credentialID)>>8), byte(len(credentialID))) //nolint:gosec // Test data is bounded.
 	data = append(data, credentialID...)
 	data = append(data, rawPublicKey...)


### PR DESCRIPTION
This fixes a missing member of the authorization list parsing and fixes a potential false error using asn1.RawValue in place of any. This should also allow implementation of the TEE-only policy in the future.