### PR TITLE
refactor(protocol): cleanup

### DIFF
--- a/metadata/decode.go
+++ b/metadata/decode.go
@@ -278,7 +278,7 @@ func validateChain(root string, chain []any) (bool, error) {
 	opts := x509.VerifyOptions{
 		Roots:         roots,
 		Intermediates: ints,
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 
 	_, err = leafcert.Verify(opts)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -437,7 +437,7 @@ func (s *Statement) Verifier(x5cis []*x509.Certificate) (opts x509.VerifyOptions
 	return x509.VerifyOptions{
 		Roots:         roots,
 		Intermediates: intermediates,
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 }
 

--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/asn1"
+	"errors"
 	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-webauthn/webauthn/metadata"
@@ -111,10 +115,22 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 		return "", nil, ErrAttestationFormat.WithDetails("Attestation certificate extensions missing 1.3.6.1.4.1.11129.2.1.17")
 	}
 
-	decoded := keyDescription{}
+	decoded := androidkeyDescription{}
 
 	if _, err = asn1.Unmarshal(attExtBytes, &decoded); err != nil {
 		return "", nil, ErrAttestationFormat.WithDetails("Unable to parse Android key attestation certificate extensions").WithError(err)
+	}
+
+	// The decode above silently abandons the remaining fields of an authorization list on meeting an element it can't
+	// model, so the elements actually present are checked against the raw extension before any of it is relied upon.
+	raw := androidkeyDescriptionRaw{}
+
+	if _, err = asn1.Unmarshal(attExtBytes, &raw); err != nil {
+		return "", nil, ErrAttestationFormat.WithDetails("Unable to parse Android key attestation certificate extensions").WithError(err)
+	}
+
+	if protoErr := androidKeyVerifyAuthorizationListTags(&raw); protoErr != nil {
+		return "", nil, protoErr
 	}
 
 	// Verify that the attestationChallenge field in the attestation certificate extension data is identical to clientDataHash.
@@ -131,7 +147,7 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 
 // androidKeyValidateAuthorizationLists performs the §8.4 verification steps which apply to the authorization lists of
 // the Android key attestation certificate extension.
-func androidKeyValidateAuthorizationLists(decoded *keyDescription) *Error {
+func androidKeyValidateAuthorizationLists(decoded *androidkeyDescription) *Error {
 	// The AuthorizationList.allApplications field is not present on either authorization list (softwareEnforced nor teeEnforced), since PublicKeyCredential MUST be scoped to the RP ID.
 	if len(decoded.SoftwareEnforced.AllApplications.FullBytes) != 0 || len(decoded.TeeEnforced.AllApplications.FullBytes) != 0 {
 		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains all applications field")
@@ -172,7 +188,7 @@ func androidKeyValidateAuthorizationLists(decoded *keyDescription) *Error {
 // authorizationListOrigin returns the origin of an authorization list and reports whether the field was present. The
 // value is decoded from the raw element because encoding/asn1 leaves an absent optional integer at its zero value,
 // which is indistinguishable from a present origin of KM_ORIGIN_GENERATED.
-func authorizationListOrigin(list *authorizationList) (origin int, present bool, err error) {
+func authorizationListOrigin(list *androidkeyAuthorizationList) (origin int, present bool, err error) {
 	// An explicit tag which is present always carries a child as encoding/asn1 rejects one which doesn't while
 	// decoding the key description, so an empty raw value means the field was absent rather than empty.
 	if len(list.Origin.FullBytes) == 0 {
@@ -202,111 +218,108 @@ func contains(s []int, e int) bool {
 	return false
 }
 
-type keyDescription struct {
-	AttestationVersion       int
-	AttestationSecurityLevel asn1.Enumerated
-	KeymasterVersion         int
-	KeymasterSecurityLevel   asn1.Enumerated
-	AttestationChallenge     []byte
-	UniqueID                 []byte
-	SoftwareEnforced         authorizationList
-	TeeEnforced              authorizationList
+// authorizationListTags contains every context specific tag number modelled by [authorizationList]. It's derived from
+// the struct definition so that declaring a field is the only step needed to support a tag, and the two can't drift.
+var authorizationListTags = func() (tags map[int]bool) {
+	t := reflect.TypeOf(androidkeyAuthorizationList{})
+
+	tags = make(map[int]bool, t.NumField())
+
+	for i := range t.NumField() {
+		field := t.Field(i)
+
+		for _, option := range strings.Split(field.Tag.Get("asn1"), ",") {
+			if !strings.HasPrefix(option, "tag:") {
+				continue
+			}
+
+			tag, err := strconv.Atoi(strings.TrimPrefix(option, "tag:"))
+			if err != nil {
+				panic(fmt.Sprintf("protocol: authorizationList field %s has a malformed asn1 tag: %v", field.Name, err))
+			}
+
+			tags[tag] = true
+		}
+	}
+
+	return tags
+}()
+
+// authorizationListValidatedTags contains the tags of the authorization list fields which the §8.4 verification steps
+// consult. An element the struct can't model only matters when it displaces one of these.
+var authorizationListValidatedTags = []int{
+	1,   // purpose.
+	600, // allApplications.
+	702, // origin.
 }
 
-type authorizationList struct {
-	Purpose                     []int         `asn1:"tag:1,explicit,set,optional"`
-	Algorithm                   int           `asn1:"tag:2,explicit,optional"`
-	KeySize                     int           `asn1:"tag:3,explicit,optional"`
-	Digest                      []int         `asn1:"tag:5,explicit,set,optional"`
-	Padding                     []int         `asn1:"tag:6,explicit,set,optional"`
-	EcCurve                     int           `asn1:"tag:10,explicit,optional"`
-	RsaPublicExponent           int           `asn1:"tag:200,explicit,optional"`
-	RollbackResistance          asn1.RawValue `asn1:"tag:303,explicit,optional"`
-	ActiveDateTime              int           `asn1:"tag:400,explicit,optional"`
-	OriginationExpireDateTime   int           `asn1:"tag:401,explicit,optional"`
-	UsageExpireDateTime         int           `asn1:"tag:402,explicit,optional"`
-	NoAuthRequired              asn1.RawValue `asn1:"tag:503,explicit,optional"`
-	UserAuthType                int           `asn1:"tag:504,explicit,optional"`
-	AuthTimeout                 int           `asn1:"tag:505,explicit,optional"`
-	AllowWhileOnBody            asn1.RawValue `asn1:"tag:506,explicit,optional"`
-	TrustedUserPresenceRequired asn1.RawValue `asn1:"tag:507,explicit,optional"`
-	TrustedConfirmationRequired asn1.RawValue `asn1:"tag:508,explicit,optional"`
-	UnlockedDeviceRequired      asn1.RawValue `asn1:"tag:509,explicit,optional"`
-	AllApplications             asn1.RawValue `asn1:"tag:600,explicit,optional"`
-	ApplicationID               asn1.RawValue `asn1:"tag:601,explicit,optional"`
-	CreationDateTime            int           `asn1:"tag:701,explicit,optional"`
-	// Origin is decoded as a raw element rather than an integer. encoding/asn1 leaves an absent optional integer at
-	// its zero value, which is indistinguishable from a present origin of KM_ORIGIN_GENERATED.
-	Origin asn1.RawValue `asn1:"tag:702,explicit,optional"`
+// androidKeyVerifyAuthorizationListTags rejects an attestation whose authorization lists carry an element that
+// [authorizationList] can't model and which precedes a field the verification procedure depends on.
+//
+// An unmodelled tag otherwise defeats the §8.4 requirement that allApplications is absent, as the element is dropped
+// along with every field declared after it while the union permits the other list to supply the origin and purpose. A
+// list which can't be modelled in full is rejected explicitly rather than silently truncated.
+func androidKeyVerifyAuthorizationListTags(raw *androidkeyDescriptionRaw) *Error {
+	for _, list := range []struct {
+		name string
+		raw  asn1.RawValue
+	}{
+		{"teeEnforced", raw.TeeEnforced},
+		{"softwareEnforced", raw.SoftwareEnforced},
+	} {
+		if err := authorizationListVerifyTags(list.raw); err != nil {
+			return ErrAttestationFormat.WithDetails(fmt.Sprintf("Unable to validate the %s authorization list", list.name)).WithInfo(err.Error()).WithError(err)
+		}
+	}
 
-	RootOfTrust rootOfTrust `asn1:"tag:704,explicit,optional"`
-
-	OsVersion                 int    `asn1:"tag:705,explicit,optional"`
-	OsPatchLevel              int    `asn1:"tag:706,explicit,optional"`
-	AttestationApplicationID  []byte `asn1:"tag:709,explicit,optional"`
-	AttestationIDBrand        []byte `asn1:"tag:710,explicit,optional"`
-	AttestationIDDevice       []byte `asn1:"tag:711,explicit,optional"`
-	AttestationIDProduct      []byte `asn1:"tag:712,explicit,optional"`
-	AttestationIDSerial       []byte `asn1:"tag:713,explicit,optional"`
-	AttestationIDImei         []byte `asn1:"tag:714,explicit,optional"`
-	AttestationIDMeid         []byte `asn1:"tag:715,explicit,optional"`
-	AttestationIDManufacturer []byte `asn1:"tag:716,explicit,optional"`
-	AttestationIDModel        []byte `asn1:"tag:717,explicit,optional"`
-	VendorPatchLevel          int    `asn1:"tag:718,explicit,optional"`
-	BootPatchLevel            int    `asn1:"tag:719,explicit,optional"`
+	return nil
 }
 
-type rootOfTrust struct {
-	VerifiedBootKey   []byte
-	DeviceLocked      bool
-	VerifiedBootState asn1.Enumerated
-	VerifiedBootHash  []byte `asn1:"optional"`
+// authorizationListVerifyTags reports an error when an element of the raw authorization list isn't modelled by
+// [authorizationList] and is positioned before an element the verification procedure consults. Anything after the last
+// consulted element can't influence the outcome as decoding reached them all, which keeps a tag appended to a later
+// revision of the schema from rejecting an otherwise sound attestation.
+func authorizationListVerifyTags(raw asn1.RawValue) (err error) {
+	if raw.Class != asn1.ClassUniversal || raw.Tag != asn1.TagSequence || !raw.IsCompound {
+		return errors.New("authorization list is not a sequence")
+	}
+
+	var tags []int
+
+	rest := raw.Bytes
+
+	for len(rest) > 0 {
+		var element asn1.RawValue
+
+		if rest, err = asn1.Unmarshal(rest, &element); err != nil {
+			return err
+		}
+
+		if element.Class != asn1.ClassContextSpecific {
+			return fmt.Errorf("element %d has class %d where a context specific class was expected", len(tags), element.Class)
+		}
+
+		tags = append(tags, element.Tag)
+	}
+
+	last := -1
+
+	for i, tag := range tags {
+		if contains(authorizationListValidatedTags, tag) {
+			last = i
+		}
+	}
+
+	for i, tag := range tags[:last+1] {
+		if authorizationListTags[tag] {
+			continue
+		}
+
+		return fmt.Errorf("element %d has tag [%d] which is not supported and precedes a field required by the verification procedure", i, tag)
+	}
+
+	return nil
 }
-
-type verifiedBootState int
-
-const (
-	Verified verifiedBootState = iota
-	SelfSigned
-	Unverified
-	Failed
-)
-
-const (
-	// KM_ORIGIN_GENERATED means generated in keymaster. Should not exist outside the TEE.
-	KM_ORIGIN_GENERATED = iota
-
-	// KM_ORIGIN_DERIVED means derived inside keymaster. Likely exists off-device.
-	KM_ORIGIN_DERIVED
-
-	// KM_ORIGIN_IMPORTED means imported into keymaster. Existed as clear text in Android.
-	KM_ORIGIN_IMPORTED
-
-	// KM_ORIGIN_UNKNOWN means keymaster did not record origin.  This value can only be seen on keys in a keymaster0
-	// implementation. The keymaster0 adapter uses this value to document the fact that it is unknown whether the key
-	// was generated inside or imported into keymaster.
-	KM_ORIGIN_UNKNOWN
-)
-
-const (
-	// KM_PURPOSE_ENCRYPT is usable with RSA, EC and AES keys.
-	KM_PURPOSE_ENCRYPT = iota
-
-	// KM_PURPOSE_DECRYPT is usable with RSA, EC and AES keys.
-	KM_PURPOSE_DECRYPT
-
-	// KM_PURPOSE_SIGN is usable with RSA, EC and HMAC keys.
-	KM_PURPOSE_SIGN
-
-	// KM_PURPOSE_VERIFY is usable with RSA, EC and HMAC keys.
-	KM_PURPOSE_VERIFY
-
-	// KM_PURPOSE_DERIVE_KEY is usable with EC keys.
-	KM_PURPOSE_DERIVE_KEY
-
-	// KM_PURPOSE_WRAP is usable with wrapped keys.
-	KM_PURPOSE_WRAP
-)
 
 var (
 	attAndroidKeyHardwareRootsCertPool *x509.CertPool

--- a/protocol/attestation_androidkey_test.go
+++ b/protocol/attestation_androidkey_test.go
@@ -313,7 +313,7 @@ func TestAndroidKeyFormat_ExtensionValidationErrors(t *testing.T) {
 	require.NotEmpty(t, keystoreExtBytes)
 
 	// Decode the keystore extension to verify it's valid.
-	decoded := keyDescription{}
+	decoded := androidkeyDescription{}
 	_, err = asn1.Unmarshal(keystoreExtBytes, &decoded)
 	require.NoError(t, err)
 
@@ -343,7 +343,7 @@ func TestAndroidKeyAuthorizationListDecoding(t *testing.T) {
 
 	require.NotEmpty(t, ext)
 
-	decoded := keyDescription{}
+	decoded := androidkeyDescription{}
 
 	rest, err := asn1.Unmarshal(ext, &decoded)
 	require.NoError(t, err)
@@ -377,7 +377,7 @@ func TestAndroidKeyAuthorizationListDecoding(t *testing.T) {
 // optional integer decodes to zero when absent, which is the value of KM_ORIGIN_GENERATED.
 func TestAndroidKeyAuthorizationListOrigin(t *testing.T) {
 	// SEQUENCE { [1] EXPLICIT SET { INTEGER 2 } [, [702] EXPLICIT INTEGER n] } where the purpose is KM_PURPOSE_SIGN.
-	list := func(t *testing.T, origin string) authorizationList {
+	list := func(t *testing.T, origin string) androidkeyAuthorizationList {
 		t.Helper()
 
 		body := "a1053103020102"
@@ -389,7 +389,7 @@ func TestAndroidKeyAuthorizationListOrigin(t *testing.T) {
 		der, err := hex.DecodeString(fmt.Sprintf("30%02x", len(body)/2) + body)
 		require.NoError(t, err)
 
-		var decoded authorizationList
+		var decoded androidkeyAuthorizationList
 
 		rest, err := asn1.Unmarshal(der, &decoded)
 		require.NoError(t, err)
@@ -404,8 +404,8 @@ func TestAndroidKeyAuthorizationListOrigin(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		tee      authorizationList
-		software authorizationList
+		tee      androidkeyAuthorizationList
+		software androidkeyAuthorizationList
 		err      string
 	}{
 		{
@@ -446,7 +446,7 @@ func TestAndroidKeyAuthorizationListOrigin(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			decoded := keyDescription{TeeEnforced: tc.tee, SoftwareEnforced: tc.software}
+			decoded := androidkeyDescription{TeeEnforced: tc.tee, SoftwareEnforced: tc.software}
 
 			protoErr := androidKeyValidateAuthorizationLists(&decoded)
 
@@ -473,7 +473,7 @@ func TestAuthorizationListOriginDER(t *testing.T) {
 	}
 
 	t.Run("ShouldRejectPresentButEmptyOriginWhileDecoding", func(t *testing.T) {
-		var list authorizationList
+		var list androidkeyAuthorizationList
 
 		_, err := asn1.Unmarshal(sequence(t, purpose+"bf853e00"), &list)
 		require.EqualError(t, err, "asn1: structure error: explicit tag has no child")
@@ -519,7 +519,7 @@ func TestAuthorizationListOriginDER(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var list authorizationList
+			var list androidkeyAuthorizationList
 
 			rest, err := asn1.Unmarshal(sequence(t, purpose+tc.origin), &list)
 			require.NoError(t, err)
@@ -552,13 +552,13 @@ func TestAndroidKeyAuthorizationListAllApplicationsDER(t *testing.T) {
 	withAllApplications, err := hex.DecodeString("3014" + "a1053103020102" + "bf8458020500" + "bf853e03020100")
 	require.NoError(t, err)
 
-	var absent authorizationList
+	var absent androidkeyAuthorizationList
 
 	rest, err := asn1.Unmarshal(withoutAllApplications, &absent)
 	require.NoError(t, err)
 	require.Empty(t, rest)
 
-	var present authorizationList
+	var present androidkeyAuthorizationList
 
 	rest, err = asn1.Unmarshal(withAllApplications, &present)
 	require.NoError(t, err)
@@ -568,7 +568,7 @@ func TestAndroidKeyAuthorizationListAllApplicationsDER(t *testing.T) {
 	require.Equal(t, []int{KM_PURPOSE_SIGN}, absent.Purpose)
 	require.Equal(t, []int{KM_PURPOSE_SIGN}, present.Purpose)
 
-	for _, list := range []*authorizationList{&absent, &present} {
+	for _, list := range []*androidkeyAuthorizationList{&absent, &present} {
 		origin, ok, err := authorizationListOrigin(list)
 		require.NoError(t, err)
 		require.True(t, ok)
@@ -580,26 +580,26 @@ func TestAndroidKeyAuthorizationListAllApplicationsDER(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		decoded keyDescription
+		decoded androidkeyDescription
 		err     string
 	}{
 		{
 			name:    "ShouldAcceptWhenAbsentFromBothLists",
-			decoded: keyDescription{SoftwareEnforced: absent, TeeEnforced: absent},
+			decoded: androidkeyDescription{SoftwareEnforced: absent, TeeEnforced: absent},
 		},
 		{
 			name:    "ShouldRejectWhenPresentInSoftwareEnforced",
-			decoded: keyDescription{SoftwareEnforced: present, TeeEnforced: absent},
+			decoded: androidkeyDescription{SoftwareEnforced: present, TeeEnforced: absent},
 			err:     "Attestation certificate extensions contains all applications field",
 		},
 		{
 			name:    "ShouldRejectWhenPresentInTeeEnforced",
-			decoded: keyDescription{SoftwareEnforced: absent, TeeEnforced: present},
+			decoded: androidkeyDescription{SoftwareEnforced: absent, TeeEnforced: present},
 			err:     "Attestation certificate extensions contains all applications field",
 		},
 		{
 			name:    "ShouldRejectWhenPresentInBothLists",
-			decoded: keyDescription{SoftwareEnforced: present, TeeEnforced: present},
+			decoded: androidkeyDescription{SoftwareEnforced: present, TeeEnforced: present},
 			err:     "Attestation certificate extensions contains all applications field",
 		},
 	}
@@ -616,6 +616,220 @@ func TestAndroidKeyAuthorizationListAllApplicationsDER(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAuthorizationListTags asserts every tag of the Keymaster/KeyMint schema is modelled by authorizationList. A tag
+// which isn't modelled displaces the fields declared after it during decoding.
+//
+// See: https://source.android.com/docs/security/features/keystore/attestation
+func TestAuthorizationListTags(t *testing.T) {
+	schema := []int{
+		1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 200, 203, 303, 305, 400, 401, 402, 405, 502, 503, 504, 505, 506, 507, 508,
+		509, 600, 601, 701, 702, 704, 705, 706, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 723, 724,
+	}
+
+	for _, tag := range schema {
+		assert.True(t, authorizationListTags[tag], "tag [%d] of the Android schema is not modelled by authorizationList", tag)
+	}
+
+	assert.Len(t, authorizationListTags, len(schema), "authorizationList models a tag which is not in the Android schema")
+
+	for _, tag := range authorizationListValidatedTags {
+		assert.True(t, authorizationListTags[tag], "validated tag [%d] is not modelled by authorizationList", tag)
+	}
+}
+
+// TestAndroidKeyAuthorizationListUnsupportedTagBypass asserts an authorization list can't conceal the allApplications
+// field behind a tag which isn't modelled.
+//
+// §8.4 requires allApplications is absent from both lists. encoding/asn1 abandons the fields declared after an element
+// it can't match, so an unmodelled tag placed ahead of allApplications drops it from the decoded list, and the union
+// permits the other list to supply the origin and purpose.
+func TestAndroidKeyAuthorizationListUnsupportedTagBypass(t *testing.T) {
+	tee := androidKeyDERPurpose + androidKeyDERUnsupportedLow + androidKeyDERAllApplications + androidKeyDEROrigin
+	software := androidKeyDERPurpose + androidKeyDEROrigin
+
+	der := androidKeyDERKeyDescription(t, software, tee)
+
+	var decoded androidkeyDescription
+
+	rest, err := asn1.Unmarshal(der, &decoded)
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	// The decode reports no error yet allApplications, which is present in the encoding, is absent from the result.
+	// The §8.4 checks alone therefore accept the attestation.
+	require.Empty(t, decoded.TeeEnforced.AllApplications.FullBytes)
+	require.Nil(t, androidKeyValidateAuthorizationLists(&decoded))
+
+	// Verifying the tags actually present against the raw extension is what rejects it.
+	var raw androidkeyDescriptionRaw
+
+	rest, err = asn1.Unmarshal(der, &raw)
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	protoErr := androidKeyVerifyAuthorizationListTags(&raw)
+	require.NotNil(t, protoErr)
+	assert.EqualError(t, protoErr, "Unable to validate the teeEnforced authorization list")
+	assert.Equal(t, androidKeyErrUnsupportedLow, protoErr.DevInfo)
+}
+
+// TestAndroidKeyAuthorizationListSchemaTagsDecode asserts a tag which is part of the schema doesn't displace the
+// fields declared after it. A device emitting earlyBootOnly [305] must still have its origin decoded, as an origin
+// read as absent rejects an otherwise sound attestation.
+func TestAndroidKeyAuthorizationListSchemaTagsDecode(t *testing.T) {
+	der, err := hex.DecodeString(androidKeyDERSequence(t, androidKeyDERPurpose+androidKeyDEREarlyBootOnly+androidKeyDEROrigin))
+	require.NoError(t, err)
+
+	var list androidkeyAuthorizationList
+
+	rest, err := asn1.Unmarshal(der, &list)
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	assert.NotEmpty(t, list.EarlyBootOnly.FullBytes)
+	assert.Equal(t, []int{KM_PURPOSE_SIGN}, list.Purpose)
+
+	origin, present, err := authorizationListOrigin(&list)
+	require.NoError(t, err)
+	assert.True(t, present)
+	assert.Equal(t, KM_ORIGIN_GENERATED, origin)
+}
+
+func TestAuthorizationListVerifyTags(t *testing.T) {
+	testCases := []struct {
+		name string
+		body string
+		err  string
+	}{
+		{
+			name: "ShouldAcceptListOfSupportedTags",
+			body: androidKeyDERPurpose + androidKeyDEROrigin,
+		},
+		{
+			name: "ShouldAcceptSchemaTagWhichIsModelled",
+			body: androidKeyDERPurpose + androidKeyDEREarlyBootOnly + androidKeyDEROrigin,
+		},
+		{
+			// A tag appended by a later revision of the schema sits after every field the procedure consults, so
+			// decoding reached them all and the attestation must not be rejected.
+			name: "ShouldAcceptUnsupportedTagAfterLastValidatedField",
+			body: androidKeyDERPurpose + androidKeyDEROrigin + androidKeyDERUnsupportedHigh,
+		},
+		{
+			name: "ShouldRejectUnsupportedTagBeforeOrigin",
+			body: androidKeyDERPurpose + androidKeyDERUnsupportedLow + androidKeyDEROrigin,
+			err:  androidKeyErrUnsupportedLow,
+		},
+		{
+			name: "ShouldRejectUnsupportedTagBeforeAllApplications",
+			body: androidKeyDERPurpose + androidKeyDERUnsupportedLow + androidKeyDERAllApplications,
+			err:  androidKeyErrUnsupportedLow,
+		},
+		{
+			// The high tag is only tolerated because it follows the fields consulted. Ahead of them it's rejected,
+			// which matters as nothing requires the elements to be ordered by tag.
+			name: "ShouldRejectUnsupportedHighTagBeforeOrigin",
+			body: androidKeyDERPurpose + androidKeyDERUnsupportedHigh + androidKeyDEROrigin,
+			err:  "element 1 has tag [725] which is not supported and precedes a field required by the verification procedure",
+		},
+		{
+			name: "ShouldRejectNonContextSpecificElement",
+			body: androidKeyDERPurpose + "0500" + androidKeyDEROrigin,
+			err:  "element 1 has class 0 where a context specific class was expected",
+		},
+		{
+			// No field the procedure consults is present, so nothing was displaced. The origin check rejects it.
+			name: "ShouldAcceptUnsupportedTagWhenNoValidatedFieldFollows",
+			body: androidKeyDERUnsupportedLow,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := authorizationListVerifyTags(androidKeyDERRawList(t, tc.body))
+
+			if tc.err != "" {
+				require.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("ShouldRejectWhenNotASequence", func(t *testing.T) {
+		der, err := hex.DecodeString("0500")
+		require.NoError(t, err)
+
+		var raw asn1.RawValue
+
+		_, err = asn1.Unmarshal(der, &raw)
+		require.NoError(t, err)
+
+		assert.EqualError(t, authorizationListVerifyTags(raw), "authorization list is not a sequence")
+	})
+}
+
+// Supporting functions and test data.
+
+// Authorization list elements in DER. The tag bytes use the high tag number form, so [600] encodes as bf 84 58 where
+// 600 = 4*128 + 88, and so on.
+const (
+	androidKeyDERPurpose         = "a1053103020102" // [1] EXPLICIT SET { INTEGER 2 }, KM_PURPOSE_SIGN.
+	androidKeyDERAllApplications = "bf8458020500"   // [600] EXPLICIT NULL.
+	androidKeyDEROrigin          = "bf853e03020100" // [702] EXPLICIT INTEGER 0, KM_ORIGIN_GENERATED.
+	androidKeyDEREarlyBootOnly   = "bf8231020500"   // [305] EXPLICIT NULL, earlyBootOnly, modelled by the schema.
+	androidKeyDERUnsupportedLow  = "bf8314020500"   // [404] EXPLICIT NULL, a tag below origin which isn't modelled.
+	androidKeyDERUnsupportedHigh = "bf8555020500"   // [725] EXPLICIT NULL, a tag above origin which isn't modelled.
+
+	androidKeyErrUnsupportedLow = "element 1 has tag [404] which is not supported and precedes a field required by the verification procedure"
+)
+
+// androidKeyDERSequence wraps a body in a DER SEQUENCE header.
+func androidKeyDERSequence(t *testing.T, body string) string {
+	t.Helper()
+
+	require.Less(t, len(body)/2, 128, "the short form length used here only encodes up to 127 bytes")
+
+	return fmt.Sprintf("30%02x", len(body)/2) + body
+}
+
+// androidKeyDERRawList decodes an authorization list body into the raw element the tag verification receives.
+func androidKeyDERRawList(t *testing.T, body string) asn1.RawValue {
+	t.Helper()
+
+	der, err := hex.DecodeString(androidKeyDERSequence(t, body))
+	require.NoError(t, err)
+
+	var raw asn1.RawValue
+
+	rest, err := asn1.Unmarshal(der, &raw)
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	return raw
+}
+
+// androidKeyDERKeyDescription builds a key description extension carrying the two authorization list bodies given.
+func androidKeyDERKeyDescription(t *testing.T, software, tee string) []byte {
+	t.Helper()
+
+	body := "020100" + // attestationVersion INTEGER 0.
+		"0a0100" + // attestationSecurityLevel ENUMERATED 0.
+		"020100" + // keymasterVersion INTEGER 0.
+		"0a0100" + // keymasterSecurityLevel ENUMERATED 0.
+		"0400" + // attestationChallenge OCTET STRING, empty.
+		"0400" + // uniqueId OCTET STRING, empty.
+		androidKeyDERSequence(t, software) +
+		androidKeyDERSequence(t, tee)
+
+	der, err := hex.DecodeString(androidKeyDERSequence(t, body))
+	require.NoError(t, err)
+
+	return der
 }
 
 var androidKeyTestResponse0 = map[string]string{

--- a/protocol/attestation_androidkey_types.go
+++ b/protocol/attestation_androidkey_types.go
@@ -1,0 +1,143 @@
+package protocol
+
+import (
+	"encoding/asn1"
+)
+
+type androidkeyDescription struct {
+	AttestationVersion       int
+	AttestationSecurityLevel asn1.Enumerated
+	KeymasterVersion         int
+	KeymasterSecurityLevel   asn1.Enumerated
+	AttestationChallenge     []byte
+	UniqueID                 []byte
+	SoftwareEnforced         androidkeyAuthorizationList
+	TeeEnforced              androidkeyAuthorizationList
+}
+
+// androidkeyDescriptionRaw mirrors [keyDescription] but captures the two authorization lists as raw elements, so the elements
+// they carry can be examined before [authorizationList] decoding discards those it can't model. The leading members
+// must remain identical to those of [keyDescription].
+type androidkeyDescriptionRaw struct {
+	AttestationVersion       int
+	AttestationSecurityLevel asn1.Enumerated
+	KeymasterVersion         int
+	KeymasterSecurityLevel   asn1.Enumerated
+	AttestationChallenge     []byte
+	UniqueID                 []byte
+	SoftwareEnforced         asn1.RawValue
+	TeeEnforced              asn1.RawValue
+}
+
+// androidkeyAuthorizationList is the Keymaster/KeyMint AuthorizationList, whose schema §8.4.1 defers to normatively.
+//
+// Every tag in the schema must be modelled even when the verification procedure never reads it. encoding/asn1 matches
+// the fields of a struct against the elements of a sequence in order, and on meeting an element which matches no
+// remaining field it abandons every field that follows, leaving them at their zero value with no error. An unmodelled
+// tag which is absent here therefore erases the fields declared after it, so the members which exist only to occupy
+// their position must not be removed. Those are declared as [asn1.RawValue] as it imposes no expectation on the
+// content, so a value which is absent, of an unexpected type, or too large for its Go type can't fail the decode of a
+// list which is otherwise sound.
+//
+// See: https://source.android.com/docs/security/features/keystore/attestation
+type androidkeyAuthorizationList struct {
+	Purpose                     []int                 `asn1:"tag:1,explicit,set,optional"`
+	Algorithm                   int                   `asn1:"tag:2,explicit,optional"`
+	KeySize                     int                   `asn1:"tag:3,explicit,optional"`
+	BlockMode                   asn1.RawValue         `asn1:"tag:4,explicit,optional"`
+	Digest                      []int                 `asn1:"tag:5,explicit,set,optional"`
+	Padding                     []int                 `asn1:"tag:6,explicit,set,optional"`
+	CallerNonce                 asn1.RawValue         `asn1:"tag:7,explicit,optional"`
+	MinMacLength                asn1.RawValue         `asn1:"tag:8,explicit,optional"`
+	EcCurve                     int                   `asn1:"tag:10,explicit,optional"`
+	MlDsaVariant                asn1.RawValue         `asn1:"tag:11,explicit,optional"`
+	RsaPublicExponent           int                   `asn1:"tag:200,explicit,optional"`
+	MgfDigest                   asn1.RawValue         `asn1:"tag:203,explicit,optional"`
+	RollbackResistance          asn1.RawValue         `asn1:"tag:303,explicit,optional"`
+	EarlyBootOnly               asn1.RawValue         `asn1:"tag:305,explicit,optional"`
+	ActiveDateTime              int                   `asn1:"tag:400,explicit,optional"`
+	OriginationExpireDateTime   int                   `asn1:"tag:401,explicit,optional"`
+	UsageExpireDateTime         int                   `asn1:"tag:402,explicit,optional"`
+	UsageCountLimit             asn1.RawValue         `asn1:"tag:405,explicit,optional"`
+	UserSecureID                asn1.RawValue         `asn1:"tag:502,explicit,optional"`
+	NoAuthRequired              asn1.RawValue         `asn1:"tag:503,explicit,optional"`
+	UserAuthType                int                   `asn1:"tag:504,explicit,optional"`
+	AuthTimeout                 int                   `asn1:"tag:505,explicit,optional"`
+	AllowWhileOnBody            asn1.RawValue         `asn1:"tag:506,explicit,optional"`
+	TrustedUserPresenceRequired asn1.RawValue         `asn1:"tag:507,explicit,optional"`
+	TrustedConfirmationRequired asn1.RawValue         `asn1:"tag:508,explicit,optional"`
+	UnlockedDeviceRequired      asn1.RawValue         `asn1:"tag:509,explicit,optional"`
+	AllApplications             asn1.RawValue         `asn1:"tag:600,explicit,optional"`
+	ApplicationID               asn1.RawValue         `asn1:"tag:601,explicit,optional"`
+	CreationDateTime            int                   `asn1:"tag:701,explicit,optional"`
+	Origin                      asn1.RawValue         `asn1:"tag:702,explicit,optional"`
+	RootOfTrust                 androidkeyRootOfTrust `asn1:"tag:704,explicit,optional"`
+	OsVersion                   int                   `asn1:"tag:705,explicit,optional"`
+	OsPatchLevel                int                   `asn1:"tag:706,explicit,optional"`
+	AttestationApplicationID    []byte                `asn1:"tag:709,explicit,optional"`
+	AttestationIDBrand          []byte                `asn1:"tag:710,explicit,optional"`
+	AttestationIDDevice         []byte                `asn1:"tag:711,explicit,optional"`
+	AttestationIDProduct        []byte                `asn1:"tag:712,explicit,optional"`
+	AttestationIDSerial         []byte                `asn1:"tag:713,explicit,optional"`
+	AttestationIDImei           []byte                `asn1:"tag:714,explicit,optional"`
+	AttestationIDMeid           []byte                `asn1:"tag:715,explicit,optional"`
+	AttestationIDManufacturer   []byte                `asn1:"tag:716,explicit,optional"`
+	AttestationIDModel          []byte                `asn1:"tag:717,explicit,optional"`
+	VendorPatchLevel            int                   `asn1:"tag:718,explicit,optional"`
+	BootPatchLevel              int                   `asn1:"tag:719,explicit,optional"`
+	DeviceUniqueAttestation     asn1.RawValue         `asn1:"tag:720,explicit,optional"`
+	AttestationIDSecondImei     asn1.RawValue         `asn1:"tag:723,explicit,optional"`
+	ModuleHash                  asn1.RawValue         `asn1:"tag:724,explicit,optional"`
+}
+
+type androidkeyRootOfTrust struct {
+	VerifiedBootKey   []byte
+	DeviceLocked      bool
+	VerifiedBootState asn1.Enumerated
+	VerifiedBootHash  []byte `asn1:"optional"`
+}
+
+type verifiedBootState int
+
+const (
+	Verified verifiedBootState = iota
+	SelfSigned
+	Unverified
+	Failed
+)
+
+const (
+	// KM_ORIGIN_GENERATED means generated in keymaster. Should not exist outside the TEE.
+	KM_ORIGIN_GENERATED = iota
+
+	// KM_ORIGIN_DERIVED means derived inside keymaster. Likely exists off-device.
+	KM_ORIGIN_DERIVED
+
+	// KM_ORIGIN_IMPORTED means imported into keymaster. Existed as clear text in Android.
+	KM_ORIGIN_IMPORTED
+
+	// KM_ORIGIN_UNKNOWN means keymaster did not record origin.  This value can only be seen on keys in a keymaster0
+	// implementation. The keymaster0 adapter uses this value to document the fact that it is unknown whether the key
+	// was generated inside or imported into keymaster.
+	KM_ORIGIN_UNKNOWN
+)
+
+const (
+	// KM_PURPOSE_ENCRYPT is usable with RSA, EC and AES keys.
+	KM_PURPOSE_ENCRYPT = iota
+
+	// KM_PURPOSE_DECRYPT is usable with RSA, EC and AES keys.
+	KM_PURPOSE_DECRYPT
+
+	// KM_PURPOSE_SIGN is usable with RSA, EC and HMAC keys.
+	KM_PURPOSE_SIGN
+
+	// KM_PURPOSE_VERIFY is usable with RSA, EC and HMAC keys.
+	KM_PURPOSE_VERIFY
+
+	// KM_PURPOSE_DERIVE_KEY is usable with EC keys.
+	KM_PURPOSE_DERIVE_KEY
+
+	// KM_PURPOSE_WRAP is usable with wrapped keys.
+	KM_PURPOSE_WRAP
+)

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -496,26 +496,20 @@ type tpmManufacturer struct {
 	code string
 }
 
+// tpmParseAIKAttCA prepares an Attestation Identity Key certificate and its parents for chain verification against the
+// Metadata Service.
+//
+// The only adjustment required is clearing the critical Subject Alternative Name, as crypto/x509 has no verification
+// option which accepts a critical extension it doesn't itself parse. The Extended Key Usages are left intact as the
+// verifier requests x509.ExtKeyUsageAny, which admits the TCG and Microsoft usages. §8.3.1 requires the attestation
+// certificate carry the AIK Extended Key Usage, which the TPM attestation handler enforces against the same
+// certificate.
 func tpmParseAIKAttCA(x5c *x509.Certificate, x5cis []*x509.Certificate) (leaf *x509.Certificate, parents []*x509.Certificate, protoErr *Error) {
 	if leaf, protoErr = tpmParseSANExtension(x5c); protoErr != nil {
 		return nil, nil, protoErr
 	}
 
-	var hasAIK bool
-
-	// The AIK Extended Key Usage is only required on the attestation certificate itself per §8.3.1. TPM vendor
-	// intermediates generally don't carry it so it must not be required of them.
-	if leaf, hasAIK = tpmRemoveEKU(leaf); !hasAIK {
-		return nil, nil, ErrAttestationFormat.WithDetails("Attestation Identity Key certificate missing required Extended Key Usage.")
-	}
-
-	for _, x5ci := range x5cis {
-		parent, _ := tpmRemoveEKU(x5ci)
-
-		parents = append(parents, parent)
-	}
-
-	return leaf, parents, nil
+	return leaf, x5cis, nil
 }
 
 func tpmParseSANExtension(attestation *x509.Certificate) (out *x509.Certificate, protoErr *Error) {
@@ -556,33 +550,6 @@ func tpmParseSANExtension(attestation *x509.Certificate) (out *x509.Certificate,
 type tpmBasicConstraints struct {
 	IsCA       bool `asn1:"optional"`
 	MaxPathLen int  `asn1:"optional,default:-1"`
-}
-
-// tpmRemoveEKU returns a copy of the certificate with the TCG and Microsoft extension key usages removed to avoid the
-// ExtKeyUsage check failure, and reports whether the certificate carried the AIK extension key usage. The certificate
-// given is never modified as it's owned by the caller.
-func tpmRemoveEKU(x5c *x509.Certificate) (out *x509.Certificate, hasAiK bool) {
-	var unknown []asn1.ObjectIdentifier
-
-	for _, eku := range x5c.UnknownExtKeyUsage {
-		if eku.Equal(oidTCGKpAIKCertificate) {
-			hasAiK = true
-
-			continue
-		}
-
-		if eku.Equal(oidMicrosoftKpPrivacyCA) {
-			continue
-		}
-
-		unknown = append(unknown, eku)
-	}
-
-	out = new(x509.Certificate)
-	*out = *x5c
-	out.UnknownExtKeyUsage = unknown
-
-	return out, hasAiK
 }
 
 func init() {

--- a/protocol/attestation_tpm_test.go
+++ b/protocol/attestation_tpm_test.go
@@ -240,58 +240,6 @@ func TestIsValidTPMManufacturer(t *testing.T) {
 	})
 }
 
-func TestTpmRemoveEKU(t *testing.T) {
-	t.Run("ShouldReportAikEkuMissing", func(t *testing.T) {
-		cert := &x509.Certificate{
-			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				{1, 2, 3, 4},
-			},
-		}
-
-		out, hasAiK := tpmRemoveEKU(cert)
-
-		assert.False(t, hasAiK)
-		require.Len(t, out.UnknownExtKeyUsage, 1)
-	})
-
-	t.Run("ShouldRemoveAikAndMicrosoftEkuButKeepOtherUnknownEku", func(t *testing.T) {
-		other := asn1.ObjectIdentifier{1, 2, 3, 4}
-
-		cert := &x509.Certificate{
-			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				oidMicrosoftKpPrivacyCA,
-				other,
-				oidTCGKpAIKCertificate,
-			},
-		}
-
-		out, hasAiK := tpmRemoveEKU(cert)
-
-		assert.True(t, hasAiK)
-
-		require.Len(t, out.UnknownExtKeyUsage, 1)
-		assert.True(t, out.UnknownExtKeyUsage[0].Equal(other))
-	})
-
-	t.Run("ShouldNotModifyTheCertificateGiven", func(t *testing.T) {
-		cert := &x509.Certificate{
-			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				oidMicrosoftKpPrivacyCA,
-				oidTCGKpAIKCertificate,
-			},
-		}
-
-		out, hasAiK := tpmRemoveEKU(cert)
-
-		assert.True(t, hasAiK)
-		assert.NotSame(t, cert, out)
-		assert.Empty(t, out.UnknownExtKeyUsage)
-		require.Len(t, cert.UnknownExtKeyUsage, 2)
-		assert.True(t, cert.UnknownExtKeyUsage[0].Equal(oidMicrosoftKpPrivacyCA))
-		assert.True(t, cert.UnknownExtKeyUsage[1].Equal(oidTCGKpAIKCertificate))
-	})
-}
-
 func TestTpmParseSANExtension(t *testing.T) {
 	makeSAN := func(t *testing.T, manufacturer, model, version string) []byte {
 		t.Helper()
@@ -433,7 +381,7 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 		assert.Equal(t, "Error occurred parsing SAN extension: asn1: syntax error: data truncated", err.DevInfo)
 	})
 
-	t.Run("ShouldSucceedWhenParentMissingAikEku", func(t *testing.T) {
+	t.Run("ShouldPreserveExtendedKeyUsages", func(t *testing.T) {
 		otherEku := asn1.ObjectIdentifier{1, 2, 3, 4}
 
 		leaf := &x509.Certificate{
@@ -457,36 +405,33 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 		outLeaf, outParents, err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
 		require.Nil(t, err)
 
-		require.Len(t, outLeaf.UnknownExtKeyUsage, 1)
-		assert.True(t, outLeaf.UnknownExtKeyUsage[0].Equal(otherEku))
+		require.Len(t, outLeaf.UnknownExtKeyUsage, 3)
+		assert.True(t, outLeaf.UnknownExtKeyUsage[0].Equal(oidTCGKpAIKCertificate))
+		assert.True(t, outLeaf.UnknownExtKeyUsage[1].Equal(oidMicrosoftKpPrivacyCA))
+		assert.True(t, outLeaf.UnknownExtKeyUsage[2].Equal(otherEku))
 
 		require.Len(t, outParents, 1)
-		require.Len(t, outParents[0].UnknownExtKeyUsage, 1)
-		assert.True(t, outParents[0].UnknownExtKeyUsage[0].Equal(otherEku))
+		assert.Same(t, parent, outParents[0])
 	})
 
-	t.Run("ShouldSucceedWhenParentHasNoEkuAtAll", func(t *testing.T) {
+	t.Run("ShouldSucceedWhenLeafMissingAikEku", func(t *testing.T) {
 		leaf := &x509.Certificate{
 			Extensions: []pkix.Extension{
 				{Id: oidExtensionSubjectAltName, Value: makeSAN(t, "id:414D4400", "ModelX", "id:00070002")},
 			},
 			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				oidTCGKpAIKCertificate,
+				oidMicrosoftKpPrivacyCA,
 			},
 		}
 
-		parent := &x509.Certificate{}
-
-		outLeaf, outParents, err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
+		outLeaf, _, err := tpmParseAIKAttCA(leaf, nil)
 		require.Nil(t, err)
 
-		assert.Empty(t, outLeaf.UnknownExtKeyUsage)
-		require.Len(t, outParents, 1)
-		assert.Empty(t, outParents[0].UnknownExtKeyUsage)
+		require.Len(t, outLeaf.UnknownExtKeyUsage, 1)
+		assert.True(t, outLeaf.UnknownExtKeyUsage[0].Equal(oidMicrosoftKpPrivacyCA))
 	})
 
-	t.Run("ShouldSucceedAndNotMutateCertificates", func(t *testing.T) {
-		otherEku := asn1.ObjectIdentifier{1, 2, 3, 4}
+	t.Run("ShouldClearCriticalSanAndNotMutateCertificates", func(t *testing.T) {
 		otherCritical := asn1.ObjectIdentifier{2, 999, 1}
 
 		leaf := &x509.Certificate{
@@ -497,38 +442,16 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 				oidExtensionSubjectAltName,
 				otherCritical,
 			},
-			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				oidTCGKpAIKCertificate,
-				oidMicrosoftKpPrivacyCA,
-				otherEku,
-			},
 		}
 
-		parent := &x509.Certificate{
-			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				oidTCGKpAIKCertificate,
-				oidMicrosoftKpPrivacyCA,
-				otherEku,
-			},
-		}
-
-		outLeaf, outParents, err := tpmParseAIKAttCA(leaf, []*x509.Certificate{parent})
+		outLeaf, _, err := tpmParseAIKAttCA(leaf, nil)
 		require.Nil(t, err)
 
 		require.Len(t, outLeaf.UnhandledCriticalExtensions, 1)
 		assert.True(t, outLeaf.UnhandledCriticalExtensions[0].Equal(otherCritical))
 
-		require.Len(t, outLeaf.UnknownExtKeyUsage, 1)
-		assert.True(t, outLeaf.UnknownExtKeyUsage[0].Equal(otherEku))
-
-		require.Len(t, outParents, 1)
-		require.Len(t, outParents[0].UnknownExtKeyUsage, 1)
-		assert.True(t, outParents[0].UnknownExtKeyUsage[0].Equal(otherEku))
 		assert.NotSame(t, leaf, outLeaf)
-		assert.NotSame(t, parent, outParents[0])
 		assert.Len(t, leaf.UnhandledCriticalExtensions, 2)
-		assert.Len(t, leaf.UnknownExtKeyUsage, 3)
-		assert.Len(t, parent.UnknownExtKeyUsage, 3)
 	})
 
 	t.Run("ShouldBeIdempotent", func(t *testing.T) {
@@ -549,20 +472,6 @@ func TestTpmParseAIKAttCA(t *testing.T) {
 
 		_, _, err = tpmParseAIKAttCA(leaf, nil)
 		assert.Nil(t, err)
-	})
-
-	t.Run("ShouldFailWhenLeafMissingAikEku", func(t *testing.T) {
-		leaf := &x509.Certificate{
-			Extensions: []pkix.Extension{
-				{Id: oidExtensionSubjectAltName, Value: makeSAN(t, "id:414D4400", "ModelX", "id:00070002")},
-			},
-			UnknownExtKeyUsage: []asn1.ObjectIdentifier{
-				oidMicrosoftKpPrivacyCA,
-			},
-		}
-
-		_, _, err := tpmParseAIKAttCA(leaf, nil)
-		assert.EqualError(t, err, "Attestation Identity Key certificate missing required Extended Key Usage.")
 	})
 }
 

--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -98,7 +98,7 @@ func ValidateMetadata(ctx context.Context, mds metadata.Provider, aaguid uuid.UU
 			}
 		}
 
-		if x5c != nil && x5c.Subject.CommonName != x5c.Issuer.CommonName {
+		if x5c != nil {
 			if !entry.MetadataStatement.AttestationTypes.HasBasicFull() {
 				return ErrMetadata.WithDetails(fmt.Sprintf("Failed to validate attestation statement signature during attestation validation for Authenticator Attestation GUID '%s'. Attestation was provided in the full format but the authenticator doesn't support the full attestation format.", aaguid))
 			}

--- a/protocol/metadata_test.go
+++ b/protocol/metadata_test.go
@@ -2,11 +2,19 @@ package protocol
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/go-webauthn/webauthn/metadata"
@@ -187,6 +195,90 @@ func TestValidateMetadata(t *testing.T) {
 	}
 }
 
+func TestValidateMetadataTrustAnchor(t *testing.T) {
+	aaguid := uuid.MustParse("0865c31d-05dc-4fb1-adce-3227bfb19967")
+
+	root, rootKey := metadataTestGenerateCertificate(t, "Metadata Root", nil, nil)
+
+	errUntrusted := &Error{
+		Type:    ErrMetadata.Type,
+		Details: fmt.Sprintf("Failed to validate attestation statement signature during attestation validation for Authenticator Attestation GUID '%s'. The attestation certificate could not be verified due to an error validating the trust chain against the Metadata Service.", aaguid),
+	}
+
+	testCases := []struct {
+		name string
+		x5cs []any
+		err  *Error
+	}{
+		{
+			// Self-signed by an attacker so it reaches no trust anchor, with the subject and issuer Common Names
+			// equal.
+			name: "ShouldRejectSelfSignedCertificateWithMatchingCommonNames",
+			x5cs: func() []any {
+				cert, _ := metadataTestGenerateCertificate(t, "Attacker", nil, nil)
+
+				return []any{cert.Raw}
+			}(),
+			err: errUntrusted,
+		},
+		{
+			name: "ShouldRejectCertificateNotIssuedByMetadataRoot",
+			x5cs: func() []any {
+				other, otherKey := metadataTestGenerateCertificate(t, "Other Root", nil, nil)
+				cert, _ := metadataTestGenerateCertificate(t, "Attestation", other, otherKey)
+
+				return []any{cert.Raw}
+			}(),
+			err: errUntrusted,
+		},
+		{
+			name: "ShouldAcceptCertificateIssuedByMetadataRoot",
+			x5cs: func() []any {
+				cert, _ := metadataTestGenerateCertificate(t, "Attestation", root, rootKey)
+
+				return []any{cert.Raw}
+			}(),
+		},
+		{
+			// A self-signed certificate which is itself the published trust anchor must verify, so an authenticator
+			// whose attestation certificate is its own root isn't rejected.
+			name: "ShouldAcceptSelfSignedCertificateWhichIsTheMetadataRoot",
+			x5cs: []any{root.Raw},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mds := mocks.NewMockMetadataProvider(ctrl)
+
+			entry := &metadata.Entry{
+				MetadataStatement: metadata.Statement{
+					AttestationTypes:            metadata.AuthenticatorAttestationTypes{metadata.BasicFull},
+					AttestationRootCertificates: []*x509.Certificate{root},
+				},
+			}
+
+			mds.EXPECT().GetEntry(gomock.Any(), gomock.Any()).Return(entry, nil)
+			mds.EXPECT().GetValidateAttestationTypes(gomock.Any()).Return(false)
+			mds.EXPECT().GetValidateStatus(gomock.Any()).Return(false)
+			mds.EXPECT().GetValidateTrustAnchor(gomock.Any()).Return(true)
+
+			actual := ValidateMetadata(context.Background(), mds, aaguid, string(metadata.BasicFull), "packed", tc.x5cs)
+
+			if tc.err == nil {
+				assert.Nil(t, actual)
+
+				return
+			}
+
+			require.NotNil(t, actual)
+			assert.Equal(t, tc.err.Type, actual.Type)
+			assert.Equal(t, tc.err.Details, actual.Details)
+		})
+	}
+}
+
 func TestLoopOrdinalNumber(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -260,4 +352,39 @@ func TestLoopOrdinalNumber(t *testing.T) {
 			assert.Equal(t, tc.expected, loopOrdinalNumber(tc.n))
 		})
 	}
+}
+
+// Supporting functions and test data.
+
+// metadataTestGenerateCertificate issues a certificate authority certificate, self-signed when parent is nil. The
+// subject and issuer Common Names of a self-signed certificate are equal by construction.
+func metadataTestGenerateCertificate(t *testing.T, commonName string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	signer, signerKey := parent, parentKey
+
+	if parent == nil {
+		signer, signerKey = template, key
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, signer, &key.PublicKey, signerKey)
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return cert, key
 }

--- a/protocol/webauthncbor/webauthncbor.go
+++ b/protocol/webauthncbor/webauthncbor.go
@@ -1,6 +1,6 @@
 package webauthncbor
 
-import "github.com/fxamacker/cbor/v2"
+import cbor "github.com/fxamacker/cbor/v2"
 
 const nestedLevelsAllowed = 4
 

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -16,8 +16,9 @@ import (
 
 	"github.com/google/go-tpm/tpm2"
 
-	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
 	"github.com/go-webauthn/x/encoding/asn1"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
 )
 
 // PublicKeyData The public key portion of a Relying Party-specific credential key pair, generated

--- a/protocol/webauthncose/webauthncose_test.go
+++ b/protocol/webauthncose/webauthncose_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2"
 	"github.com/google/go-tpm/tpm2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
This cleans up a lot of the elements within androidkey and tpm attestation implementations after lots of changes.