### PR TITLE
feat: typed extension inputs and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ which are not available in that version. The current intentionally supported ver
 
 - go 1.26
 - go 1.25
-- go 1.24
 
 ## Status
 
@@ -146,34 +145,60 @@ represents when the format was introduced into the spec.
 
 ### Extensions
 
+Extensions with a typed input have a dedicated functional option (`webauthn.WithExtension<Name>`) taking typed
+Go values, applied via `webauthn.WithExtensions` (registration) or `webauthn.WithAssertionExtensions`
+(authentication); a typed client output is exposed as a field of `protocol.AuthenticationExtensionsClientOutputs`,
+and a typed authenticator output as a field of `protocol.AuthenticatorExtensionOutputs`. An identifier with no
+dedicated option is not modelled: it can still be set on input with the generic `webauthn.WithExtension`, which
+conveys the value to the client verbatim, and any output returned under that identifier is preserved in the
+relevant `Extra` map rather than dropped.
+
 Standardized and Specification Listed Extensions:
 
-|                                                                                   Extension                                                                                    |   Identifier   | Supported (Registration) | Supported (Authentication) | Level |
-|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:--------------:|:------------------------:|:--------------------------:|:-----:|
-|                                              [§10.1.1 FIDO AppID Extension](https://www.w3.org/TR/webauthn/#sctn-appid-extension)                                              |    `appid`     |         N/A[^2]          |        Yes (manual)        | 3 (1) |
-|                                     [§10.1.2 FIDO AppID Exclusion Extension](https://www.w3.org/TR/webauthn/#sctn-appid-exclude-extension)                                     | `appidExclude` |       Yes (manual)       |          N/A[^1]           | 3 (1) |
-|                        [§10.1.3 Credential Properties Extension](https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension)                         |  `credProps`   |       Yes (manual)       |          N/A[^1]           | 3 (2) |
-|                                       [§10.1.5 Large Blob Storage Extension](https://www.w3.org/TR/webauthn/#sctn-large-blob-extension)                                        |  `largeBlob`   |       Yes (manual)       |        Yes (manual)        | 3 (2) |
+|                                                            Extension                                                            |   Identifier   |                 Registration                  |                       Authentication                        | Level |
+|:-------------------------------------------------------------------------------------------------------------------------------:|:--------------:|:---------------------------------------------:|:-----------------------------------------------------------:|:-----:|
+|                     [§10.1.1 FIDO AppID Extension](https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)                      |    `appid`     |                    N/A[^2]                    |                    `WithExtensionAppID`                     | 3 (1) |
+|            [§10.1.2 FIDO AppID Exclusion Extension](https://www.w3.org/TR/webauthn-3/#sctn-appid-exclude-extension)             | `appidExclude` |          `WithExtensionAppIDExclude`          |                           N/A[^1]                           | 3 (1) |
+| [§10.1.3 Credential Properties Extension](https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension) |  `credProps`   |           `WithExtensionCredProps`            |                           N/A[^1]                           | 3 (2) |
+|                   [§10.1.4 Pseudo-Random Function Extension](https://www.w3.org/TR/webauthn-3/#prf-extension)                   |     `prf`      | `WithExtensionPRF`, `WithExtensionPRFSupport` |        `WithExtensionPRF`, `WithExtensionPRFSupport`        | 3 (2) |
+|               [§10.1.5 Large Blob Storage Extension](https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)               |  `largeBlob`   |        `WithExtensionLargeBlobSupport`        | `WithExtensionLargeBlobRead`, `WithExtensionLargeBlobWrite` | 3 (2) |
 
-CTAP2 Extensions Which Are Largely unsupported:
+CTAP 2.1 / CTAP 2.2 / CTAP 2.3 Extensions registered in the IANA ["WebAuthn Extension Identifiers"](https://www.iana.org/assignments/webauthn/webauthn.xhtml)
+registry:
 
-|                                                                                             Extension                                                                                             |      Identifier       | Supported (Registration) | Supported (Authentication) |
-|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------:|:------------------------:|:--------------------------:|
-|          [Credential Protection Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-credProtect-extension)           |     `credProtect`     |       Yes (manual)       |          N/A[^1]           |
-|               [Credential Blob Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-credBlob-extension)               |      `credBlob`       |       Yes (manual)       |        Yes (manual)        | 
-|             [Large Blob Key Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-largeBlobKey-extension)              |    `largeBlobKey`     |       Yes (manual)       |        Yes (manual)        |
-|           [Minimum PIN Length Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-minpinlength-extension)            |    `minPinLength`     |       Yes (manual)       |        Yes (manual)        |
-|          [PIN Complexity Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-pincomplexitypolicy-extension)          | `pinComplexityPolicy` |       Yes (manual)       |          N/A[^1]           | 
-|               [HMAC Secret Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension)                |     `hmac-secret`     |       Yes (manual)       |        Yes (manual)        | 
-|   [HMAC Secret MakeCredential Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-make-cred-extension)   |   `hmac-secret-mc`    |         N/A[^2]          |        Yes (manual)        | 
-| [Third-Party Payment Authentication Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-thirdPartyPayment-extension) |  `thirdPartyPayment`  |       Yes (manual)       |        Yes (manual)        |
+|                                                                                             Extension                                                                                             |              Identifier              |               Registration                |        Authentication        |
+|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:------------------------------------:|:-----------------------------------------:|:----------------------------:|
+|          [Credential Protection Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-credProtect-extension)           |            `credProtect`             | `WithExtensionCredentialProtectionPolicy` |           N/A[^1]            |
+|               [Credential Blob Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-credBlob-extension)               |      `credBlob` / `getCredBlob`      |          `WithExtensionCredBlob`          |  `WithExtensionGetCredBlob`  |
+|           [Minimum PIN Length Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-minpinlength-extension)            |            `minPinLength`            |        `WithExtensionMinPinLength`        |           N/A[^1]            |
+|               [HMAC Secret Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-hmac-secret-extension)                | `hmacCreateSecret` / `hmacGetSecret` |      `WithExtensionHMACCreateSecret`      | `WithExtensionHMACGetSecret` |
+|                                                [User Verification Method Extension](https://www.iana.org/assignments/webauthn/webauthn.xhtml)[^5]                                                 |                `uvm`                 |            `WithExtensionUVM`             |      `WithExtensionUVM`      |
+|             [Large Blob Key Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-largeBlobKey-extension)              |            `largeBlobKey`            |             Not modelled[^3]              |       Not modelled[^3]       |
+|          [PIN Complexity Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-pincomplexitypolicy-extension)          |        `pinComplexityPolicy`         |             Not modelled[^4]              |           N/A[^1]            |
+|   [HMAC Secret MakeCredential Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-hmac-secret-make-cred-extension)   |           `hmac-secret-mc`           |             Not modelled[^4]              |           N/A[^1]            |
+| [Third-Party Payment Authentication Extension](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#sctn-thirdPartyPayment-extension) |         `thirdPartyPayment`          |             Not modelled[^4]              |       Not modelled[^4]       |
+
+The CTAP authenticator data also carries a `hmac-secret` extension output identifier (`protocol.ExtensionHMACSecret`),
+distinct from the `hmacCreateSecret` / `hmacGetSecret` client-facing identifiers above; it is decoded automatically
+into `AuthenticatorExtensionOutputs.HMACSecret` / `HMACSecretV` and is not something a Relying Party requests.
 
 [^1]: This extension is only applicable during Registration.
 [^2]: This extension is only applicable during Authentication.
+[^3]: Deliberately not modelled. CTAP 2.3 §12.3 defines no client extension input, output, or processing for
+      `largeBlobKey`: it is a CTAP response member returned directly to the platform, not to the Relying Party.
+      `protocol.ExtensionLargeBlobKey` is kept as a documented identifier and remains reachable verbatim via
+      `webauthn.WithExtension`.
+[^4]: Not modelled. Set on input with `webauthn.WithExtension`; an output returned under this identifier is
+      preserved in the outputs' `Extra` map.
+[^5]: `uvm` was deprecated from the core WebAuthn spec text at Level 3 (see the deprecated extensions table
+      below) but remains registered as a CTAP 2.1/2.2/2.3 extension in the IANA registry and is still forwarded by
+      several clients, hence a dedicated option.
 
 Extensions that have been deprecated and removed from the spec. The deprecated level is the first spec level that did
-not include the extension. These are all technically supported by the extensions map, but have no official support from
-this library, and are most likely not supported by either browsers or authenticators.
+not include the extension. These are all technically reachable as untyped values via `webauthn.WithExtension`, but
+have no official (typed) support from this library, and are most likely not supported by either browsers or
+authenticators. The one exception is `uvm`: it remains registered as a CTAP extension and is modelled, so
+`webauthn.WithExtension` rejects it and `webauthn.WithExtensionUVM` is used instead.
 
 These extensions often either were excluded due to privacy or security concerns, were introduced into the core of the
 spec as legitimate inputs outside of extensions, or never received support from browsers or authenticators.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ registry:
 
 The CTAP authenticator data also carries a `hmac-secret` extension output identifier (`protocol.ExtensionHMACSecret`),
 distinct from the `hmacCreateSecret` / `hmacGetSecret` client-facing identifiers above; it is decoded automatically
-into `AuthenticatorExtensionOutputs.HMACSecret` / `HMACSecretV` and is not something a Relying Party requests.
+into `AuthenticatorExtensionOutputs.HMACSecret` / `HMACSecretOutput` and is not something a Relying Party requests.
 
 [^1]: This extension is only applicable during Registration.
 [^2]: This extension is only applicable during Authentication.

--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -160,13 +160,19 @@ func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPa
 	// Begin Step 11. Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the RP.
 	rpIDHash := sha256.Sum256([]byte(relyingPartyID))
 
-	var appIDHash [32]byte
+	// The appid is only non-empty when the Relying Party requested the FIDO AppID Extension and the client reported
+	// having acted on it; see [ParsedPublicKeyCredential.GetAppID], which derives it from the session data. In that
+	// case §10.1.1 requires the AppID hash to be the expected rpIdHash in place of the RP ID hash, so the hash is
+	// left nil rather than zeroed when the extension does not apply.
+	var appIDHash []byte
+
 	if appID != "" {
-		appIDHash = sha256.Sum256([]byte(appID))
+		sum := sha256.Sum256([]byte(appID))
+		appIDHash = sum[:]
 	}
 
 	// Handle steps 11 through 14, verifying the authenticator data.
-	validError = p.Response.AuthenticatorData.Verify(rpIDHash[:], appIDHash[:], verifyUser, verifyUserPresence)
+	validError = p.Response.AuthenticatorData.Verify(rpIDHash[:], appIDHash, verifyUser, verifyUserPresence)
 	if validError != nil {
 		return validError
 	}

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -50,8 +50,8 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 						Type: string(PublicKeyCredentialType),
 					},
 					RawID: byteID,
-					ClientExtensionResults: map[string]any{
-						"appID": "example.com",
+					ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+						Extra: map[string]any{"vendorAppID": "example.com"},
 					},
 				},
 				Response: ParsedAssertionResponse{
@@ -81,8 +81,8 @@ func TestParseCredentialRequestResponse(t *testing.T) {
 							ID:   "AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
 						},
 						RawID: byteID,
-						ClientExtensionResults: map[string]any{
-							"appID": "example.com",
+						ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+							Extra: map[string]any{"vendorAppID": "example.com"},
 						},
 					},
 					AssertionResponse: AuthenticatorAssertionResponse{
@@ -325,11 +325,25 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 			err:             "Error validating the assertion signature: <nil>",
 		},
 		{
-			name:            "ShouldFailWithAppID",
+			// The authenticator data of this vector is scoped to the RP ID, so an appid in play must be rejected
+			// rather than silently falling back to the RP ID hash. §10.1.1 requires the Relying Party to expect the
+			// hash of the AppID and not the hash of the RP ID once the client reports the extension was acted upon.
+			name:            "ShouldFailWithAppIDNotMatchingAuthenticatorData",
 			challenge:       challenge,
 			relyingPartyID:  "example.org",
 			rpOrigins:       []string{"https://example.org"},
 			appID:           "https://example.org",
+			credentialBytes: credPubKey,
+			err:             "Error validating the authenticator response",
+		},
+		{
+			// An appid whose hash does match the authenticator data reaches the FIDO U2F public key parser, which
+			// this CTAP2 formatted spec vector key is not valid for.
+			name:            "ShouldFailWithAppIDMatchingAuthenticatorData",
+			challenge:       challenge,
+			relyingPartyID:  "example.org",
+			rpOrigins:       []string{"https://example.org"},
+			appID:           "example.org",
 			credentialBytes: credPubKey,
 			err:             "Error parsing the assertion public key: failed to parse FIDO public key: crypto/ecdh: invalid public key",
 		},
@@ -512,7 +526,7 @@ var testAssertionResponses = map[string]string{
 	`success`: `{
 		"id":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
 		"rawId":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
-		"clientExtensionResults":{"appID":"example.com"},
+		"clientExtensionResults":{"vendorAppID":"example.com"},
 		"type":"public-key",
 		"response":{
 			"authenticatorData":"dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBFXJJiGa3OAAI1vMYKZIsLJfHwVQMANwCOw-atj9C0vhWpfWU-whzNjeQS21Lpxfdk_G-omAtffWztpGoErlNOfuXWRqm9Uj9ANJck1p6lAQIDJiABIVggKAhfsdHcBIc0KPgAcRyAIK_-Vi-nCXHkRHPNaCMBZ-4iWCBxB8fGYQSBONi9uvq0gv95dGWlhJrBwCsj_a4LJQKVHQ",
@@ -524,7 +538,7 @@ var testAssertionResponses = map[string]string{
 	`trailingData`: `{
 		"id":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
 		"rawId":"AI7D5q2P0LS-Fal9ZT7CHM2N5BLbUunF92T8b6iYC199bO2kagSuU05-5dZGqb1SP0A0lyTWng",
-		"clientExtensionResults":{"appID":"example.com"},
+		"clientExtensionResults":{"vendorAppID":"example.com"},
 		"type":"public-key",
 		"response":{
 			"authenticatorData":"dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvBFXJJiGa3OAAI1vMYKZIsLJfHwVQMANwCOw-atj9C0vhWpfWU-whzNjeQS21Lpxfdk_G-omAtffWztpGoErlNOfuXWRqm9Uj9ANJck1p6lAQIDJiABIVggKAhfsdHcBIc0KPgAcRyAIK_-Vi-nCXHkRHPNaCMBZ-4iWCBxB8fGYQSBONi9uvq0gv95dGWlhJrBwCsj_a4LJQKVHQ",

--- a/protocol/authenticator.go
+++ b/protocol/authenticator.go
@@ -42,11 +42,12 @@ type AuthenticatorResponse struct {
 //
 // Specification: §6.1. Authenticator Data (https://www.w3.org/TR/webauthn/#sctn-authenticator-data)
 type AuthenticatorData struct {
-	RPIDHash []byte                 `json:"rpid"`
-	Flags    AuthenticatorFlags     `json:"flags"`
-	Counter  uint32                 `json:"sign_count"`
-	AttData  AttestedCredentialData `json:"att_data"`
-	ExtData  []byte                 `json:"ext_data"`
+	RPIDHash []byte                         `json:"rpid"`
+	Flags    AuthenticatorFlags             `json:"flags"`
+	Counter  uint32                         `json:"sign_count"`
+	AttData  AttestedCredentialData         `json:"att_data"`
+	ExtData  []byte                         `json:"ext_data"`
+	Ext      *AuthenticatorExtensionOutputs `json:"ext,omitempty"`
 }
 
 // AttestedCredentialData is a variable-length byte array added to the authenticator data when generating an attestation
@@ -333,6 +334,10 @@ func (a *AuthenticatorData) Unmarshal(rawAuthData []byte) (err error) {
 		if remaining != 0 {
 			a.ExtData = rawAuthData[len(rawAuthData)-remaining:]
 			remaining -= len(a.ExtData)
+
+			if a.Ext, err = ParseAuthenticatorExtensionOutputs(a.ExtData); err != nil {
+				return err
+			}
 		} else {
 			return ErrBadRequest.WithDetails("Extensions flag set but extensions data is missing")
 		}
@@ -405,12 +410,30 @@ func ResidentKeyNotRequired() *bool {
 
 // Verify on AuthenticatorData handles Steps 13 through 15 & 17 for Registration
 // and Steps 15 through 18 for Assertion.
+//
+// A non-empty appIDHash replaces rpIdHash as the sole expected value rather than being accepted alongside it. It must
+// therefore only be supplied when the FIDO AppID Extension was requested by the Relying Party and the client reported
+// having acted on it, which for an assertion is what [ParsedPublicKeyCredential.GetAppID] determines from the session
+// data. Callers with no appid in play, such as registration, pass nil.
+//
+// Specification: §10.1.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)
 func (a *AuthenticatorData) Verify(rpIdHash []byte, appIDHash []byte, userVerificationRequired bool, userPresenceRequired bool) (err error) {
 	// Registration Step 13 & Assertion Step 15
 	// Verify that the RP ID hash in authData is indeed the SHA-256
 	// hash of the RP ID expected by the RP.
-	if !bytes.Equal(a.RPIDHash, rpIdHash) && !bytes.Equal(a.RPIDHash, appIDHash) {
-		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x", a.RPIDHash, rpIdHash))
+	//
+	// The appid client extension output being true means the assertion was scoped to the AppID, so §10.1.1 requires
+	// the Relying Party to expect the hash of the AppID and not the hash of the RP ID. Accepting either would let a
+	// client claim the extension was used while returning an assertion scoped to the RP ID, and would also make an
+	// unset appIDHash an all zero hash the authenticator could match.
+	expected := rpIdHash
+
+	if len(appIDHash) != 0 {
+		expected = appIDHash
+	}
+
+	if !bytes.Equal(a.RPIDHash, expected) {
+		return ErrVerification.WithInfo(fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x", expected, a.RPIDHash))
 	}
 
 	// Registration Step 15 & Assertion Step 16

--- a/protocol/authenticator_test.go
+++ b/protocol/authenticator_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
 )
 
 const (
@@ -466,6 +468,7 @@ func TestAuthenticatorData_Verify(t *testing.T) {
 
 	type args struct {
 		rpIdHash                 []byte
+		appIDHash                []byte
 		userVerificationRequired bool
 		userPresenceRequired     bool
 	}
@@ -501,7 +504,55 @@ func TestAuthenticatorData_Verify(t *testing.T) {
 			err:        "Error validating the authenticator response",
 			errType:    "verification_error",
 			errDetails: "Error validating the authenticator response",
-			errInfo:    "RP Hash mismatch. Expected ff and Received aa",
+			errInfo:    "RP Hash mismatch. Expected aa and Received ff",
+		},
+		{
+			// The FIDO AppID Extension was used, so the AppID hash is the value the authenticator is expected to
+			// have signed over.
+			name: "AppID hash matches",
+			fields: fields{
+				RPIDHash: []byte{1, 2, 3},
+				Flags:    AuthenticatorFlags(0x05),
+			},
+			args: args{
+				rpIdHash:  []byte{0xaa},
+				appIDHash: []byte{1, 2, 3},
+			},
+			err: "",
+		},
+		{
+			// Specification: §10.1.1. When the appid client extension output is true the Relying Party MUST expect
+			// the rpIdHash to be the hash of the AppID, not the RP ID, so the RP ID hash must no longer satisfy the
+			// check once an AppID hash is in play.
+			name: "AppID hash set and only RP ID hash matches",
+			fields: fields{
+				RPIDHash: []byte{1, 2, 3},
+				Flags:    AuthenticatorFlags(0x05),
+			},
+			args: args{
+				rpIdHash:  []byte{1, 2, 3},
+				appIDHash: []byte{0xaa},
+			},
+			err:        "Error validating the authenticator response",
+			errType:    "verification_error",
+			errDetails: "Error validating the authenticator response",
+			errInfo:    "RP Hash mismatch. Expected aa and Received 010203",
+		},
+		{
+			// An absent AppID hash must not become a second acceptable value. The all zero hash is the shape a
+			// caller passing an unset [32]byte would produce.
+			name: "Zero RP ID hash without an AppID",
+			fields: fields{
+				RPIDHash: make([]byte, 32),
+				Flags:    AuthenticatorFlags(0x05),
+			},
+			args: args{
+				rpIdHash: []byte{1, 2, 3},
+			},
+			err:        "Error validating the authenticator response",
+			errType:    "verification_error",
+			errDetails: "Error validating the authenticator response",
+			errInfo:    "RP Hash mismatch. Expected 010203 and Received 0000000000000000000000000000000000000000000000000000000000000000",
 		},
 		{
 			name: "UP flag not set",
@@ -546,7 +597,7 @@ func TestAuthenticatorData_Verify(t *testing.T) {
 				ExtData:  tc.fields.ExtData,
 			}
 
-			err := a.Verify(tc.args.rpIdHash, nil, tc.args.userVerificationRequired, tc.args.userPresenceRequired)
+			err := a.Verify(tc.args.rpIdHash, tc.args.appIDHash, tc.args.userVerificationRequired, tc.args.userPresenceRequired)
 
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
@@ -557,4 +608,22 @@ func TestAuthenticatorData_Verify(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthenticatorDataUnmarshalDecodesExtensions(t *testing.T) {
+	extData, err := webauthncbor.Marshal(map[string]any{"minPinLength": uint64(4)})
+	require.NoError(t, err)
+
+	raw := make([]byte, 37)
+	raw[32] = byte(FlagHasExtensions)
+	raw = append(raw, extData...)
+
+	var authData AuthenticatorData
+
+	require.NoError(t, authData.Unmarshal(raw))
+
+	assert.Equal(t, extData, authData.ExtData, "the raw signed bytes must be preserved")
+	require.NotNil(t, authData.Ext)
+	require.NotNil(t, authData.Ext.MinPinLength)
+	assert.Equal(t, uint(4), *authData.Ext.MinPinLength)
 }

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -39,7 +39,7 @@ type PublicKeyCredential struct {
 	Credential
 
 	RawID                   URLEncodedBase64                      `json:"rawId"`
-	ClientExtensionResults  AuthenticationExtensionsClientOutputs `json:"clientExtensionResults,omitempty"`
+	ClientExtensionResults  AuthenticationExtensionsClientOutputs `json:"clientExtensionResults,omitzero"`
 	AuthenticatorAttachment string                                `json:"authenticatorAttachment,omitempty"`
 }
 
@@ -48,7 +48,7 @@ type ParsedPublicKeyCredential struct {
 	ParsedCredential
 
 	RawID                   []byte                                `json:"rawId"`
-	ClientExtensionResults  AuthenticationExtensionsClientOutputs `json:"clientExtensionResults,omitempty"`
+	ClientExtensionResults  AuthenticationExtensionsClientOutputs `json:"clientExtensionResults,omitzero"`
 	AuthenticatorAttachment AuthenticatorAttachment               `json:"authenticatorAttachment,omitempty"`
 }
 
@@ -228,56 +228,38 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingP
 	return clientDataHash, nil
 }
 
-// GetAppID takes a AuthenticationExtensions object or nil. It then performs the following checks in order:
+// GetAppID determines the Relying Party ID to use for a credential registered through the legacy FIDO U2F
+// JavaScript API. It returns an empty string when the FIDO AppID Extension does not apply, and the session's appid
+// when it does.
 //
-// 1. Check that the Session Data's AuthenticationExtensions has been provided and if it hasn't return an error.
-// 2. Check that the AuthenticationExtensionsClientOutputs contains the extensions output and return an empty string if it doesn't.
-// 3. Check that the Credential AttestationFormat is `fido-u2f` and return an empty string if it isn't.
-// 4. Check that the AuthenticationExtensionsClientOutputs contains the appid key and if it doesn't return an empty string.
-// 5. Check that the AuthenticationExtensionsClientOutputs appid is a bool and if it isn't return an error.
-// 6. Check that the appid output is true and if it isn't return an empty string.
-// 7. Check that the Session Data has an appid extension defined and if it doesn't return an error.
-// 8. Check that the appid extension in Session Data is a string and if it isn't return an error.
-// 9. Return the appid extension value from the Session data.
-func (ppkc ParsedPublicKeyCredential) GetAppID(authExt AuthenticationExtensions, credentialAttestationFormat string) (appID string, err error) {
-	var (
-		value, clientValue interface{}
-		enableAppID, ok    bool
-	)
-
-	if authExt == nil {
+// The checks performed, in order:
+//
+//  1. If the client did not report the appid extension output, or reported it as false, return an empty string.
+//  2. If the credential's attestation format is not "fido-u2f" it is assumed not to be a FIDO U2F credential, so
+//     return an empty string.
+//  3. If the session data has no appid, return an error; the client indicates it acted on an extension the Relying
+//     Party did not request.
+//  4. Return the session's appid.
+//
+// A client output whose appid member is not a boolean is rejected when the response is parsed rather than here.
+//
+// A non-empty return value becomes the sole expected rpIdHash for the assertion. The specification requires the
+// Relying Party to expect the hash of the AppID and not the hash of the RP ID once the client reports the extension
+// was acted upon, so the RP ID hash is not accepted as an alternative; see [AuthenticatorData.Verify].
+//
+// Specification: §10.1.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)
+func (ppkc ParsedPublicKeyCredential) GetAppID(session SessionExtensions, credentialAttestationFormat string) (appID string, err error) {
+	if ppkc.ClientExtensionResults.AppID == nil || !*ppkc.ClientExtensionResults.AppID {
 		return "", nil
 	}
 
-	if ppkc.ClientExtensionResults == nil {
-		return "", nil
-	}
-
-	// If the credential is not in the fido-u2f attestation FORMAT it is assumed to NOT be a fido-u2f credential.
-	// https://www.w3.org/TR/webauthn/#sctn-fido-u2f-attestation
 	if credentialAttestationFormat != string(AttestationFormatFIDOUniversalSecondFactor) {
 		return "", nil
 	}
 
-	if clientValue, ok = ppkc.ClientExtensionResults[ExtensionAppID]; !ok {
-		return "", nil
-	}
-
-	if enableAppID, ok = clientValue.(bool); !ok {
-		return "", ErrBadRequest.WithDetails("Client Output appid did not have the expected type")
-	}
-
-	if !enableAppID {
-		return "", nil
-	}
-
-	if value, ok = authExt[ExtensionAppID]; !ok {
+	if session.AppID == "" {
 		return "", ErrBadRequest.WithDetails("Session Data does not have an appid but Client Output indicates it should be set")
 	}
 
-	if appID, ok = value.(string); !ok {
-		return "", ErrBadRequest.WithDetails("Session Data appid did not have the expected type")
-	}
-
-	return appID, nil
+	return session.AppID, nil
 }

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -48,7 +48,7 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 					},
 					RawID: byteID,
 					ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-						"appid": true,
+						AppID: ptr(true),
 					},
 					AuthenticatorAttachment: Platform,
 				},
@@ -82,7 +82,7 @@ func TestParseCredentialCreationResponse(t *testing.T) {
 						},
 						RawID: byteID,
 						ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-							"appid": true,
+							AppID: ptr(true),
 						},
 						AuthenticatorAttachment: "platform",
 					},
@@ -370,22 +370,15 @@ func TestGetAppID(t *testing.T) {
 	testCases := []struct {
 		name                        string
 		ppkc                        ParsedPublicKeyCredential
-		authExt                     AuthenticationExtensions
+		authExt                     SessionExtensions
 		credentialAttestationFormat string
 		expectedAppID               string
 		err                         string
 	}{
 		{
-			name:                        "ShouldReturnEmptyWhenAuthExtNil",
-			ppkc:                        ParsedPublicKeyCredential{},
-			authExt:                     nil,
-			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
-			expectedAppID:               "",
-		},
-		{
 			name:                        "ShouldReturnEmptyWhenClientExtNil",
-			ppkc:                        ParsedPublicKeyCredential{},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: "https://example.com"},
+			ppkc:                        ParsedPublicKeyCredential{ClientExtensionResults: AuthenticationExtensionsClientOutputs{}},
+			authExt:                     SessionExtensions{AppID: "https://example.com"},
 			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
 			expectedAppID:               "",
 		},
@@ -393,10 +386,10 @@ func TestGetAppID(t *testing.T) {
 			name: "ShouldReturnEmptyWhenNotFIDOU2F",
 			ppkc: ParsedPublicKeyCredential{
 				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					ExtensionAppID: true,
+					AppID: ptr(true),
 				},
 			},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: "https://example.com"},
+			authExt:                     SessionExtensions{AppID: "https://example.com"},
 			credentialAttestationFormat: "packed",
 			expectedAppID:               "",
 		},
@@ -404,67 +397,50 @@ func TestGetAppID(t *testing.T) {
 			name: "ShouldReturnEmptyWhenAppIDNotInClientExt",
 			ppkc: ParsedPublicKeyCredential{
 				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					"other": "value",
+					AppID: nil,
+					Extra: map[string]any{"other": "value"},
 				},
 			},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: "https://example.com"},
+			authExt:                     SessionExtensions{AppID: "https://example.com"},
 			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
 			expectedAppID:               "",
-		},
-		{
-			name: "ShouldFailWhenClientAppIDNotBool",
-			ppkc: ParsedPublicKeyCredential{
-				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					ExtensionAppID: "not-a-bool",
-				},
-			},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: "https://example.com"},
-			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
-			err:                         "Client Output appid did not have the expected type",
 		},
 		{
 			name: "ShouldReturnEmptyWhenAppIDFalse",
 			ppkc: ParsedPublicKeyCredential{
 				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					ExtensionAppID: false,
+					AppID: ptr(false),
 				},
 			},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: "https://example.com"},
+			authExt:                     SessionExtensions{AppID: "https://example.com"},
 			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
 			expectedAppID:               "",
-		},
-		{
-			name: "ShouldFailWhenSessionAppIDMissing",
-			ppkc: ParsedPublicKeyCredential{
-				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					ExtensionAppID: true,
-				},
-			},
-			authExt:                     AuthenticationExtensions{},
-			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
-			err:                         "Session Data does not have an appid but Client Output indicates it should be set",
-		},
-		{
-			name: "ShouldFailWhenSessionAppIDNotString",
-			ppkc: ParsedPublicKeyCredential{
-				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					ExtensionAppID: true,
-				},
-			},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: 123},
-			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
-			err:                         "Session Data appid did not have the expected type",
 		},
 		{
 			name: "ShouldReturnAppID",
 			ppkc: ParsedPublicKeyCredential{
 				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
-					ExtensionAppID: true,
+					AppID: ptr(true),
 				},
 			},
-			authExt:                     AuthenticationExtensions{ExtensionAppID: "https://example.com"},
+			authExt:                     SessionExtensions{AppID: "https://example.com"},
 			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
 			expectedAppID:               "https://example.com",
+		},
+		{
+			// A zero SessionExtensions is indistinguishable from one whose appid was simply never requested: the
+			// typed session has no "nil map" state to short-circuit on the way the old map-typed
+			// ClientExtensionResults did. A client reporting the appid output true against such a session is
+			// therefore treated as unsolicited and rejected, matching the documented GetAppID contract.
+			name: "ShouldFailWhenSessionAppIDMissing",
+			ppkc: ParsedPublicKeyCredential{
+				ClientExtensionResults: AuthenticationExtensionsClientOutputs{
+					AppID: ptr(true),
+				},
+			},
+			authExt:                     SessionExtensions{},
+			credentialAttestationFormat: string(AttestationFormatFIDOUniversalSecondFactor),
+			err:                         "Session Data does not have an appid but Client Output indicates it should be set",
 		},
 	}
 

--- a/protocol/extensions.go
+++ b/protocol/extensions.go
@@ -20,7 +20,20 @@ import (
 // exact-case name from the untyped member map while encoding/json bound the case-insensitive variant to the typed
 // field, leaving the same member present in both the typed field and Extra.
 func extensionNameModelled(names []string, key string) bool {
-	return slices.ContainsFunc(names, func(name string) bool { return strings.EqualFold(name, key) })
+	_, modelled := extensionNameCanonical(names, key)
+
+	return modelled
+}
+
+// extensionNameCanonical resolves key to the entry of names it matches case-insensitively, so a member whose key
+// differs from a modelled name only by case is reported under the identifier the rest of the package uses. It
+// backs extensionNameModelled so the two cannot disagree about what counts as a match.
+func extensionNameCanonical(names []string, key string) (name string, modelled bool) {
+	if index := slices.IndexFunc(names, func(name string) bool { return strings.EqualFold(name, key) }); index >= 0 {
+		return names[index], true
+	}
+
+	return "", false
 }
 
 const (
@@ -74,6 +87,12 @@ const (
 	// ExtensionEnforceCredentialProtectionPolicy requires that the requested credential protection policy is
 	// honoured, failing the ceremony if the authenticator cannot satisfy it.
 	ExtensionEnforceCredentialProtectionPolicy = "enforceCredentialProtectionPolicy"
+
+	// ExtensionCredProtect is the credProtect extension's authenticator-output identifier, carried in the
+	// authenticator data's extension outputs. It is deliberately distinct from
+	// ExtensionCredentialProtectionPolicy, which is the client-facing input identifier used by the
+	// create() extensions member; authenticators echo this abbreviated identifier, not that one.
+	ExtensionCredProtect = "credProtect"
 
 	// ExtensionMinPinLength requests the authenticator's current minimum PIN length at registration.
 	ExtensionMinPinLength = "minPinLength"

--- a/protocol/extensions.go
+++ b/protocol/extensions.go
@@ -1,26 +1,209 @@
 package protocol
 
-// Extensions are discussed in §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn/#extensions).
+import (
+	"slices"
+	"strings"
+)
 
-// For a list of commonly supported extensions, see §10. Defined Extensions
-// (https://www.w3.org/TR/webauthn/#sctn-defined-extensions).
+// Extensions are discussed in §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn-3/#extensions).
 
-// AuthenticationExtensionsClientOutputs represents the IDL of the same name. It is a map of extension identifier
-// strings to their output values, returned by the client after a create() or get() call.
+// For a list of defined extensions, see §10. Defined Extensions
+// (https://www.w3.org/TR/webauthn-3/#sctn-defined-extensions).
+
+// extensionNameModelled reports whether key matches one of names, comparing case-insensitively. It is shared by the
+// extension input codec (extensions_inputs.go) and the extension output codec (extensions_outputs.go) so a JSON
+// member whose key differs from a modelled name only by case is treated consistently by both: as a collision when
+// marshalling Extra, and as the modelled field rather than an Extra entry when unmarshalling.
 //
-// Specification: §5.9. Authentication Extensions Client Outputs (https://www.w3.org/TR/webauthn/#iface-authentication-extensions-client-outputs)
-type AuthenticationExtensionsClientOutputs map[string]any
+// The case-insensitive comparison mirrors the fallback [encoding/json] itself uses when it cannot find a struct
+// field whose tag exactly matches a JSON object key. Without this, the two codecs would delete only the
+// exact-case name from the untyped member map while encoding/json bound the case-insensitive variant to the typed
+// field, leaving the same member present in both the typed field and Extra.
+func extensionNameModelled(names []string, key string) bool {
+	return slices.ContainsFunc(names, func(name string) bool { return strings.EqualFold(name, key) })
+}
 
 const (
 	// ExtensionAppID is the FIDO AppID Extension identifier. It is used during authentication to allow credentials
 	// registered via the legacy FIDO U2F JavaScript API to be used with WebAuthn.
 	//
-	// Specification: §10.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn/#sctn-appid-extension)
+	// Specification: §10.1.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)
 	ExtensionAppID = "appid"
 
 	// ExtensionAppIDExclude is the FIDO AppID Exclusion Extension identifier. It is used during registration to
 	// exclude credentials previously registered via the legacy FIDO U2F JavaScript API.
 	//
-	// Specification: §10.2. FIDO AppID Exclusion Extension (https://www.w3.org/TR/webauthn/#sctn-appid-exclude-extension)
+	// Specification: §10.1.2. FIDO AppID Exclusion Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-exclude-extension)
 	ExtensionAppIDExclude = "appidExclude"
+
+	// ExtensionCredProps is the Credential Properties Extension identifier. It is used during registration to
+	// request that the client report properties of the newly created credential.
+	//
+	// Specification: §10.1.3. Credential Properties Extension (https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension)
+	ExtensionCredProps = "credProps"
+
+	// ExtensionPRF is the Pseudo-random function Extension identifier. It is used during registration and
+	// authentication to evaluate a PRF scoped to the credential.
+	//
+	// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+	ExtensionPRF = "prf"
+
+	// ExtensionLargeBlob is the Large blob storage Extension identifier. It is used during registration to request
+	// support, and during authentication to read or write opaque data associated with a credential.
+	//
+	// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+	ExtensionLargeBlob = "largeBlob"
+
+	// ExtensionRemoteClientDataJSON is the Remote Client Data JSON Extension identifier. It is set by a remote
+	// desktop web client, not by a Relying Party. A Relying Party receiving this output should understand that the
+	// local client delegated every RP ID and origin check to a remote host.
+	//
+	// Specification: §10.1.6. Remote Client Data JSON extension (https://www.w3.org/TR/webauthn-3/#sctn-remote-client-data-json-extension)
+	ExtensionRemoteClientDataJSON = "remoteClientDataJSON"
 )
+
+// The following extension identifiers are defined by CTAP 2.1 and CTAP 2.2 and registered in the IANA "WebAuthn
+// Extension Identifiers" registry established by RFC8809. They are not defined by WebAuthn Level 3, however several
+// clients forward them as extension inputs.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+const (
+	// ExtensionCredentialProtectionPolicy requests a credential protection policy at registration.
+	ExtensionCredentialProtectionPolicy = "credentialProtectionPolicy"
+
+	// ExtensionEnforceCredentialProtectionPolicy requires that the requested credential protection policy is
+	// honoured, failing the ceremony if the authenticator cannot satisfy it.
+	ExtensionEnforceCredentialProtectionPolicy = "enforceCredentialProtectionPolicy"
+
+	// ExtensionMinPinLength requests the authenticator's current minimum PIN length at registration.
+	ExtensionMinPinLength = "minPinLength"
+
+	// ExtensionCredBlob requests that a small blob is stored with the credential at registration.
+	ExtensionCredBlob = "credBlob"
+
+	// ExtensionGetCredBlob requests the blob stored with the credential at authentication.
+	ExtensionGetCredBlob = "getCredBlob"
+
+	// ExtensionLargeBlobKey is the CTAP largeBlobKey extension identifier. It is deliberately NOT modelled by
+	// this library: it has no client extension input and no client extension output, so there is nothing for a
+	// Relying Party to send or receive. CTAP 2.1 §12.3 states "Client extension input / output / processing:
+	// None" and that the extension "is not suitable to be directly exposed to RPs". The key itself is returned
+	// as the largeBlobKey (0x05) member of the CTAP response structure, not as a client extension and not as an
+	// authenticator data extension, and it is driven by the client platform rather than the Relying Party.
+	//
+	// Do not add a typed member or a dedicated functional option for this. A caller with a non-browser CTAP
+	// client that genuinely needs to set it can use webauthn.WithExtension with this identifier, which routes it
+	// through the untyped extension inputs verbatim.
+	ExtensionLargeBlobKey = "largeBlobKey"
+
+	// ExtensionHMACCreateSecret requests that the authenticator provisions an HMAC secret at registration.
+	ExtensionHMACCreateSecret = "hmacCreateSecret"
+
+	// ExtensionHMACGetSecret requests evaluation of the HMAC secret at authentication.
+	ExtensionHMACGetSecret = "hmacGetSecret"
+
+	// ExtensionHMACSecret is the CTAP hmac-secret extension's authenticator-output identifier. It is carried in
+	// the authenticator data's extension outputs, as a boolean at registration and as a byte string at
+	// authentication. It is deliberately distinct from ExtensionHMACCreateSecret and ExtensionHMACGetSecret,
+	// which are the client-facing input identifiers used by the create()/get() extensions member; authenticators
+	// echo this hyphenated identifier, not those, in their extension outputs.
+	ExtensionHMACSecret = "hmac-secret"
+
+	// ExtensionUVM requests the user verification methods used for the operation.
+	ExtensionUVM = "uvm"
+)
+
+// LargeBlobSupport represents the LargeBlobSupport IDL enumeration used by the large blob storage extension during
+// registration.
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+type LargeBlobSupport string
+
+const (
+	// LargeBlobSupportRequired indicates the credential MUST support the large blob storage extension. The client
+	// fails the ceremony when no eligible authenticator supports it.
+	LargeBlobSupportRequired LargeBlobSupport = "required"
+
+	// LargeBlobSupportPreferred indicates the credential SHOULD support the large blob storage extension.
+	LargeBlobSupportPreferred LargeBlobSupport = "preferred"
+)
+
+// CredentialProtectionPolicy represents the credential protection policy values of the CTAP credProtect extension.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+type CredentialProtectionPolicy string
+
+const (
+	// CredentialProtectionPolicyUserVerificationOptional is credProtect value 0x01.
+	CredentialProtectionPolicyUserVerificationOptional CredentialProtectionPolicy = "userVerificationOptional"
+
+	// CredentialProtectionPolicyUserVerificationOptionalWithCredentialIDList is credProtect value 0x02.
+	CredentialProtectionPolicyUserVerificationOptionalWithCredentialIDList CredentialProtectionPolicy = "userVerificationOptionalWithCredentialIDList"
+
+	// CredentialProtectionPolicyUserVerificationRequired is credProtect value 0x03.
+	CredentialProtectionPolicyUserVerificationRequired CredentialProtectionPolicy = "userVerificationRequired"
+)
+
+// PRFValues represents the AuthenticationExtensionsPRFValuesJSON IDL. The byte values are conveyed to the client
+// base64url encoded.
+//
+// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+type PRFValues struct {
+	First  URLEncodedBase64 `json:"first"`
+	Second URLEncodedBase64 `json:"second,omitempty"`
+}
+
+// IsZero returns true when no PRF value is set. It is used by the encoding/json omitzero tag option.
+func (v PRFValues) IsZero() bool {
+	return len(v.First) == 0 && len(v.Second) == 0
+}
+
+// PRFInputs represents the AuthenticationExtensionsPRFInputsJSON IDL.
+//
+// Every member is optional. A zero value is the bare availability probe, i.e. the "prf":{} input a Relying Party
+// sends at registration to learn whether the pseudo-random function is available for the credential; the client
+// answers with the 'enabled' output. This is why [AuthenticationExtensions.PRF] is a pointer while its
+// [LargeBlobInputs] and [HMACGetSecretInputs] siblings are not.
+//
+// EvalByCredential is only valid during authentication; the client throws a NotSupportedError when it is present
+// during registration. Its keys are base64url encoded credential IDs which MUST each match an entry of the
+// allowed credentials.
+//
+// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+type PRFInputs struct {
+	Eval             PRFValues            `json:"eval,omitzero"`
+	EvalByCredential map[string]PRFValues `json:"evalByCredential,omitempty"`
+}
+
+// IsZero returns true when no PRF input is set. It is used by the encoding/json omitzero tag option.
+func (i PRFInputs) IsZero() bool {
+	return i.Eval.IsZero() && len(i.EvalByCredential) == 0
+}
+
+// LargeBlobInputs represents the AuthenticationExtensionsLargeBlobInputsJSON IDL. Support is only valid during
+// registration; Read and Write are only valid during authentication and are mutually exclusive.
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+type LargeBlobInputs struct {
+	Support LargeBlobSupport `json:"support,omitempty"`
+	Read    bool             `json:"read,omitempty"`
+	Write   URLEncodedBase64 `json:"write,omitempty"`
+}
+
+// IsZero returns true when no large blob input is set. It is used by the encoding/json omitzero tag option.
+func (i LargeBlobInputs) IsZero() bool {
+	return i.Support == "" && !i.Read && len(i.Write) == 0
+}
+
+// HMACGetSecretInputs represents the inputs of the CTAP hmac-secret extension during authentication.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+type HMACGetSecretInputs struct {
+	Salt1 URLEncodedBase64 `json:"salt1"`
+	Salt2 URLEncodedBase64 `json:"salt2,omitempty"`
+}
+
+// IsZero returns true when no salt is set. It is used by the encoding/json omitzero tag option.
+func (i HMACGetSecretInputs) IsZero() bool {
+	return len(i.Salt1) == 0 && len(i.Salt2) == 0
+}

--- a/protocol/extensions.go
+++ b/protocol/extensions.go
@@ -1,6 +1,8 @@
 package protocol
 
 import (
+	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 )
@@ -34,6 +36,36 @@ func extensionNameCanonical(names []string, key string) (name string, modelled b
 	}
 
 	return "", false
+}
+
+// extensionsMarshalExtra merges extra into the already marshalled form of the modelled members and returns the
+// combined JSON object. It backs the MarshalJSON of both the extension inputs and the extension outputs, which
+// differ only in their identifier list and in the label their errors carry. Marshalling always routes through a map
+// so the key ordering does not depend on whether extra is populated.
+//
+// The collision check is against names rather than the marshalled members so a modelled extension is rejected even
+// when its field is zero and therefore absent from the output. Routing a modelled extension through the untyped bag
+// would bypass the typed model and be silently dropped on the way back in. The comparison is case-insensitive
+// because encoding/json would bind a case-variant key to the modelled field on the way back in; see
+// extensionNameModelled.
+func extensionsMarshalExtra(data []byte, names []string, extra map[string]any, label string) (out []byte, err error) {
+	var members map[string]json.RawMessage
+
+	if err = json.Unmarshal(data, &members); err != nil {
+		return nil, err
+	}
+
+	for key, value := range extra {
+		if extensionNameModelled(names, key) {
+			return nil, fmt.Errorf("error marshalling %s: extra extension %q collides with a modelled extension", label, key)
+		}
+
+		if members[key], err = json.Marshal(value); err != nil {
+			return nil, fmt.Errorf("error marshalling %s: extra extension %q: %w", label, key, err)
+		}
+	}
+
+	return json.Marshal(members)
 }
 
 const (

--- a/protocol/extensions_authenticator.go
+++ b/protocol/extensions_authenticator.go
@@ -1,8 +1,10 @@
 package protocol
 
 import (
+	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
 )
@@ -112,25 +114,62 @@ func ParseAuthenticatorExtensionOutputs(data []byte) (out *AuthenticatorExtensio
 // A nil receiver is valid and means the authenticator returned no extension outputs at all, which is itself a
 // failure when a credential protection policy was requested with enforcement.
 //
-// Only the credProtect policy is asserted. CTAP requires the client to fail the ceremony when
-// 'enforceCredentialProtectionPolicy' is set and the authenticator cannot honour the requested policy, but the
-// Relying Party is the only party that can confirm this independently, and unlike the client extension outputs the
-// authenticator data is signed, so the value checked here is covered by the attestation signature.
+// Two rules are enforced, both of which apply only to registration. The credProtect policy must be honoured when
+// enforcement was requested, and a blob submitted for storage with the credential must actually have been stored.
+// Every problem found is reported rather than only the first, matching
+// [AuthenticationExtensionsClientOutputs.Verify].
+//
+// CTAP requires the client to fail the ceremony when 'enforceCredentialProtectionPolicy' is set and the
+// authenticator cannot honour the requested policy, but the Relying Party is the only party that can confirm this
+// independently, and unlike the client extension outputs the authenticator data is signed, so the values checked
+// here are covered by the attestation signature.
 //
 // The applied policy is compared as at-least-as-strict rather than equal, because an authenticator is permitted to
 // apply a stricter policy than the one requested, for instance where its own default exceeds the request.
 //
 // A ceremony which is neither [CreateCeremony] nor [AssertCeremony] is treated as a registration, matching
 // [AuthenticationExtensionsClientOutputs.Verify], so an unexpected value fails closed rather than skipping the
-// assertion.
+// assertions.
 //
 // Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
 func (o *AuthenticatorExtensionOutputs) Verify(session SessionExtensions, ceremony CeremonyType) error {
-	// credProtect is a registration extension, so there is nothing to assert for an assertion ceremony.
+	// Both rules cover registration extensions, so there is nothing to assert for an assertion ceremony.
 	if ceremony == AssertCeremony {
 		return nil
 	}
 
+	var errs []error
+
+	if err := o.verifyCredentialProtectionPolicy(session); err != nil {
+		errs = append(errs, err)
+	}
+
+	// A blob the authenticator did not store is a silent failure: the Relying Party would otherwise believe its
+	// data is held against the credential and only discover otherwise when a later getCredBlob returns nothing.
+	if session.CredBlob {
+		if o == nil || o.CredBlobSet == nil {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with a blob to store but the authenticator did not report whether it was stored", ExtensionCredBlob)))
+		} else if !*o.CredBlobSet {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with a blob to store but the authenticator reported it was not stored", ExtensionCredBlob)))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// As with the client extension outputs, the joined error is kept as the cause so errors.As and errors.Is reach
+	// each individual problem while the caller still receives an *Error.
+	joined := errors.Join(errs...)
+
+	return ErrBadRequest.
+		WithDetails(fmt.Sprintf("Error validating the authenticator extension outputs: %s", strings.ReplaceAll(joined.Error(), "\n", "; "))).
+		WithError(joined)
+}
+
+// verifyCredentialProtectionPolicy asserts the policy the authenticator applied against the one the Relying Party
+// required. A policy requested without enforcement is advisory, so it is not asserted.
+func (o *AuthenticatorExtensionOutputs) verifyCredentialProtectionPolicy(session SessionExtensions) error {
 	if !session.EnforceCredentialProtectionPolicy || session.CredentialProtectionPolicy == "" {
 		return nil
 	}

--- a/protocol/extensions_authenticator.go
+++ b/protocol/extensions_authenticator.go
@@ -1,0 +1,190 @@
+package protocol
+
+import (
+	"math"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+)
+
+// AuthenticatorExtensionOutputs is the decoded form of the extension outputs carried in the authenticator data.
+// WebAuthn Level 3 defines no authenticator extensions; every member below is defined by CTAP 2.1 or CTAP 2.2 and
+// registered in the IANA "WebAuthn Extension Identifiers" registry.
+//
+// Specification: §6.1. Authenticator Data (https://www.w3.org/TR/webauthn-3/#sctn-authenticator-data)
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+type AuthenticatorExtensionOutputs struct {
+	// CredProtect is the credential protection policy applied to the credential. Registration only.
+	CredProtect *CredentialProtectionPolicy `json:"credProtect,omitempty"`
+
+	// MinPinLength is the authenticator's current minimum PIN length. Registration only.
+	MinPinLength *uint `json:"minPinLength,omitempty"`
+
+	// CredBlobSet reports whether the requested blob was stored. Registration only.
+	CredBlobSet *bool `json:"-"`
+
+	// CredBlob is the blob stored with the credential. Authentication only.
+	CredBlob []byte `json:"credBlob,omitempty"`
+
+	// HMACSecret reports whether the hmac-secret was provisioned. Registration only.
+	HMACSecret *bool `json:"-"`
+
+	// HMACSecretV is the encrypted hmac-secret output. Authentication only.
+	HMACSecretV []byte `json:"-"`
+
+	// UVM reports the user verification methods used for the operation.
+	UVM []UserVerificationMethod `json:"uvm,omitempty"`
+
+	// Extra carries authenticator extension outputs this library does not model, and the values of modelled
+	// extensions that arrived with an unexpected type.
+	Extra map[string]any `json:"-"`
+}
+
+// UserVerificationMethod is a single entry of the CTAP uvm extension output.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+type UserVerificationMethod struct {
+	UserVerificationMethod uint32 `json:"userVerificationMethod"`
+	KeyProtectionType      uint32 `json:"keyProtectionType"`
+	MatcherProtectionType  uint32 `json:"matcherProtectionType"`
+}
+
+// credentialProtectionPolicies maps the CTAP credProtect integer values to their policy names.
+var credentialProtectionPolicies = map[uint64]CredentialProtectionPolicy{
+	1: CredentialProtectionPolicyUserVerificationOptional,
+	2: CredentialProtectionPolicyUserVerificationOptionalWithCredentialIDList,
+	3: CredentialProtectionPolicyUserVerificationRequired,
+}
+
+// ParseAuthenticatorExtensionOutputs decodes the CBOR extension outputs from the authenticator data.
+//
+// A structurally invalid encoding is an error, as the data is signed and malformation indicates something is
+// genuinely wrong. A recognised identifier carrying an unexpected type is preserved in
+// [AuthenticatorExtensionOutputs.Extra] without an error, so a single non-conforming authenticator cannot fail
+// every ceremony it participates in.
+func ParseAuthenticatorExtensionOutputs(data []byte) (out *AuthenticatorExtensionOutputs, err error) {
+	var members map[string]any
+
+	if err = webauthncbor.Unmarshal(data, &members); err != nil {
+		return nil, ErrBadRequest.
+			WithDetails("Error decoding authenticator extension outputs").
+			WithInfo(err.Error()).
+			WithError(err)
+	}
+
+	out = &AuthenticatorExtensionOutputs{}
+
+	for key, value := range members {
+		if out.assign(key, value) {
+			continue
+		}
+
+		if out.Extra == nil {
+			out.Extra = map[string]any{}
+		}
+
+		out.Extra[key] = value
+	}
+
+	return out, nil
+}
+
+// assign stores a single decoded extension output, reporting whether the identifier was recognised and the value
+// had the expected type. A false result sends the entry to Extra.
+func (o *AuthenticatorExtensionOutputs) assign(key string, value any) bool {
+	switch key {
+	case ExtensionCredentialProtectionPolicy, "credProtect":
+		raw, ok := value.(uint64)
+		if !ok {
+			return false
+		}
+
+		policy, ok := credentialProtectionPolicies[raw]
+		if !ok {
+			return false
+		}
+
+		o.CredProtect = &policy
+
+		return true
+	case ExtensionMinPinLength:
+		raw, ok := value.(uint64)
+		if !ok {
+			return false
+		}
+
+		if raw > math.MaxUint {
+			return false
+		}
+
+		o.MinPinLength = ptr(uint(raw))
+
+		return true
+	case ExtensionCredBlob:
+		switch raw := value.(type) {
+		case bool:
+			o.CredBlobSet = ptr(raw)
+		case []byte:
+			o.CredBlob = raw
+		default:
+			return false
+		}
+
+		return true
+	case ExtensionHMACSecret:
+		switch raw := value.(type) {
+		case bool:
+			o.HMACSecret = ptr(raw)
+		case []byte:
+			o.HMACSecretV = raw
+		default:
+			return false
+		}
+
+		return true
+	case ExtensionUVM:
+		entries, ok := value.([]any)
+		if !ok {
+			return false
+		}
+
+		methods := make([]UserVerificationMethod, 0, len(entries))
+
+		for _, entry := range entries {
+			fields, ok := entry.([]any)
+			if !ok || len(fields) != 3 {
+				return false
+			}
+
+			var method UserVerificationMethod
+
+			for i, field := range fields {
+				raw, ok := field.(uint64)
+				if !ok {
+					return false
+				}
+
+				if raw > math.MaxUint32 {
+					return false
+				}
+
+				switch i {
+				case 0:
+					method.UserVerificationMethod = uint32(raw)
+				case 1:
+					method.KeyProtectionType = uint32(raw)
+				case 2:
+					method.MatcherProtectionType = uint32(raw)
+				}
+			}
+
+			methods = append(methods, method)
+		}
+
+		o.UVM = methods
+
+		return true
+	default:
+		return false
+	}
+}

--- a/protocol/extensions_authenticator.go
+++ b/protocol/extensions_authenticator.go
@@ -105,19 +105,36 @@ func ParseAuthenticatorExtensionOutputs(data []byte) (out *AuthenticatorExtensio
 
 	out = &AuthenticatorExtensionOutputs{}
 
+	// Both credProtect identifiers assign the same field, so a map carrying both would otherwise resolve by map
+	// iteration order and yield a different policy from one parse to the next. ExtensionCredProtect is the
+	// identifier authenticators actually echo, so it wins; the other is preserved in Extra rather than discarded,
+	// leaving the conflict visible to a Relying Party which wants to inspect it.
+	_, credProtect := members[ExtensionCredProtect]
+
 	for key, value := range members {
+		if key == ExtensionCredentialProtectionPolicy && credProtect {
+			out.extra(key, value)
+
+			continue
+		}
+
 		if out.assign(key, value) {
 			continue
 		}
 
-		if out.Extra == nil {
-			out.Extra = map[string]any{}
-		}
-
-		out.Extra[key] = value
+		out.extra(key, value)
 	}
 
 	return out, nil
+}
+
+// extra records an extension output which was not assigned to a modelled field, allocating the map on first use.
+func (o *AuthenticatorExtensionOutputs) extra(key string, value any) {
+	if o.Extra == nil {
+		o.Extra = map[string]any{}
+	}
+
+	o.Extra[key] = value
 }
 
 // Verify checks these authenticator extension outputs against the extensions recorded in the session.

--- a/protocol/extensions_authenticator.go
+++ b/protocol/extensions_authenticator.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
@@ -49,11 +50,28 @@ type UserVerificationMethod struct {
 	MatcherProtectionType  uint32 `json:"matcherProtectionType"`
 }
 
-// credentialProtectionPolicies maps the CTAP credProtect integer values to their policy names.
+// credentialProtectionPolicies maps the CTAP credProtect integer values to their policy names. The values are
+// ordered by increasing strictness; see [CredentialProtectionPolicy.Value].
 var credentialProtectionPolicies = map[uint64]CredentialProtectionPolicy{
 	1: CredentialProtectionPolicyUserVerificationOptional,
 	2: CredentialProtectionPolicyUserVerificationOptionalWithCredentialIDList,
 	3: CredentialProtectionPolicyUserVerificationRequired,
+}
+
+// Value returns the CTAP credProtect integer value of this policy, reporting false for a policy this library does
+// not recognise. The values increase with strictness, so an applied policy satisfies a requested one when its value
+// is greater than or equal to the requested value.
+//
+// The lookup walks [credentialProtectionPolicies] rather than duplicating it in the opposite direction so the two
+// representations cannot disagree.
+func (p CredentialProtectionPolicy) Value() (value uint64, ok bool) {
+	for candidate, policy := range credentialProtectionPolicies {
+		if policy == p {
+			return candidate, true
+		}
+	}
+
+	return 0, false
 }
 
 // ParseAuthenticatorExtensionOutputs decodes the CBOR extension outputs from the authenticator data.
@@ -87,6 +105,53 @@ func ParseAuthenticatorExtensionOutputs(data []byte) (out *AuthenticatorExtensio
 	}
 
 	return out, nil
+}
+
+// Verify checks these authenticator extension outputs against the extensions recorded in the session.
+//
+// A nil receiver is valid and means the authenticator returned no extension outputs at all, which is itself a
+// failure when a credential protection policy was requested with enforcement.
+//
+// Only the credProtect policy is asserted. CTAP requires the client to fail the ceremony when
+// 'enforceCredentialProtectionPolicy' is set and the authenticator cannot honour the requested policy, but the
+// Relying Party is the only party that can confirm this independently, and unlike the client extension outputs the
+// authenticator data is signed, so the value checked here is covered by the attestation signature.
+//
+// The applied policy is compared as at-least-as-strict rather than equal, because an authenticator is permitted to
+// apply a stricter policy than the one requested, for instance where its own default exceeds the request.
+//
+// A ceremony which is neither [CreateCeremony] nor [AssertCeremony] is treated as a registration, matching
+// [AuthenticationExtensionsClientOutputs.Verify], so an unexpected value fails closed rather than skipping the
+// assertion.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func (o *AuthenticatorExtensionOutputs) Verify(session SessionExtensions, ceremony CeremonyType) error {
+	// credProtect is a registration extension, so there is nothing to assert for an assertion ceremony.
+	if ceremony == AssertCeremony {
+		return nil
+	}
+
+	if !session.EnforceCredentialProtectionPolicy || session.CredentialProtectionPolicy == "" {
+		return nil
+	}
+
+	requested, ok := session.CredentialProtectionPolicy.Value()
+	if !ok {
+		return ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with enforcement but the requested policy %q is not a known policy", ExtensionCredentialProtectionPolicy, session.CredentialProtectionPolicy))
+	}
+
+	if o == nil || o.CredProtect == nil {
+		return ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with enforcement but the authenticator did not report the policy it applied", ExtensionCredentialProtectionPolicy))
+	}
+
+	// A parsed CredProtect is always one of the known policies; assign only sets it from the same map Value walks.
+	applied, _ := o.CredProtect.Value()
+
+	if applied < requested {
+		return ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with enforcement of policy %q but the authenticator applied the less restrictive policy %q", ExtensionCredentialProtectionPolicy, session.CredentialProtectionPolicy, *o.CredProtect))
+	}
+
+	return nil
 }
 
 // assign stores a single decoded extension output, reporting whether the identifier was recognised and the value

--- a/protocol/extensions_authenticator.go
+++ b/protocol/extensions_authenticator.go
@@ -32,8 +32,8 @@ type AuthenticatorExtensionOutputs struct {
 	// HMACSecret reports whether the hmac-secret was provisioned. Registration only.
 	HMACSecret *bool `json:"-"`
 
-	// HMACSecretV is the encrypted hmac-secret output. Authentication only.
-	HMACSecretV []byte `json:"-"`
+	// HMACSecretOutput is the encrypted hmac-secret output. Authentication only.
+	HMACSecretOutput []byte `json:"-"`
 
 	// UVM reports the user verification methods used for the operation.
 	UVM []UserVerificationMethod `json:"uvm,omitempty"`
@@ -83,13 +83,24 @@ func (p CredentialProtectionPolicy) Value() (value uint64, ok bool) {
 // [AuthenticatorExtensionOutputs.Extra] without an error, so a single non-conforming authenticator cannot fail
 // every ceremony it participates in.
 func ParseAuthenticatorExtensionOutputs(data []byte) (out *AuthenticatorExtensionOutputs, err error) {
-	var members map[string]any
+	var (
+		members map[string]any
+		n       int
+	)
 
-	if err = webauthncbor.Unmarshal(data, &members); err != nil {
+	// The extension data is the remainder of the authenticator data, so the caller cannot bound it; anything after
+	// the map is unaccounted for and must be rejected here or not at all.
+	if n, err = webauthncbor.UnmarshalFirst(data, &members); err != nil {
 		return nil, ErrBadRequest.
 			WithDetails("Error decoding authenticator extension outputs").
 			WithInfo(err.Error()).
 			WithError(err)
+	}
+
+	if n != len(data) {
+		return nil, ErrBadRequest.
+			WithDetails("Leftover bytes decoding authenticator extension outputs").
+			WithInfo(fmt.Sprintf("The extension output map consumed %d of %d bytes", n, len(data)))
 	}
 
 	out = &AuthenticatorExtensionOutputs{}
@@ -197,7 +208,7 @@ func (o *AuthenticatorExtensionOutputs) verifyCredentialProtectionPolicy(session
 // had the expected type. A false result sends the entry to Extra.
 func (o *AuthenticatorExtensionOutputs) assign(key string, value any) bool {
 	switch key {
-	case ExtensionCredentialProtectionPolicy, "credProtect":
+	case ExtensionCredentialProtectionPolicy, ExtensionCredProtect:
 		raw, ok := value.(uint64)
 		if !ok {
 			return false
@@ -240,7 +251,7 @@ func (o *AuthenticatorExtensionOutputs) assign(key string, value any) bool {
 		case bool:
 			o.HMACSecret = ptr(raw)
 		case []byte:
-			o.HMACSecretV = raw
+			o.HMACSecretOutput = raw
 		default:
 			return false
 		}

--- a/protocol/extensions_authenticator_test.go
+++ b/protocol/extensions_authenticator_test.go
@@ -322,15 +322,68 @@ func TestParseAuthenticatorExtensionOutputsUnknownKey(t *testing.T) {
 
 func TestParseAuthenticatorExtensionOutputsWrongTypeIsPreserved(t *testing.T) {
 	// A known key carrying an unexpected type is preserved rather than failing the ceremony, so one vendor's odd
-	// encoding cannot break registration for that authenticator.
-	data, err := webauthncbor.Marshal(map[string]any{"minPinLength": "six"})
-	require.NoError(t, err)
+	// encoding cannot break registration for that authenticator. Each modelled identifier has its own type
+	// assertion, so each one is exercised; a branch which errored instead of falling through to Extra would fail
+	// every ceremony that authenticator takes part in.
+	testCases := []struct {
+		name  string
+		key   string
+		value any
+		field func(o *AuthenticatorExtensionOutputs) any
+	}{
+		{
+			name:  "CredProtectWrongType",
+			key:   ExtensionCredProtect,
+			value: "three",
+			field: func(o *AuthenticatorExtensionOutputs) any { return o.CredProtect },
+		},
+		{
+			// A value outside the three policies CTAP defines is not one this library can name.
+			name:  "CredProtectUnknownPolicy",
+			key:   ExtensionCredProtect,
+			value: uint64(4),
+			field: func(o *AuthenticatorExtensionOutputs) any { return o.CredProtect },
+		},
+		{
+			name:  "MinPinLengthWrongType",
+			key:   ExtensionMinPinLength,
+			value: "six",
+			field: func(o *AuthenticatorExtensionOutputs) any { return o.MinPinLength },
+		},
+		{
+			// credBlob is a bool at registration and a byte string at authentication; anything else is neither.
+			name:  "CredBlobWrongType",
+			key:   ExtensionCredBlob,
+			value: uint64(1),
+			field: func(o *AuthenticatorExtensionOutputs) any { return o.CredBlobSet },
+		},
+		{
+			name:  "HMACSecretWrongType",
+			key:   ExtensionHMACSecret,
+			value: uint64(1),
+			field: func(o *AuthenticatorExtensionOutputs) any { return o.HMACSecret },
+		},
+		{
+			name:  "UVMFieldWrongType",
+			key:   ExtensionUVM,
+			value: []any{[]any{"not-an-integer", uint64(4), uint64(2)}},
+			field: func(o *AuthenticatorExtensionOutputs) any { return o.UVM },
+		},
+	}
 
-	have, err := ParseAuthenticatorExtensionOutputs(data)
-	require.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := webauthncbor.Marshal(map[string]any{tc.key: tc.value})
+			require.NoError(t, err)
 
-	assert.Nil(t, have.MinPinLength)
-	assert.Equal(t, map[string]any{"minPinLength": "six"}, have.Extra)
+			have, err := ParseAuthenticatorExtensionOutputs(data)
+			require.NoError(t, err)
+
+			assert.Nil(t, tc.field(have), "the modelled field must stay unset")
+			require.Contains(t, have.Extra, tc.key, "the value must be preserved rather than dropped")
+			assert.Equal(t, tc.value, have.Extra[tc.key])
+		})
+	}
 }
 
 func TestParseAuthenticatorExtensionOutputsMalformed(t *testing.T) {

--- a/protocol/extensions_authenticator_test.go
+++ b/protocol/extensions_authenticator_test.go
@@ -10,6 +10,121 @@ import (
 	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
 )
 
+func TestCredentialProtectionPolicyValue(t *testing.T) {
+	for policy, expected := range map[CredentialProtectionPolicy]uint64{
+		CredentialProtectionPolicyUserVerificationOptional:                     1,
+		CredentialProtectionPolicyUserVerificationOptionalWithCredentialIDList: 2,
+		CredentialProtectionPolicyUserVerificationRequired:                     3,
+	} {
+		value, ok := policy.Value()
+
+		assert.True(t, ok)
+		assert.Equal(t, expected, value)
+	}
+
+	value, ok := CredentialProtectionPolicy("nonsense").Value()
+
+	assert.False(t, ok)
+	assert.Equal(t, uint64(0), value)
+}
+
+func TestAuthenticatorExtensionOutputsVerify(t *testing.T) {
+	testCases := []struct {
+		name     string
+		outputs  *AuthenticatorExtensionOutputs
+		session  SessionExtensions
+		ceremony CeremonyType
+		errs     []string
+	}{
+		{
+			name:     "NotEnforcedIsNotChecked",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired},
+			ceremony: CreateCeremony,
+		},
+		{
+			name:     "EnforcedWithoutPolicyIsNotChecked",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+		},
+		{
+			name:     "EnforcedAndHonoured",
+			outputs:  &AuthenticatorExtensionOutputs{CredProtect: ptr(CredentialProtectionPolicyUserVerificationRequired)},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+		},
+		{
+			// An authenticator may apply a stricter policy than the one requested, for instance where its own
+			// default exceeds the request.
+			name:     "EnforcedAndExceeded",
+			outputs:  &AuthenticatorExtensionOutputs{CredProtect: ptr(CredentialProtectionPolicyUserVerificationRequired)},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationOptional, EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+		},
+		{
+			name:     "EnforcedAndDowngraded",
+			outputs:  &AuthenticatorExtensionOutputs{CredProtect: ptr(CredentialProtectionPolicyUserVerificationOptional)},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credentialProtectionPolicy", "less restrictive"},
+		},
+		{
+			name:     "EnforcedButNotReported",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credentialProtectionPolicy", "did not report the policy"},
+		},
+		{
+			// An authenticator returning no extension outputs at all decodes to a nil receiver.
+			name:     "EnforcedWithNoOutputsAtAll",
+			outputs:  nil,
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credentialProtectionPolicy", "did not report the policy"},
+		},
+		{
+			name:     "EnforcedWithUnknownPolicy",
+			outputs:  &AuthenticatorExtensionOutputs{CredProtect: ptr(CredentialProtectionPolicyUserVerificationRequired)},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicy("nonsense"), EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credentialProtectionPolicy", "not a known policy"},
+		},
+		{
+			// credProtect is a registration extension, so an assertion has nothing to assert.
+			name:     "AssertionIsNotChecked",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: AssertCeremony,
+		},
+		{
+			// An unrecognised ceremony must fail closed, matching the client output guard.
+			name:     "UnknownCeremonyFailsClosed",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: testCeremonyUnknown,
+			errs:     []string{"credentialProtectionPolicy", "did not report the policy"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.outputs.Verify(tc.session, tc.ceremony)
+
+			if len(tc.errs) == 0 {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			for _, fragment := range tc.errs {
+				assert.ErrorContains(t, err, fragment)
+			}
+		})
+	}
+}
+
 func TestParseAuthenticatorExtensionOutputs(t *testing.T) {
 	data, err := webauthncbor.Marshal(map[string]any{
 		"credProtect":  uint64(3),

--- a/protocol/extensions_authenticator_test.go
+++ b/protocol/extensions_authenticator_test.go
@@ -269,6 +269,29 @@ func TestParseAuthenticatorExtensionOutputsUVMMalformed(t *testing.T) {
 	}
 }
 
+func TestParseAuthenticatorExtensionOutputsCredProtectIdentifierPrecedence(t *testing.T) {
+	// Both identifiers assign CredProtect. A map carrying both must not resolve by map iteration order, which
+	// would otherwise make the policy, and therefore the enforcement check in Verify, differ between parses of
+	// byte-identical signed data.
+	data, err := webauthncbor.Marshal(map[string]any{
+		ExtensionCredProtect:                uint64(1),
+		ExtensionCredentialProtectionPolicy: uint64(3),
+	})
+	require.NoError(t, err)
+
+	for range 32 {
+		have, err := ParseAuthenticatorExtensionOutputs(data)
+		require.NoError(t, err)
+
+		require.NotNil(t, have.CredProtect)
+		assert.Equal(t, CredentialProtectionPolicyUserVerificationOptional, *have.CredProtect,
+			"the CTAP identifier authenticators echo must win")
+
+		// The losing value stays visible rather than being silently discarded.
+		assert.Equal(t, uint64(3), have.Extra[ExtensionCredentialProtectionPolicy])
+	}
+}
+
 func TestParseAuthenticatorExtensionOutputsRejectsTrailingBytes(t *testing.T) {
 	// The extension data is the remainder of the authenticator data, so nothing else bounds it. Anything after the
 	// map is unaccounted for and must not be silently ignored.

--- a/protocol/extensions_authenticator_test.go
+++ b/protocol/extensions_authenticator_test.go
@@ -1,0 +1,121 @@
+package protocol
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+)
+
+func TestParseAuthenticatorExtensionOutputs(t *testing.T) {
+	data, err := webauthncbor.Marshal(map[string]any{
+		"credProtect":  uint64(3),
+		"minPinLength": uint64(6),
+		"credBlob":     true,
+		"hmac-secret":  true,
+	})
+	require.NoError(t, err)
+
+	have, err := ParseAuthenticatorExtensionOutputs(data)
+	require.NoError(t, err)
+	require.NotNil(t, have)
+
+	require.NotNil(t, have.CredProtect)
+	assert.Equal(t, CredentialProtectionPolicyUserVerificationRequired, *have.CredProtect)
+
+	require.NotNil(t, have.MinPinLength)
+	assert.Equal(t, uint(6), *have.MinPinLength)
+
+	require.NotNil(t, have.CredBlobSet)
+	assert.True(t, *have.CredBlobSet)
+	assert.Nil(t, have.CredBlob)
+
+	require.NotNil(t, have.HMACSecret)
+	assert.True(t, *have.HMACSecret)
+
+	assert.Empty(t, have.Extra)
+}
+
+func TestParseAuthenticatorExtensionOutputsAssertionForms(t *testing.T) {
+	// credBlob and hmac-secret are polymorphic by ceremony: boolean at registration, byte string at assertion.
+	data, err := webauthncbor.Marshal(map[string]any{
+		"credBlob":    []byte{0x01, 0x02},
+		"hmac-secret": []byte{0x03, 0x04},
+	})
+	require.NoError(t, err)
+
+	have, err := ParseAuthenticatorExtensionOutputs(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, []byte{0x01, 0x02}, have.CredBlob)
+	assert.Nil(t, have.CredBlobSet)
+	assert.Equal(t, []byte{0x03, 0x04}, have.HMACSecretV)
+	assert.Nil(t, have.HMACSecret)
+}
+
+func TestParseAuthenticatorExtensionOutputsUVM(t *testing.T) {
+	data, err := webauthncbor.Marshal(map[string]any{
+		"uvm": []any{
+			[]any{uint64(2), uint64(4), uint64(2)},
+			[]any{uint64(4), uint64(2), uint64(4)},
+		},
+	})
+	require.NoError(t, err)
+
+	have, err := ParseAuthenticatorExtensionOutputs(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, []UserVerificationMethod{
+		{UserVerificationMethod: 2, KeyProtectionType: 4, MatcherProtectionType: 2},
+		{UserVerificationMethod: 4, KeyProtectionType: 2, MatcherProtectionType: 4},
+	}, have.UVM)
+}
+
+func TestParseAuthenticatorExtensionOutputsUVMFieldOutOfRange(t *testing.T) {
+	// A uvm field value that cannot fit in a uint32 is preserved in Extra rather than silently truncated.
+	data, err := webauthncbor.Marshal(map[string]any{
+		"uvm": []any{
+			[]any{uint64(math.MaxUint32) + 1, uint64(4), uint64(2)},
+		},
+	})
+	require.NoError(t, err)
+
+	have, err := ParseAuthenticatorExtensionOutputs(data)
+	require.NoError(t, err)
+
+	assert.Nil(t, have.UVM)
+	require.Contains(t, have.Extra, "uvm")
+}
+
+func TestParseAuthenticatorExtensionOutputsUnknownKey(t *testing.T) {
+	data, err := webauthncbor.Marshal(map[string]any{"vendorThing": "x"})
+	require.NoError(t, err)
+
+	have, err := ParseAuthenticatorExtensionOutputs(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{"vendorThing": "x"}, have.Extra)
+}
+
+func TestParseAuthenticatorExtensionOutputsWrongTypeIsPreserved(t *testing.T) {
+	// A known key carrying an unexpected type is preserved rather than failing the ceremony, so one vendor's odd
+	// encoding cannot break registration for that authenticator.
+	data, err := webauthncbor.Marshal(map[string]any{"minPinLength": "six"})
+	require.NoError(t, err)
+
+	have, err := ParseAuthenticatorExtensionOutputs(data)
+	require.NoError(t, err)
+
+	assert.Nil(t, have.MinPinLength)
+	assert.Equal(t, map[string]any{"minPinLength": "six"}, have.Extra)
+}
+
+func TestParseAuthenticatorExtensionOutputsMalformed(t *testing.T) {
+	// Structurally invalid CBOR is signed data that failed to parse; that is a hard error.
+	_, err := ParseAuthenticatorExtensionOutputs([]byte{0xff, 0xff, 0xff})
+
+	assert.Error(t, err)
+}

--- a/protocol/extensions_authenticator_test.go
+++ b/protocol/extensions_authenticator_test.go
@@ -208,7 +208,7 @@ func TestParseAuthenticatorExtensionOutputsAssertionForms(t *testing.T) {
 
 	assert.Equal(t, []byte{0x01, 0x02}, have.CredBlob)
 	assert.Nil(t, have.CredBlobSet)
-	assert.Equal(t, []byte{0x03, 0x04}, have.HMACSecretV)
+	assert.Equal(t, []byte{0x03, 0x04}, have.HMACSecretOutput)
 	assert.Nil(t, have.HMACSecret)
 }
 
@@ -230,20 +230,61 @@ func TestParseAuthenticatorExtensionOutputsUVM(t *testing.T) {
 	}, have.UVM)
 }
 
-func TestParseAuthenticatorExtensionOutputsUVMFieldOutOfRange(t *testing.T) {
-	// A uvm field value that cannot fit in a uint32 is preserved in Extra rather than silently truncated.
-	data, err := webauthncbor.Marshal(map[string]any{
-		"uvm": []any{
-			[]any{uint64(math.MaxUint32) + 1, uint64(4), uint64(2)},
+func TestParseAuthenticatorExtensionOutputsUVMMalformed(t *testing.T) {
+	// A uvm output this library cannot represent is preserved in Extra rather than silently truncated, dropped, or
+	// failing the whole ceremony.
+	testCases := []struct {
+		name  string
+		value any
+	}{
+		{
+			name:  "FieldOutOfRange",
+			value: []any{[]any{uint64(math.MaxUint32) + 1, uint64(4), uint64(2)}},
 		},
-	})
+		{
+			name:  "NotAList",
+			value: "not-a-list",
+		},
+		{
+			name:  "TooFewFields",
+			value: []any{[]any{uint64(2), uint64(4)}},
+		},
+		{
+			name:  "TooManyFields",
+			value: []any{[]any{uint64(2), uint64(4), uint64(2), uint64(1)}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := webauthncbor.Marshal(map[string]any{"uvm": tc.value})
+			require.NoError(t, err)
+
+			have, err := ParseAuthenticatorExtensionOutputs(data)
+			require.NoError(t, err)
+
+			assert.Nil(t, have.UVM)
+			require.Contains(t, have.Extra, "uvm")
+		})
+	}
+}
+
+func TestParseAuthenticatorExtensionOutputsRejectsTrailingBytes(t *testing.T) {
+	// The extension data is the remainder of the authenticator data, so nothing else bounds it. Anything after the
+	// map is unaccounted for and must not be silently ignored.
+	data, err := webauthncbor.Marshal(map[string]any{"credProtect": uint64(3)})
 	require.NoError(t, err)
 
-	have, err := ParseAuthenticatorExtensionOutputs(data)
-	require.NoError(t, err)
+	have, err := ParseAuthenticatorExtensionOutputs(append(append([]byte{}, data...), 0xff))
 
-	assert.Nil(t, have.UVM)
-	require.Contains(t, have.Extra, "uvm")
+	assert.Nil(t, have)
+	assert.ErrorContains(t, err, "Leftover bytes")
+
+	// A second complete map is the same problem: without the length check the first would silently win.
+	have, err = ParseAuthenticatorExtensionOutputs(append(append([]byte{}, data...), data...))
+
+	assert.Nil(t, have)
+	assert.ErrorContains(t, err, "Leftover bytes")
 }
 
 func TestParseAuthenticatorExtensionOutputsUnknownKey(t *testing.T) {

--- a/protocol/extensions_authenticator_test.go
+++ b/protocol/extensions_authenticator_test.go
@@ -106,6 +106,47 @@ func TestAuthenticatorExtensionOutputsVerify(t *testing.T) {
 			ceremony: testCeremonyUnknown,
 			errs:     []string{"credentialProtectionPolicy", "did not report the policy"},
 		},
+		{
+			name:     "CredBlobStored",
+			outputs:  &AuthenticatorExtensionOutputs{CredBlobSet: ptr(true)},
+			session:  SessionExtensions{CredBlob: true},
+			ceremony: CreateCeremony,
+		},
+		{
+			name:     "CredBlobNotStored",
+			outputs:  &AuthenticatorExtensionOutputs{CredBlobSet: ptr(false)},
+			session:  SessionExtensions{CredBlob: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credBlob", "was not stored"},
+		},
+		{
+			name:     "CredBlobOutcomeMissing",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{CredBlob: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credBlob", "did not report whether it was stored"},
+		},
+		{
+			name:     "CredBlobNotRequested",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+		},
+		{
+			// credBlob is a registration extension, so the authentication arm must not assert the outcome.
+			name:     "CredBlobAssertionIsNotChecked",
+			outputs:  &AuthenticatorExtensionOutputs{},
+			session:  SessionExtensions{CredBlob: true},
+			ceremony: AssertCeremony,
+		},
+		{
+			// Both rules are reported together rather than stopping at the first.
+			name:     "EveryProblemIsReported",
+			outputs:  &AuthenticatorExtensionOutputs{CredBlobSet: ptr(false)},
+			session:  SessionExtensions{CredBlob: true, CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired, EnforceCredentialProtectionPolicy: true},
+			ceremony: CreateCeremony,
+			errs:     []string{"credBlob", "was not stored", "credentialProtectionPolicy", "did not report the policy"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/protocol/extensions_inputs.go
+++ b/protocol/extensions_inputs.go
@@ -107,28 +107,7 @@ func (e AuthenticationExtensions) MarshalJSON() (data []byte, err error) {
 		return nil, err
 	}
 
-	var members map[string]json.RawMessage
-
-	if err = json.Unmarshal(data, &members); err != nil {
-		return nil, err
-	}
-
-	for key, value := range e.Extra {
-		// The check is against the identifier list rather than the marshalled members so a modelled extension is
-		// rejected even when its field is zero and therefore absent from the output. Routing a modelled extension
-		// through the untyped bag would bypass the typed model and be silently dropped on the way back in. The
-		// comparison is case-insensitive because encoding/json would bind a case-variant key to the modelled field
-		// on the way back in; see extensionNameModelled.
-		if extensionNameModelled(extensionInputNames, key) {
-			return nil, fmt.Errorf("error marshalling extension inputs: extra extension %q collides with a modelled extension", key)
-		}
-
-		if members[key], err = json.Marshal(value); err != nil {
-			return nil, fmt.Errorf("error marshalling extension inputs: extra extension %q: %w", key, err)
-		}
-	}
-
-	return json.Marshal(members)
+	return extensionsMarshalExtra(data, extensionInputNames, e.Extra, "extension inputs")
 }
 
 // UnmarshalJSON implements the [json.Unmarshaler] interface, collecting unrecognised members into

--- a/protocol/extensions_inputs.go
+++ b/protocol/extensions_inputs.go
@@ -1,0 +1,349 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// AuthenticationExtensions represents the AuthenticationExtensionsClientInputs IDL. It contains additional
+// parameters requesting additional processing by the client and authenticator.
+//
+// Members are marshalled in the AuthenticationExtensionsClientInputsJSON form, i.e. buffer sources are base64url
+// encoded strings, which is the form consumed by PublicKeyCredential.parseCreationOptionsFromJSON().
+//
+// A JSON member whose key matches a modelled name only by case (e.g. "CredProps" for "credProps") is bound to that
+// modelled field, not collected into [AuthenticationExtensions.Extra]: encoding/json resolves the case-insensitive
+// match during the first decoding pass, before UnmarshalJSON ever sees the untyped member map. If such a member's
+// value has the wrong type for the modelled field, unmarshalling fails outright rather than falling back to Extra.
+// encoding/json (v1, the only version this module may use) offers no way to defer that binding.
+//
+// Specification: §5.7.1. Authentication Extensions Client Inputs (https://www.w3.org/TR/webauthn-3/#iface-authentication-extensions-client-inputs)
+//
+// Specification: §10.1. Client Extensions (https://www.w3.org/TR/webauthn-3/#sctn-defined-client-extensions)
+type AuthenticationExtensions struct {
+	// AppID is the FIDO AppID Extension input. Authentication only.
+	AppID string `json:"appid,omitempty"`
+
+	// AppIDExclude is the FIDO AppID Exclusion Extension input. Registration only.
+	AppIDExclude string `json:"appidExclude,omitempty"`
+
+	// CredProps requests the Credential Properties Extension. Registration only.
+	CredProps bool `json:"credProps,omitempty"`
+
+	// PRF is the Pseudo-random function Extension input. It is a pointer because an empty dictionary is a
+	// meaningful input for this extension and only this extension: a Relying Party sends "prf":{} at registration
+	// to ask whether the pseudo-random function is available for the credential being created, and the client
+	// answers with the 'enabled' output. A value type combined with omitzero cannot express the difference between
+	// an absent member and a member present but empty, so a non-nil pointer to a zero value is what carries the
+	// bare availability probe.
+	PRF *PRFInputs `json:"prf,omitempty"`
+
+	// LargeBlob is the Large blob storage Extension input.
+	LargeBlob LargeBlobInputs `json:"largeBlob,omitzero"`
+
+	// RemoteClientDataJSON is the Remote Client Data JSON Extension input. This member is set by a remote desktop
+	// web client and a Relying Party should not normally set it. See [ExtensionRemoteClientDataJSON].
+	RemoteClientDataJSON string `json:"remoteClientDataJSON,omitempty"`
+
+	// CredentialProtectionPolicy is the CTAP credProtect policy. Registration only.
+	CredentialProtectionPolicy CredentialProtectionPolicy `json:"credentialProtectionPolicy,omitempty"`
+
+	// EnforceCredentialProtectionPolicy requires the credProtect policy is honoured. Registration only.
+	EnforceCredentialProtectionPolicy bool `json:"enforceCredentialProtectionPolicy,omitempty"`
+
+	// MinPinLength requests the authenticator minimum PIN length. Registration only.
+	MinPinLength bool `json:"minPinLength,omitempty"`
+
+	// CredBlob is the blob to store with the credential. Registration only.
+	CredBlob URLEncodedBase64 `json:"credBlob,omitempty"`
+
+	// GetCredBlob requests the blob stored with the credential. Authentication only.
+	GetCredBlob bool `json:"getCredBlob,omitempty"`
+
+	// HMACCreateSecret requests provisioning of the CTAP hmac-secret. Registration only.
+	HMACCreateSecret bool `json:"hmacCreateSecret,omitempty"`
+
+	// HMACGetSecret requests evaluation of the CTAP hmac-secret. Authentication only.
+	HMACGetSecret HMACGetSecretInputs `json:"hmacGetSecret,omitzero"`
+
+	// UVM requests the user verification methods used for the operation.
+	UVM bool `json:"uvm,omitempty"`
+
+	// Extra carries extension inputs this library does not model. Entries are merged into the top-level object
+	// when marshalling and unrecognised members are collected here when unmarshalling. An entry whose key matches
+	// a modelled extension is an error, as the intent would be ambiguous.
+	Extra map[string]any `json:"-"`
+}
+
+// extensionInputNames lists the identifiers of every modelled extension input in the order they are reported by
+// [AuthenticationExtensions.Requested]. Extra keys follow, sorted.
+var extensionInputNames = []string{
+	ExtensionAppID,
+	ExtensionAppIDExclude,
+	ExtensionCredProps,
+	ExtensionPRF,
+	ExtensionLargeBlob,
+	ExtensionRemoteClientDataJSON,
+	ExtensionCredentialProtectionPolicy,
+	ExtensionEnforceCredentialProtectionPolicy,
+	ExtensionMinPinLength,
+	ExtensionCredBlob,
+	ExtensionGetCredBlob,
+	ExtensionHMACCreateSecret,
+	ExtensionHMACGetSecret,
+	ExtensionUVM,
+}
+
+// MarshalJSON implements the [json.Marshaler] interface, merging [AuthenticationExtensions.Extra] into the
+// top-level object. Marshalling always routes through a map so the key ordering does not depend on whether Extra
+// is populated.
+func (e AuthenticationExtensions) MarshalJSON() (data []byte, err error) {
+	type alias AuthenticationExtensions
+
+	if data, err = json.Marshal(alias(e)); err != nil {
+		return nil, err
+	}
+
+	var members map[string]json.RawMessage
+
+	if err = json.Unmarshal(data, &members); err != nil {
+		return nil, err
+	}
+
+	for key, value := range e.Extra {
+		// The check is against the identifier list rather than the marshalled members so a modelled extension is
+		// rejected even when its field is zero and therefore absent from the output. Routing a modelled extension
+		// through the untyped bag would bypass the typed model and be silently dropped on the way back in. The
+		// comparison is case-insensitive because encoding/json would bind a case-variant key to the modelled field
+		// on the way back in; see extensionNameModelled.
+		if extensionNameModelled(extensionInputNames, key) {
+			return nil, fmt.Errorf("error marshalling extension inputs: extra extension %q collides with a modelled extension", key)
+		}
+
+		if members[key], err = json.Marshal(value); err != nil {
+			return nil, fmt.Errorf("error marshalling extension inputs: extra extension %q: %w", key, err)
+		}
+	}
+
+	return json.Marshal(members)
+}
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface, collecting unrecognised members into
+// [AuthenticationExtensions.Extra].
+func (e *AuthenticationExtensions) UnmarshalJSON(data []byte) (err error) {
+	type alias AuthenticationExtensions
+
+	var decoded alias
+
+	if err = json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var members map[string]json.RawMessage
+
+	if err = json.Unmarshal(data, &members); err != nil {
+		return err
+	}
+
+	// Deleting by case-insensitive match (rather than deleting each exact name in extensionInputNames) matters
+	// because the alias decode above already bound a case-variant key (e.g. "CredProps") to its modelled field via
+	// encoding/json's case-insensitive fallback. Deleting only the exact-case name would leave that key in members
+	// and duplicate it into Extra alongside the typed field it was actually bound to.
+	for key := range members {
+		if extensionNameModelled(extensionInputNames, key) {
+			delete(members, key)
+		}
+	}
+
+	if len(members) != 0 {
+		decoded.Extra = make(map[string]any, len(members))
+
+		for key, value := range members {
+			var decodedValue any
+
+			if err = json.Unmarshal(value, &decodedValue); err != nil {
+				return fmt.Errorf("error unmarshalling extension inputs: extra extension %q: %w", key, err)
+			}
+
+			decoded.Extra[key] = decodedValue
+		}
+	}
+
+	*e = AuthenticationExtensions(decoded)
+
+	return nil
+}
+
+// IsZero returns true when no extension input is set. It is used by the encoding/json omitzero tag option so a
+// Relying Party that requests no extensions does not send an empty extensions member to the client.
+//
+// It is defined in terms of [AuthenticationExtensions.Requested] so the two cannot disagree about what "set"
+// means. Requested does not allocate for a zero value, so neither does this.
+func (e AuthenticationExtensions) IsZero() bool {
+	return len(e.Requested()) == 0
+}
+
+// Requested returns the extension identifiers present in these inputs, in specification order followed by the
+// sorted [AuthenticationExtensions.Extra] keys. It returns nil rather than an empty slice when no extension is
+// requested, so the result survives a round trip through an encoding that elides empty collections.
+//
+// The result is stored in [SessionExtensions] and drives the unsolicited output check performed by
+// [AuthenticationExtensionsClientOutputs.Verify].
+func (e AuthenticationExtensions) Requested() (names []string) {
+	for _, present := range []struct {
+		name string
+		set  bool
+	}{
+		{ExtensionAppID, e.AppID != ""},
+		{ExtensionAppIDExclude, e.AppIDExclude != ""},
+		{ExtensionCredProps, e.CredProps},
+		{ExtensionPRF, e.PRF != nil},
+		{ExtensionLargeBlob, !e.LargeBlob.IsZero()},
+		{ExtensionRemoteClientDataJSON, e.RemoteClientDataJSON != ""},
+		{ExtensionCredentialProtectionPolicy, e.CredentialProtectionPolicy != ""},
+		{ExtensionEnforceCredentialProtectionPolicy, e.EnforceCredentialProtectionPolicy},
+		{ExtensionMinPinLength, e.MinPinLength},
+		{ExtensionCredBlob, len(e.CredBlob) != 0},
+		{ExtensionGetCredBlob, e.GetCredBlob},
+		{ExtensionHMACCreateSecret, e.HMACCreateSecret},
+		{ExtensionHMACGetSecret, !e.HMACGetSecret.IsZero()},
+		{ExtensionUVM, e.UVM},
+	} {
+		if present.set {
+			names = append(names, present.name)
+		}
+	}
+
+	return append(names, slices.Sorted(maps.Keys(e.Extra))...)
+}
+
+// Map returns the inputs in their untyped map form, equivalent to the marshalled JSON object. It exists so callers
+// migrating from the previous map-based representation can adapt existing logging, storage, or conformance code
+// incrementally.
+func (e AuthenticationExtensions) Map() (out map[string]any, err error) {
+	var data []byte
+
+	if data, err = json.Marshal(e); err != nil {
+		return nil, err
+	}
+
+	out = map[string]any{}
+
+	if err = json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// ParseAuthenticationExtensions converts a map of extension inputs into typed fields. Recognised identifiers whose
+// values have the wrong type return an error and unrecognised identifiers are placed in
+// [AuthenticationExtensions.Extra].
+//
+// This is the only supported ingress for the untyped map form; no functional option accepts a map, so the coercion
+// is an explicit and fallible step the caller owns.
+func ParseAuthenticationExtensions(in map[string]any) (out AuthenticationExtensions, err error) {
+	var data []byte
+
+	if data, err = json.Marshal(in); err != nil {
+		return out, fmt.Errorf("error parsing extension inputs: %w", err)
+	}
+
+	if err = json.Unmarshal(data, &out); err != nil {
+		var typeErr *json.UnmarshalTypeError
+
+		if errors.As(err, &typeErr) {
+			return AuthenticationExtensions{}, fmt.Errorf("error parsing extension inputs: extension %q: %w", typeErr.Field, err)
+		}
+
+		return AuthenticationExtensions{}, fmt.Errorf("error parsing extension inputs: %w", err)
+	}
+
+	return out, nil
+}
+
+// Validate reports whether these inputs are internally consistent and applicable to the given ceremony. Every
+// problem found is reported, joined with [errors.Join], rather than only the first.
+//
+// Registration-only members are rejected during authentication and authentication-only members are rejected during
+// registration. A ceremony which is neither [CreateCeremony] nor [AssertCeremony] is treated as a registration, so
+// an unexpected value fails closed rather than admitting the authentication-only members unchecked.
+//
+// Members the IDL marks required must also be non-empty when the dictionary containing them is present: the 'first'
+// value of a PRF 'eval' and of every 'evalByCredential' entry, and the 'salt1' value of an 'hmacGetSecret'. Without
+// these the member would be marshalled as a JSON null.
+func (e AuthenticationExtensions) Validate(c CeremonyType) (err error) {
+	var errs []error
+
+	// The comparison is against AssertCeremony rather than CreateCeremony so an unrecognised ceremony is treated as
+	// a registration, mirroring [AuthenticationExtensionsClientOutputs.Verify]. Treating it as an authentication
+	// would instead admit the authentication-only appid, getCredBlob and hmacGetSecret members unchecked.
+	creation := c != AssertCeremony
+
+	for _, rule := range []struct {
+		name         string
+		set          bool
+		registration bool
+	}{
+		{ExtensionAppIDExclude, e.AppIDExclude != "", true},
+		{ExtensionCredProps, e.CredProps, true},
+		{ExtensionCredentialProtectionPolicy, e.CredentialProtectionPolicy != "", true},
+		{ExtensionEnforceCredentialProtectionPolicy, e.EnforceCredentialProtectionPolicy, true},
+		{ExtensionMinPinLength, e.MinPinLength, true},
+		{ExtensionCredBlob, len(e.CredBlob) != 0, true},
+		{ExtensionHMACCreateSecret, e.HMACCreateSecret, true},
+		{ExtensionAppID, e.AppID != "", false},
+		{ExtensionGetCredBlob, e.GetCredBlob, false},
+		{ExtensionHMACGetSecret, !e.HMACGetSecret.IsZero(), false},
+	} {
+		if !rule.set {
+			continue
+		}
+
+		if rule.registration && !creation {
+			errs = append(errs, fmt.Errorf("extension %q is a registration extension but was provided for an authentication ceremony", rule.name))
+		} else if !rule.registration && creation {
+			errs = append(errs, fmt.Errorf("extension %q is an authentication extension but was provided for a registration ceremony", rule.name))
+		}
+	}
+
+	if creation {
+		if e.PRF != nil && len(e.PRF.EvalByCredential) != 0 {
+			errs = append(errs, fmt.Errorf("extension %q member 'evalByCredential' is an authentication extension member but was provided for a registration ceremony", ExtensionPRF))
+		}
+
+		if e.LargeBlob.Read || len(e.LargeBlob.Write) != 0 {
+			errs = append(errs, fmt.Errorf("extension %q members 'read' and 'write' are authentication extension members but were provided for a registration ceremony", ExtensionLargeBlob))
+		}
+	} else if e.LargeBlob.Support != "" {
+		errs = append(errs, fmt.Errorf("extension %q member 'support' is a registration extension member but was provided for an authentication ceremony", ExtensionLargeBlob))
+	}
+
+	// PRFValues is shared between 'eval' and the entries of 'evalByCredential', so the required 'first' member has
+	// to be checked against each use rather than against the type.
+	if e.PRF != nil {
+		if !e.PRF.Eval.IsZero() && len(e.PRF.Eval.First) == 0 {
+			errs = append(errs, fmt.Errorf("extension %q member 'eval' requires a non-empty 'first' value", ExtensionPRF))
+		}
+
+		// The keys are sorted so the reported problems do not depend on the map iteration order.
+		for _, id := range slices.Sorted(maps.Keys(e.PRF.EvalByCredential)) {
+			if len(e.PRF.EvalByCredential[id].First) == 0 {
+				errs = append(errs, fmt.Errorf("extension %q member 'evalByCredential' entry %q requires a non-empty 'first' value", ExtensionPRF, id))
+			}
+		}
+	}
+
+	if !e.HMACGetSecret.IsZero() && len(e.HMACGetSecret.Salt1) == 0 {
+		errs = append(errs, fmt.Errorf("extension %q member 'salt1' requires a non-empty value", ExtensionHMACGetSecret))
+	}
+
+	if len(e.LargeBlob.Write) != 0 && e.LargeBlob.Read {
+		errs = append(errs, fmt.Errorf("extension %q members 'read' and 'write' are mutually exclusive", ExtensionLargeBlob))
+	}
+
+	return errors.Join(errs...)
+}

--- a/protocol/extensions_inputs_test.go
+++ b/protocol/extensions_inputs_test.go
@@ -265,6 +265,7 @@ func TestAuthenticationExtensionsSession(t *testing.T) {
 	assert.Equal(t, "https://example.com", session.AppID)
 	assert.Equal(t, "https://exclude.example.com", session.AppIDExclude)
 	assert.Equal(t, LargeBlobSupportRequired, session.LargeBlob)
+	assert.True(t, session.LargeBlobWrite)
 	assert.Equal(t, map[string]any{"vendorThing": true}, session.Extra)
 	assert.Equal(t, have.Requested(), session.Requested)
 

--- a/protocol/extensions_inputs_test.go
+++ b/protocol/extensions_inputs_test.go
@@ -1,0 +1,488 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCeremonyUnknown is a CeremonyType which is neither CreateCeremony nor AssertCeremony. The ceremony-applicable
+// guards must fail closed against it rather than defaulting to the more permissive branch.
+const testCeremonyUnknown CeremonyType = "webauthn.unrecognised"
+
+func TestAuthenticationExtensionsMarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     AuthenticationExtensions
+		expected string
+	}{
+		{"Empty", AuthenticationExtensions{}, `{}`},
+		{"AppID", AuthenticationExtensions{AppID: "https://example.com"}, `{"appid":"https://example.com"}`},
+		{"CredProps", AuthenticationExtensions{CredProps: true}, `{"credProps":true}`},
+		{
+			"PRFEval",
+			AuthenticationExtensions{PRF: &PRFInputs{Eval: PRFValues{First: []byte("abc")}}},
+			`{"prf":{"eval":{"first":"YWJj"}}}`,
+		},
+		{
+			"PRFBare",
+			AuthenticationExtensions{PRF: &PRFInputs{}},
+			`{"prf":{}}`,
+		},
+		{
+			"LargeBlobSupport",
+			AuthenticationExtensions{LargeBlob: LargeBlobInputs{Support: LargeBlobSupportRequired}},
+			`{"largeBlob":{"support":"required"}}`,
+		},
+		{
+			"Extra",
+			AuthenticationExtensions{CredProps: true, Extra: map[string]any{"vendorThing": true}},
+			`{"credProps":true,"vendorThing":true}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.have)
+
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.expected, string(data))
+		})
+	}
+}
+
+func TestAuthenticationExtensionsMarshalJSONExtraCollision(t *testing.T) {
+	testCases := []struct {
+		name string
+		have AuthenticationExtensions
+		err  string
+	}{
+		{
+			"SetField",
+			AuthenticationExtensions{CredProps: true, Extra: map[string]any{"credProps": false}},
+			`extra extension "credProps" collides with a modelled extension`,
+		},
+		{
+			// A modelled extension routed through Extra must be rejected even when its own field is zero, so it
+			// cannot bypass the typed model. UnmarshalJSON would route the member back to the typed field and drop
+			// the Extra entry, so permitting it would also be silently lossy.
+			"ZeroField",
+			AuthenticationExtensions{Extra: map[string]any{"prf": map[string]any{"eval": map[string]any{"first": "YWJj"}}}},
+			`extra extension "prf" collides with a modelled extension`,
+		},
+		{
+			"ZeroFieldBool",
+			AuthenticationExtensions{Extra: map[string]any{"credProps": true}},
+			`extra extension "credProps" collides with a modelled extension`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := json.Marshal(tc.have)
+
+			assert.ErrorContains(t, err, tc.err)
+		})
+	}
+}
+
+func TestAuthenticationExtensionsExtraCaseInsensitiveCollision(t *testing.T) {
+	var have AuthenticationExtensions
+
+	require.NoError(t, json.Unmarshal([]byte(`{"CredProps":true}`), &have))
+
+	// A case-variant of a modelled name must be bound to that field only, never also collected into Extra:
+	// otherwise Requested would report the same extension twice under two different spellings.
+	assert.True(t, have.CredProps)
+	assert.Nil(t, have.Extra)
+	assert.Equal(t, []string{ExtensionCredProps}, have.Requested())
+}
+
+func TestAuthenticationExtensionsMarshalJSONExtraCollisionCaseVariant(t *testing.T) {
+	have := AuthenticationExtensions{Extra: map[string]any{"CredProps": true}}
+
+	_, err := json.Marshal(have)
+
+	assert.ErrorContains(t, err, `extra extension "CredProps" collides with a modelled extension`)
+}
+
+func TestAuthenticationExtensionsIsZero(t *testing.T) {
+	assert.True(t, AuthenticationExtensions{}.IsZero())
+	assert.Nil(t, AuthenticationExtensions{}.Requested())
+	assert.False(t, AuthenticationExtensions{CredProps: true}.IsZero())
+	assert.False(t, AuthenticationExtensions{Extra: map[string]any{"vendorThing": true}}.IsZero())
+
+	// A zero value must be omitted from the options sent to the client rather than serialised as an empty object.
+	creation, err := json.Marshal(PublicKeyCredentialCreationOptions{Challenge: []byte("1234567890123456")})
+	require.NoError(t, err)
+	assert.NotContains(t, string(creation), "extensions")
+
+	request, err := json.Marshal(PublicKeyCredentialRequestOptions{Challenge: []byte("1234567890123456")})
+	require.NoError(t, err)
+	assert.NotContains(t, string(request), "extensions")
+
+	// A populated value must still be present.
+	creation, err = json.Marshal(PublicKeyCredentialCreationOptions{
+		Challenge:  []byte("1234567890123456"),
+		Extensions: AuthenticationExtensions{CredProps: true},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(creation), `"extensions":{"credProps":true}`)
+}
+
+func TestSessionExtensionsIsZero(t *testing.T) {
+	assert.True(t, SessionExtensions{}.IsZero())
+	assert.False(t, SessionExtensions{Requested: []string{"credProps"}}.IsZero())
+	assert.False(t, SessionExtensions{AppID: "a"}.IsZero())
+	assert.False(t, SessionExtensions{AppIDExclude: "a"}.IsZero())
+	assert.False(t, SessionExtensions{LargeBlob: LargeBlobSupportRequired}.IsZero())
+	assert.False(t, SessionExtensions{Extra: map[string]any{"a": 1}}.IsZero())
+}
+
+func TestAuthenticationExtensionsSessionClonesExtra(t *testing.T) {
+	have := AuthenticationExtensions{Extra: map[string]any{"vendorThing": true}}
+
+	session := have.Session()
+
+	// The session must not alias the live options; mutating one after the begin step must not change the other.
+	have.Extra["vendorThing"] = false
+	have.Extra["added"] = true
+
+	assert.Equal(t, map[string]any{"vendorThing": true}, session.Extra)
+	assert.Nil(t, AuthenticationExtensions{}.Session().Extra)
+}
+
+func TestAuthenticationExtensionsMarshalJSONKeyOrderIsStable(t *testing.T) {
+	// Marshalling always routes through a map so encoding/json sorts the keys. Output ordering must not depend on
+	// whether Extra is populated, otherwise golden comparisons drift.
+	withExtra, err := json.Marshal(AuthenticationExtensions{AppID: "a", CredProps: true, Extra: map[string]any{"zz": 1}})
+	require.NoError(t, err)
+
+	withoutExtra, err := json.Marshal(AuthenticationExtensions{AppID: "a", CredProps: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, `{"appid":"a","credProps":true,"zz":1}`, string(withExtra))
+	assert.Equal(t, `{"appid":"a","credProps":true}`, string(withoutExtra))
+}
+
+func TestAuthenticationExtensionsUnmarshalJSON(t *testing.T) {
+	var have AuthenticationExtensions
+
+	require.NoError(t, json.Unmarshal([]byte(`{"credProps":true,"prf":{"eval":{"first":"YWJj"}},"vendorThing":"x"}`), &have))
+
+	assert.True(t, have.CredProps)
+	assert.Equal(t, []byte("abc"), []byte(have.PRF.Eval.First))
+	assert.Equal(t, map[string]any{"vendorThing": "x"}, have.Extra)
+}
+
+// TestAuthenticationExtensionsPRFBareProbe pins the bare "prf":{} registration probe end to end. The probe is the
+// canonical way to ask a client whether the pseudo-random function is available for a credential, so it must be
+// emittable, must round trip, must be reported by Requested, and must therefore not be rejected as an unsolicited
+// output when the client answers with 'enabled'.
+func TestAuthenticationExtensionsPRFBareProbe(t *testing.T) {
+	have := AuthenticationExtensions{PRF: &PRFInputs{}}
+
+	require.False(t, have.IsZero())
+	assert.Equal(t, []string{ExtensionPRF}, have.Requested())
+	assert.NoError(t, have.Validate(CreateCeremony))
+	assert.NoError(t, have.Validate(AssertCeremony))
+
+	data, err := json.Marshal(have)
+	require.NoError(t, err)
+	assert.Equal(t, `{"prf":{}}`, string(data))
+
+	var decoded AuthenticationExtensions
+
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.PRF)
+	assert.Equal(t, have, decoded)
+	assert.Empty(t, decoded.Extra)
+
+	// The load-bearing consequence: Verify must accept the prf output the probe solicits.
+	outputs := AuthenticationExtensionsClientOutputs{PRF: &PRFOutputs{Enabled: ptr(true)}}
+	assert.NoError(t, outputs.Verify(have.Session(), CreateCeremony, UnsolicitedOutputPolicyReject))
+
+	// An absent prf member remains absent, and its output remains unsolicited.
+	var absent AuthenticationExtensions
+
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &absent))
+	assert.Nil(t, absent.PRF)
+	assert.Empty(t, absent.Requested())
+	assert.ErrorContains(t, outputs.Verify(absent.Session(), CreateCeremony, UnsolicitedOutputPolicyReject), "prf")
+}
+
+func TestAuthenticationExtensionsRequestedMatchesMarshalledKeys(t *testing.T) {
+	// Requested is hand-written per field. This invariant catches it drifting from the codec.
+	testCases := []AuthenticationExtensions{
+		{AppID: "a"},
+		{AppIDExclude: "a"},
+		{CredProps: true},
+		{PRF: &PRFInputs{Eval: PRFValues{First: []byte("a")}}},
+		{LargeBlob: LargeBlobInputs{Read: true}},
+		{RemoteClientDataJSON: "{}"},
+		{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired},
+		{EnforceCredentialProtectionPolicy: true},
+		{MinPinLength: true},
+		{CredBlob: []byte("a")},
+		{GetCredBlob: true},
+		{HMACCreateSecret: true},
+		{HMACGetSecret: HMACGetSecretInputs{Salt1: []byte("a")}},
+		{UVM: true},
+		{Extra: map[string]any{"b": 1, "a": 2}},
+	}
+
+	for _, tc := range testCases {
+		data, err := json.Marshal(tc)
+		require.NoError(t, err)
+
+		var keys map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &keys))
+
+		requested := tc.Requested()
+
+		assert.Len(t, requested, len(keys))
+
+		for _, name := range requested {
+			assert.Contains(t, keys, name)
+		}
+	}
+}
+
+func TestAuthenticationExtensionsSession(t *testing.T) {
+	have := AuthenticationExtensions{
+		AppID:        "https://example.com",
+		AppIDExclude: "https://exclude.example.com",
+		CredProps:    true,
+		PRF:          &PRFInputs{Eval: PRFValues{First: []byte("secret-salt")}},
+		LargeBlob:    LargeBlobInputs{Support: LargeBlobSupportRequired, Write: []byte("a large payload")},
+		Extra:        map[string]any{"vendorThing": true},
+	}
+
+	session := have.Session()
+
+	assert.Equal(t, "https://example.com", session.AppID)
+	assert.Equal(t, "https://exclude.example.com", session.AppIDExclude)
+	assert.Equal(t, LargeBlobSupportRequired, session.LargeBlob)
+	assert.Equal(t, map[string]any{"vendorThing": true}, session.Extra)
+	assert.Equal(t, have.Requested(), session.Requested)
+
+	// The per-ceremony PRF salts and the large blob payload are deliberately not persisted.
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "secret-salt")
+	assert.NotContains(t, string(data), "a large payload")
+}
+
+func TestParseAuthenticationExtensions(t *testing.T) {
+	have, err := ParseAuthenticationExtensions(map[string]any{
+		"credProps":   true,
+		"appid":       "https://example.com",
+		"vendorThing": "x",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, have.CredProps)
+	assert.Equal(t, "https://example.com", have.AppID)
+	assert.Equal(t, map[string]any{"vendorThing": "x"}, have.Extra)
+}
+
+func TestParseAuthenticationExtensionsWrongType(t *testing.T) {
+	_, err := ParseAuthenticationExtensions(map[string]any{"credProps": "yes"})
+
+	assert.ErrorContains(t, err, "credProps")
+}
+
+func TestParseAuthenticationExtensionsRoundTripsThroughMap(t *testing.T) {
+	original := AuthenticationExtensions{
+		AppID:     "https://example.com",
+		CredProps: true,
+		PRF:       &PRFInputs{Eval: PRFValues{First: []byte("abc")}},
+		Extra:     map[string]any{"vendorThing": true},
+	}
+
+	asMap, err := original.Map()
+	require.NoError(t, err)
+
+	parsed, err := ParseAuthenticationExtensions(asMap)
+	require.NoError(t, err)
+
+	assert.Equal(t, original, parsed)
+}
+
+func TestAuthenticationExtensionsValidate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     AuthenticationExtensions
+		ceremony CeremonyType
+		errs     []string
+	}{
+		{"CredPropsCreation", AuthenticationExtensions{CredProps: true}, CreateCeremony, nil},
+		{"CredPropsAssertion", AuthenticationExtensions{CredProps: true}, AssertCeremony, []string{"credProps"}},
+		{"AppIDAssertion", AuthenticationExtensions{AppID: "a"}, AssertCeremony, nil},
+		{"AppIDCreation", AuthenticationExtensions{AppID: "a"}, CreateCeremony, []string{"appid"}},
+		{"AppIDExcludeCreation", AuthenticationExtensions{AppIDExclude: "a"}, CreateCeremony, nil},
+		{"AppIDExcludeAssertion", AuthenticationExtensions{AppIDExclude: "a"}, AssertCeremony, []string{"appidExclude"}},
+		{
+			"CredentialProtectionPolicyCreation",
+			AuthenticationExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired},
+			CreateCeremony,
+			nil,
+		},
+		{
+			"CredentialProtectionPolicyAssertion",
+			AuthenticationExtensions{CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationRequired},
+			AssertCeremony,
+			[]string{"credentialProtectionPolicy"},
+		},
+		{"EnforceCredentialProtectionPolicyCreation", AuthenticationExtensions{EnforceCredentialProtectionPolicy: true}, CreateCeremony, nil},
+		{
+			"EnforceCredentialProtectionPolicyAssertion",
+			AuthenticationExtensions{EnforceCredentialProtectionPolicy: true},
+			AssertCeremony,
+			[]string{"enforceCredentialProtectionPolicy"},
+		},
+		{"MinPinLengthCreation", AuthenticationExtensions{MinPinLength: true}, CreateCeremony, nil},
+		{"MinPinLengthAssertion", AuthenticationExtensions{MinPinLength: true}, AssertCeremony, []string{"minPinLength"}},
+		{"CredBlobCreation", AuthenticationExtensions{CredBlob: []byte("a")}, CreateCeremony, nil},
+		{"CredBlobAssertion", AuthenticationExtensions{CredBlob: []byte("a")}, AssertCeremony, []string{"credBlob"}},
+		{"HMACCreateSecretCreation", AuthenticationExtensions{HMACCreateSecret: true}, CreateCeremony, nil},
+		{"HMACCreateSecretAssertion", AuthenticationExtensions{HMACCreateSecret: true}, AssertCeremony, []string{"hmacCreateSecret"}},
+		{"GetCredBlobAssertion", AuthenticationExtensions{GetCredBlob: true}, AssertCeremony, nil},
+		{"GetCredBlobCreation", AuthenticationExtensions{GetCredBlob: true}, CreateCeremony, []string{"getCredBlob"}},
+		{
+			"HMACGetSecretAssertion",
+			AuthenticationExtensions{HMACGetSecret: HMACGetSecretInputs{Salt1: []byte("a")}},
+			AssertCeremony,
+			nil,
+		},
+		{
+			"HMACGetSecretCreation",
+			AuthenticationExtensions{HMACGetSecret: HMACGetSecretInputs{Salt1: []byte("a")}},
+			CreateCeremony,
+			[]string{"hmacGetSecret"},
+		},
+		{
+			"EvalByCredentialCreation",
+			AuthenticationExtensions{PRF: &PRFInputs{EvalByCredential: map[string]PRFValues{"a": {First: []byte("b")}}}},
+			CreateCeremony,
+			[]string{"prf"},
+		},
+		{
+			"LargeBlobReadCreation",
+			AuthenticationExtensions{LargeBlob: LargeBlobInputs{Read: true}},
+			CreateCeremony,
+			[]string{"largeBlob"},
+		},
+		{
+			"LargeBlobWriteCreation",
+			AuthenticationExtensions{LargeBlob: LargeBlobInputs{Write: []byte("a")}},
+			CreateCeremony,
+			[]string{"largeBlob"},
+		},
+		{
+			"LargeBlobSupportAssertion",
+			AuthenticationExtensions{LargeBlob: LargeBlobInputs{Support: LargeBlobSupportRequired}},
+			AssertCeremony,
+			[]string{"largeBlob"},
+		},
+		{
+			"LargeBlobReadWriteMutuallyExclusive",
+			AuthenticationExtensions{LargeBlob: LargeBlobInputs{Read: true, Write: []byte("a")}},
+			AssertCeremony,
+			[]string{"largeBlob", "mutually exclusive"},
+		},
+		{
+			"PRFEvalMissingFirst",
+			AuthenticationExtensions{PRF: &PRFInputs{Eval: PRFValues{Second: []byte("b")}}},
+			CreateCeremony,
+			[]string{"first"},
+		},
+		{
+			// PRFValues is shared between eval and evalByCredential, so a rule written against eval alone does
+			// not follow the type. Without this the entry marshals "first":null for a required member.
+			"PRFEvalByCredentialMissingFirst",
+			AuthenticationExtensions{PRF: &PRFInputs{EvalByCredential: map[string]PRFValues{"aabb": {Second: []byte("b")}}}},
+			AssertCeremony,
+			[]string{"evalByCredential", "aabb", "first"},
+		},
+		{
+			"PRFEvalByCredentialEmptyEntryMissingFirst",
+			AuthenticationExtensions{PRF: &PRFInputs{EvalByCredential: map[string]PRFValues{"aabb": {}}}},
+			AssertCeremony,
+			[]string{"evalByCredential", "first"},
+		},
+		{
+			"PRFEvalByCredentialAllEntriesReported",
+			AuthenticationExtensions{PRF: &PRFInputs{EvalByCredential: map[string]PRFValues{
+				"aabb": {Second: []byte("b")},
+				"ccdd": {Second: []byte("d")},
+			}}},
+			AssertCeremony,
+			[]string{"aabb", "ccdd"},
+		},
+		{
+			"PRFEvalByCredentialFirstPresent",
+			AuthenticationExtensions{PRF: &PRFInputs{EvalByCredential: map[string]PRFValues{"aabb": {First: []byte("a")}}}},
+			AssertCeremony,
+			nil,
+		},
+		{
+			// Likewise salt1, which the IDL marks required, would otherwise marshal as null.
+			"HMACGetSecretMissingSalt1",
+			AuthenticationExtensions{HMACGetSecret: HMACGetSecretInputs{Salt2: []byte("b")}},
+			AssertCeremony,
+			[]string{"hmacGetSecret", "salt1"},
+		},
+		{
+			"MultipleProblemsAllReported",
+			AuthenticationExtensions{CredProps: true, MinPinLength: true},
+			AssertCeremony,
+			[]string{"credProps", "minPinLength"},
+		},
+
+		// Members valid in both ceremonies: a future over-eager ceremony restriction should fail one of these.
+		{"PRFEvalCreation", AuthenticationExtensions{PRF: &PRFInputs{Eval: PRFValues{First: []byte("a")}}}, CreateCeremony, nil},
+		{"PRFEvalAssertion", AuthenticationExtensions{PRF: &PRFInputs{Eval: PRFValues{First: []byte("a")}}}, AssertCeremony, nil},
+		{"RemoteClientDataJSONCreation", AuthenticationExtensions{RemoteClientDataJSON: "{}"}, CreateCeremony, nil},
+		{"RemoteClientDataJSONAssertion", AuthenticationExtensions{RemoteClientDataJSON: "{}"}, AssertCeremony, nil},
+		{"UVMCreation", AuthenticationExtensions{UVM: true}, CreateCeremony, nil},
+		{"UVMAssertion", AuthenticationExtensions{UVM: true}, AssertCeremony, nil},
+
+		// An unrecognised ceremony is treated as a registration so it fails closed: the authentication-only
+		// members are rejected rather than admitted unchecked.
+		{"AppIDUnknownCeremony", AuthenticationExtensions{AppID: "a"}, testCeremonyUnknown, []string{"appid"}},
+		{"GetCredBlobUnknownCeremony", AuthenticationExtensions{GetCredBlob: true}, testCeremonyUnknown, []string{"getCredBlob"}},
+		{
+			"HMACGetSecretUnknownCeremony",
+			AuthenticationExtensions{HMACGetSecret: HMACGetSecretInputs{Salt1: []byte("a")}},
+			testCeremonyUnknown,
+			[]string{"hmacGetSecret"},
+		},
+		{
+			"EvalByCredentialUnknownCeremony",
+			AuthenticationExtensions{PRF: &PRFInputs{EvalByCredential: map[string]PRFValues{"a": {First: []byte("b")}}}},
+			testCeremonyUnknown,
+			[]string{"prf"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.have.Validate(tc.ceremony)
+
+			if len(tc.errs) == 0 {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+
+			for _, fragment := range tc.errs {
+				assert.ErrorContains(t, err, fragment)
+			}
+		})
+	}
+}

--- a/protocol/extensions_inputs_test.go
+++ b/protocol/extensions_inputs_test.go
@@ -1,7 +1,9 @@
 package protocol
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,6 +156,25 @@ func TestAuthenticationExtensionsSessionClonesExtra(t *testing.T) {
 	assert.Nil(t, AuthenticationExtensions{}.Session().Extra)
 }
 
+func TestAuthenticationExtensionsSessionClonesExtraShallowly(t *testing.T) {
+	// The clone is documented as shallow. This pins that boundary so the guarantee Session actually makes is the
+	// one that is tested: the top level is independent, a nested reference type is not.
+	nested := map[string]any{"inner": "original"}
+	have := AuthenticationExtensions{Extra: map[string]any{"vendorThing": nested}}
+
+	session := have.Session()
+
+	nested["inner"] = "mutated"
+
+	assert.Equal(t, map[string]any{"inner": "mutated"}, session.Extra["vendorThing"],
+		"the clone is shallow, so a nested map stays shared; widening this requires a deep clone, not a test change")
+
+	// The top level is still independent, which is what the clone is there for.
+	have.Extra["added"] = true
+
+	assert.NotContains(t, session.Extra, "added")
+}
+
 func TestAuthenticationExtensionsMarshalJSONKeyOrderIsStable(t *testing.T) {
 	// Marshalling always routes through a map so encoding/json sorts the keys. Output ordering must not depend on
 	// whether Extra is populated, otherwise golden comparisons drift.
@@ -233,20 +254,23 @@ func TestAuthenticationExtensionsRequestedMatchesMarshalledKeys(t *testing.T) {
 		{Extra: map[string]any{"b": 1, "a": 2}},
 	}
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		data, err := json.Marshal(tc)
 		require.NoError(t, err)
 
-		var keys map[string]json.RawMessage
-		require.NoError(t, json.Unmarshal(data, &keys))
+		// The marshalled form names the entry that drifted, which a bare index would not.
+		t.Run(fmt.Sprintf("%d/%s", i, data), func(t *testing.T) {
+			var keys map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(data, &keys))
 
-		requested := tc.Requested()
+			requested := tc.Requested()
 
-		assert.Len(t, requested, len(keys))
+			assert.Len(t, requested, len(keys))
 
-		for _, name := range requested {
-			assert.Contains(t, keys, name)
-		}
+			for _, name := range requested {
+				assert.Contains(t, keys, name)
+			}
+		})
 	}
 }
 
@@ -269,11 +293,17 @@ func TestAuthenticationExtensionsSession(t *testing.T) {
 	assert.Equal(t, map[string]any{"vendorThing": true}, session.Extra)
 	assert.Equal(t, have.Requested(), session.Requested)
 
-	// The per-ceremony PRF salts and the large blob payload are deliberately not persisted.
+	// The per-ceremony PRF salts and the large blob payload are deliberately not persisted. Both are byte values
+	// which would be base64url encoded on the way out, so asserting only against the raw strings would pass even if
+	// they were persisted; the encoded forms are what the assertion has to look for.
 	data, err := json.Marshal(session)
 	require.NoError(t, err)
-	assert.NotContains(t, string(data), "secret-salt")
-	assert.NotContains(t, string(data), "a large payload")
+
+	for _, secret := range [][]byte{[]byte("secret-salt"), []byte("a large payload")} {
+		assert.NotContains(t, string(data), string(secret))
+		assert.NotContains(t, string(data), base64.RawURLEncoding.EncodeToString(secret))
+		assert.NotContains(t, string(data), base64.URLEncoding.EncodeToString(secret))
+	}
 }
 
 func TestParseAuthenticationExtensions(t *testing.T) {

--- a/protocol/extensions_inputs_test.go
+++ b/protocol/extensions_inputs_test.go
@@ -517,3 +517,30 @@ func TestAuthenticationExtensionsValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthenticationExtensionsMapPropagatesMarshalError(t *testing.T) {
+	// Map goes through MarshalJSON, so the collision check it performs has to surface rather than yielding a
+	// partial map the caller would treat as the real inputs.
+	have, err := AuthenticationExtensions{Extra: map[string]any{ExtensionCredProps: true}}.Map()
+
+	assert.Nil(t, have)
+	assert.ErrorContains(t, err, "collides with a modelled extension")
+}
+
+func TestAuthenticationExtensionsMarshalJSONExtraValueError(t *testing.T) {
+	// An Extra value which cannot be marshalled is reported against the extension that carries it, and under the
+	// inputs label rather than the outputs one.
+	_, err := AuthenticationExtensions{Extra: map[string]any{"vendorThing": make(chan int)}}.MarshalJSON()
+
+	assert.ErrorContains(t, err, "extension inputs")
+	assert.ErrorContains(t, err, `"vendorThing"`)
+}
+
+func TestParseAuthenticationExtensionsUnmarshallableInput(t *testing.T) {
+	// The map form is untyped, so it can carry a value encoding/json cannot represent at all. That has to be an
+	// error from the coercion step rather than a panic or a silently empty result.
+	have, err := ParseAuthenticationExtensions(map[string]any{"vendorThing": make(chan int)})
+
+	assert.Equal(t, AuthenticationExtensions{}, have)
+	assert.ErrorContains(t, err, "error parsing extension inputs")
+}

--- a/protocol/extensions_outputs.go
+++ b/protocol/extensions_outputs.go
@@ -1,11 +1,16 @@
 package protocol
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"maps"
 	"slices"
 )
+
+// jsonNull is the encoded form of a JSON null, compared against a raw member value to detect a modelled extension
+// output the client returned without a value.
+var jsonNull = []byte("null")
 
 // AuthenticationExtensionsClientOutputs represents the AuthenticationExtensionsClientOutputs IDL, returned by the
 // client after a create() or get() call.
@@ -49,6 +54,16 @@ type AuthenticationExtensionsClientOutputs struct {
 
 	// Extra carries extension outputs this library does not model.
 	Extra map[string]any `json:"-"`
+
+	// nullModelled lists the modelled extension identifiers the client returned with a JSON null value. A null
+	// leaves the typed field nil, but the member was still present in the response, and
+	// [AuthenticationExtensionsClientOutputs.Verify] must be able to see it: without this an unsolicited modelled
+	// output could evade the unsolicited check simply by being null, while an unsolicited unmodelled one could not,
+	// because a null value in [AuthenticationExtensionsClientOutputs.Extra] is still a key.
+	//
+	// It is decoder state rather than part of the IDL, hence unexported, and is therefore not reproduced by
+	// [AuthenticationExtensionsClientOutputs.MarshalJSON]; a null member does not survive a marshal round trip.
+	nullModelled []string
 }
 
 // CredentialPropertiesOutput represents the CredentialPropertiesOutput IDL. The editor's draft defines no member
@@ -171,11 +186,24 @@ func (o *AuthenticationExtensionsClientOutputs) UnmarshalJSON(data []byte) (err 
 	// because the alias decode above already bound a case-variant key (e.g. "AppID") to its modelled field via
 	// encoding/json's case-insensitive fallback. Deleting only the exact-case name would leave that key in members
 	// and duplicate it into Extra alongside the typed field it was actually bound to.
-	for key := range members {
-		if extensionNameModelled(extensionOutputNames, key) {
-			delete(members, key)
+	//
+	// A modelled member whose value is null leaves the typed field nil, so it is recorded under its canonical
+	// identifier before being deleted; see the nullModelled documentation.
+	for key, value := range members {
+		name, modelled := extensionNameCanonical(extensionOutputNames, key)
+		if !modelled {
+			continue
 		}
+
+		if bytes.Equal(bytes.TrimSpace(value), jsonNull) {
+			decoded.nullModelled = append(decoded.nullModelled, name)
+		}
+
+		delete(members, key)
 	}
+
+	// The map iteration order above is undefined, so the identifiers are sorted to keep Present deterministic.
+	slices.Sort(decoded.nullModelled)
 
 	if len(members) != 0 {
 		decoded.Extra = make(map[string]any, len(members))
@@ -208,6 +236,10 @@ func (o AuthenticationExtensionsClientOutputs) IsZero() bool {
 
 // Present returns the extension identifiers present in these outputs, in specification order followed by the
 // sorted [AuthenticationExtensionsClientOutputs.Extra] keys.
+//
+// A modelled member the client returned as JSON null is present: it leaves the typed field nil, but the client did
+// return the member, and the unsolicited output check must treat it the same as the unmodelled null it would
+// otherwise be inconsistent with.
 func (o AuthenticationExtensionsClientOutputs) Present() (names []string) {
 	for _, present := range []struct {
 		name string
@@ -222,7 +254,7 @@ func (o AuthenticationExtensionsClientOutputs) Present() (names []string) {
 		{ExtensionHMACCreateSecret, o.HMACCreateSecret != nil},
 		{ExtensionHMACGetSecret, o.HMACGetSecret != nil},
 	} {
-		if present.set {
+		if present.set || slices.Contains(o.nullModelled, present.name) {
 			names = append(names, present.name)
 		}
 	}

--- a/protocol/extensions_outputs.go
+++ b/protocol/extensions_outputs.go
@@ -1,0 +1,248 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// AuthenticationExtensionsClientOutputs represents the AuthenticationExtensionsClientOutputs IDL, returned by the
+// client after a create() or get() call.
+//
+// Every modelled member is a pointer so an absent value is distinguishable from a false or empty one; the
+// unsolicited output check performed by [AuthenticationExtensionsClientOutputs.Verify] depends on that distinction.
+//
+// A JSON member whose key matches a modelled name only by case (e.g. "AppID" for "appid") is bound to that
+// modelled field, not collected into [AuthenticationExtensionsClientOutputs.Extra]: encoding/json resolves the
+// case-insensitive match during the first decoding pass, before UnmarshalJSON ever sees the untyped member map. If
+// such a member's value has the wrong type for the modelled field, unmarshalling fails outright rather than
+// falling back to Extra. encoding/json (v1, the only version this module may use) offers no way to defer that
+// binding.
+//
+// Specification: §5.9. Authentication Extensions Client Outputs (https://www.w3.org/TR/webauthn-3/#iface-authentication-extensions-client-outputs)
+type AuthenticationExtensionsClientOutputs struct {
+	// AppID indicates the FIDO AppID Extension was acted upon.
+	AppID *bool `json:"appid,omitempty"`
+
+	// AppIDExclude indicates the FIDO AppID Exclusion Extension was acted upon.
+	AppIDExclude *bool `json:"appidExclude,omitempty"`
+
+	// CredProps reports the properties of a newly created credential.
+	CredProps *CredentialPropertiesOutput `json:"credProps,omitempty"`
+
+	// PRF reports the availability and results of the pseudo-random function extension.
+	PRF *PRFOutputs `json:"prf,omitempty"`
+
+	// LargeBlob reports large blob support at registration, or the read or written blob at authentication.
+	LargeBlob *LargeBlobOutputs `json:"largeBlob,omitempty"`
+
+	// RemoteClientDataJSON indicates the Remote Client Data JSON Extension was acted upon, which means the local
+	// client delegated every Relying Party ID and origin check to a remote host.
+	RemoteClientDataJSON *bool `json:"remoteClientDataJSON,omitempty"`
+
+	// HMACCreateSecret indicates the CTAP hmac-secret was provisioned at registration.
+	HMACCreateSecret *bool `json:"hmacCreateSecret,omitempty"`
+
+	// HMACGetSecret reports the CTAP hmac-secret evaluation results.
+	HMACGetSecret *HMACGetSecretOutputs `json:"hmacGetSecret,omitempty"`
+
+	// Extra carries extension outputs this library does not model.
+	Extra map[string]any `json:"-"`
+}
+
+// CredentialPropertiesOutput represents the CredentialPropertiesOutput IDL. The editor's draft defines no member
+// other than rk.
+//
+// Specification: §10.1.3. Credential Properties Extension (https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension)
+type CredentialPropertiesOutput struct {
+	// RK reports whether the created credential is a client-side discoverable credential. A false value is
+	// meaningful and distinct from the client not reporting the property at all.
+	RK *bool `json:"rk,omitempty"`
+}
+
+// PRFOutputs represents the AuthenticationExtensionsPRFOutputsJSON IDL.
+//
+// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+type PRFOutputs struct {
+	// Enabled reports whether the pseudo-random function is available for the credential. It is the answer to the
+	// bare "prf":{} input a Relying Party sends at registration. A false value is meaningful and distinct from
+	// the client not reporting availability at all.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Results carries the outputs of evaluating the pseudo-random function over the requested salts. Second is
+	// only set when a second salt was supplied.
+	Results *PRFValues `json:"results,omitempty"`
+}
+
+// LargeBlobOutputs represents the AuthenticationExtensionsLargeBlobOutputsJSON IDL.
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+type LargeBlobOutputs struct {
+	// Supported reports whether the created credential supports large blob storage. It is only present at
+	// registration, in answer to the 'support' input. A false value is meaningful and distinct from the client
+	// not reporting support at all; [AuthenticationExtensionsClientOutputs.Verify] rejects both when support was
+	// requested as required.
+	Supported *bool `json:"supported,omitempty"`
+
+	// Blob is the stored blob, present at authentication in answer to a 'read' input.
+	Blob URLEncodedBase64 `json:"blob,omitempty"`
+
+	// Written reports whether the blob supplied by a 'write' input was stored. A false value is meaningful and
+	// distinct from the client not reporting the outcome at all.
+	Written *bool `json:"written,omitempty"`
+}
+
+// HMACGetSecretOutputs represents the outputs of the CTAP hmac-secret extension during authentication.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+type HMACGetSecretOutputs struct {
+	// Output1 is the HMAC secret evaluated over the first salt.
+	Output1 URLEncodedBase64 `json:"output1,omitempty"`
+
+	// Output2 is the HMAC secret evaluated over the second salt, present only when a second salt was supplied.
+	Output2 URLEncodedBase64 `json:"output2,omitempty"`
+}
+
+// extensionOutputNames lists the identifiers of every modelled extension output in the order they are reported by
+// [AuthenticationExtensionsClientOutputs.Present]. Extra keys follow, sorted.
+var extensionOutputNames = []string{
+	ExtensionAppID,
+	ExtensionAppIDExclude,
+	ExtensionCredProps,
+	ExtensionPRF,
+	ExtensionLargeBlob,
+	ExtensionRemoteClientDataJSON,
+	ExtensionHMACCreateSecret,
+	ExtensionHMACGetSecret,
+}
+
+// MarshalJSON implements the [json.Marshaler] interface, merging
+// [AuthenticationExtensionsClientOutputs.Extra] into the top-level object.
+func (o AuthenticationExtensionsClientOutputs) MarshalJSON() (data []byte, err error) {
+	type alias AuthenticationExtensionsClientOutputs
+
+	if data, err = json.Marshal(alias(o)); err != nil {
+		return nil, err
+	}
+
+	var members map[string]json.RawMessage
+
+	if err = json.Unmarshal(data, &members); err != nil {
+		return nil, err
+	}
+
+	for key, value := range o.Extra {
+		// The check is against the identifier list rather than the marshalled members so a modelled extension is
+		// rejected even when its field is zero and therefore absent from the output. Routing a modelled extension
+		// through the untyped bag would bypass the typed model and be silently dropped on the way back in. The
+		// comparison is case-insensitive because encoding/json would bind a case-variant key to the modelled field
+		// on the way back in; see extensionNameModelled.
+		if extensionNameModelled(extensionOutputNames, key) {
+			return nil, fmt.Errorf("error marshalling extension outputs: extra extension %q collides with a modelled extension", key)
+		}
+
+		if members[key], err = json.Marshal(value); err != nil {
+			return nil, fmt.Errorf("error marshalling extension outputs: extra extension %q: %w", key, err)
+		}
+	}
+
+	return json.Marshal(members)
+}
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface, collecting unrecognised members into
+// [AuthenticationExtensionsClientOutputs.Extra].
+func (o *AuthenticationExtensionsClientOutputs) UnmarshalJSON(data []byte) (err error) {
+	type alias AuthenticationExtensionsClientOutputs
+
+	var decoded alias
+
+	if err = json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var members map[string]json.RawMessage
+
+	if err = json.Unmarshal(data, &members); err != nil {
+		return err
+	}
+
+	// Deleting by case-insensitive match (rather than deleting each exact name in extensionOutputNames) matters
+	// because the alias decode above already bound a case-variant key (e.g. "AppID") to its modelled field via
+	// encoding/json's case-insensitive fallback. Deleting only the exact-case name would leave that key in members
+	// and duplicate it into Extra alongside the typed field it was actually bound to.
+	for key := range members {
+		if extensionNameModelled(extensionOutputNames, key) {
+			delete(members, key)
+		}
+	}
+
+	if len(members) != 0 {
+		decoded.Extra = make(map[string]any, len(members))
+
+		for key, value := range members {
+			var decodedValue any
+
+			if err = json.Unmarshal(value, &decodedValue); err != nil {
+				return fmt.Errorf("error unmarshalling extension outputs: extra extension %q: %w", key, err)
+			}
+
+			decoded.Extra[key] = decodedValue
+		}
+	}
+
+	*o = AuthenticationExtensionsClientOutputs(decoded)
+
+	return nil
+}
+
+// IsZero returns true when no extension output is set. It is used by the encoding/json omitzero tag option so a
+// [ParsedPublicKeyCredential] or [PublicKeyCredential] whose client reported no extension output does not marshal
+// an empty clientExtensionResults member.
+//
+// It is defined in terms of [AuthenticationExtensionsClientOutputs.Present] so the two cannot disagree about what
+// "set" means.
+func (o AuthenticationExtensionsClientOutputs) IsZero() bool {
+	return len(o.Present()) == 0
+}
+
+// Present returns the extension identifiers present in these outputs, in specification order followed by the
+// sorted [AuthenticationExtensionsClientOutputs.Extra] keys.
+func (o AuthenticationExtensionsClientOutputs) Present() (names []string) {
+	for _, present := range []struct {
+		name string
+		set  bool
+	}{
+		{ExtensionAppID, o.AppID != nil},
+		{ExtensionAppIDExclude, o.AppIDExclude != nil},
+		{ExtensionCredProps, o.CredProps != nil},
+		{ExtensionPRF, o.PRF != nil},
+		{ExtensionLargeBlob, o.LargeBlob != nil},
+		{ExtensionRemoteClientDataJSON, o.RemoteClientDataJSON != nil},
+		{ExtensionHMACCreateSecret, o.HMACCreateSecret != nil},
+		{ExtensionHMACGetSecret, o.HMACGetSecret != nil},
+	} {
+		if present.set {
+			names = append(names, present.name)
+		}
+	}
+
+	return append(names, slices.Sorted(maps.Keys(o.Extra))...)
+}
+
+// Map returns the outputs in their untyped map form, equivalent to the marshalled JSON object.
+func (o AuthenticationExtensionsClientOutputs) Map() (out map[string]any, err error) {
+	var data []byte
+
+	if data, err = json.Marshal(o); err != nil {
+		return nil, err
+	}
+
+	out = map[string]any{}
+
+	if err = json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/protocol/extensions_outputs.go
+++ b/protocol/extensions_outputs.go
@@ -141,28 +141,7 @@ func (o AuthenticationExtensionsClientOutputs) MarshalJSON() (data []byte, err e
 		return nil, err
 	}
 
-	var members map[string]json.RawMessage
-
-	if err = json.Unmarshal(data, &members); err != nil {
-		return nil, err
-	}
-
-	for key, value := range o.Extra {
-		// The check is against the identifier list rather than the marshalled members so a modelled extension is
-		// rejected even when its field is zero and therefore absent from the output. Routing a modelled extension
-		// through the untyped bag would bypass the typed model and be silently dropped on the way back in. The
-		// comparison is case-insensitive because encoding/json would bind a case-variant key to the modelled field
-		// on the way back in; see extensionNameModelled.
-		if extensionNameModelled(extensionOutputNames, key) {
-			return nil, fmt.Errorf("error marshalling extension outputs: extra extension %q collides with a modelled extension", key)
-		}
-
-		if members[key], err = json.Marshal(value); err != nil {
-			return nil, fmt.Errorf("error marshalling extension outputs: extra extension %q: %w", key, err)
-		}
-	}
-
-	return json.Marshal(members)
+	return extensionsMarshalExtra(data, extensionOutputNames, o.Extra, "extension outputs")
 }
 
 // UnmarshalJSON implements the [json.Unmarshaler] interface, collecting unrecognised members into

--- a/protocol/extensions_outputs_test.go
+++ b/protocol/extensions_outputs_test.go
@@ -1,0 +1,140 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientOutputsUnmarshalJSON(t *testing.T) {
+	var have AuthenticationExtensionsClientOutputs
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"appid": true,
+		"credProps": {"rk": false},
+		"prf": {"enabled": true, "results": {"first": "YWJj"}},
+		"largeBlob": {"supported": true},
+		"vendorThing": 7
+	}`), &have))
+
+	require.NotNil(t, have.AppID)
+	assert.True(t, *have.AppID)
+
+	require.NotNil(t, have.CredProps)
+	require.NotNil(t, have.CredProps.RK)
+	assert.False(t, *have.CredProps.RK, "rk false must be distinguishable from absent")
+
+	require.NotNil(t, have.PRF)
+	assert.True(t, *have.PRF.Enabled)
+	assert.Equal(t, []byte("abc"), []byte(have.PRF.Results.First))
+
+	require.NotNil(t, have.LargeBlob)
+	assert.True(t, *have.LargeBlob.Supported)
+
+	assert.Equal(t, map[string]any{"vendorThing": float64(7)}, have.Extra)
+}
+
+func TestClientOutputsAbsentIsNotFalse(t *testing.T) {
+	var have AuthenticationExtensionsClientOutputs
+
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &have))
+
+	assert.Nil(t, have.AppID)
+	assert.Nil(t, have.CredProps)
+	assert.Empty(t, have.Present())
+}
+
+func TestClientOutputsPresent(t *testing.T) {
+	have := AuthenticationExtensionsClientOutputs{
+		AppID:     ptr(false),
+		CredProps: &CredentialPropertiesOutput{RK: ptr(true)},
+		Extra:     map[string]any{"vendorThing": 1},
+	}
+
+	assert.Equal(t, []string{ExtensionAppID, ExtensionCredProps, "vendorThing"}, have.Present())
+}
+
+func TestClientOutputsRoundTrip(t *testing.T) {
+	original := AuthenticationExtensionsClientOutputs{
+		PRF:   &PRFOutputs{Enabled: ptr(true)},
+		Extra: map[string]any{"vendorThing": "x"},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded AuthenticationExtensionsClientOutputs
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, original, decoded)
+}
+
+func TestClientOutputsAppIDWrongType(t *testing.T) {
+	var outputs AuthenticationExtensionsClientOutputs
+
+	err := json.Unmarshal([]byte(`{"appid":"not-a-bool"}`), &outputs)
+
+	var typeErr *json.UnmarshalTypeError
+	require.ErrorAs(t, err, &typeErr, "must fail with the standard library's typed unmarshal error, not merely some error mentioning the field")
+	assert.Equal(t, "appid", typeErr.Field)
+}
+
+func TestClientOutputsAppIDWrongTypeCaseVariant(t *testing.T) {
+	// encoding/json binds "appID" to the appid field via its case-insensitive tag fallback before UnmarshalJSON's
+	// Extra split ever runs, so a case-variant key with an incompatible value still fails the whole unmarshal
+	// rather than being collected into Extra. This is inherent to encoding/json v1 (see the type doc comment) and
+	// must not be silently hidden by, say, a fixture rename that only exercises the exact-case key.
+	var outputs AuthenticationExtensionsClientOutputs
+
+	err := json.Unmarshal([]byte(`{"appID":"not-a-bool"}`), &outputs)
+
+	var typeErr *json.UnmarshalTypeError
+	require.ErrorAs(t, err, &typeErr)
+}
+
+func TestClientOutputsExtraCaseInsensitiveCollision(t *testing.T) {
+	var have AuthenticationExtensionsClientOutputs
+
+	require.NoError(t, json.Unmarshal([]byte(`{"appID":true}`), &have))
+
+	require.NotNil(t, have.AppID)
+	assert.True(t, *have.AppID)
+
+	// A case-variant of a modelled name must be bound to that field only, never also collected into Extra: the
+	// unsolicited output check in Present must not report the same output twice under two different spellings.
+	assert.Nil(t, have.Extra)
+	assert.Equal(t, []string{ExtensionAppID}, have.Present())
+}
+
+func TestClientOutputsMarshalJSONExtraCollisionCaseVariant(t *testing.T) {
+	have := AuthenticationExtensionsClientOutputs{
+		Extra: map[string]any{"CredProps": true},
+	}
+
+	_, err := json.Marshal(have)
+
+	assert.ErrorContains(t, err, `extra extension "CredProps" collides with a modelled extension`)
+}
+
+func TestClientOutputsIsZero(t *testing.T) {
+	assert.True(t, AuthenticationExtensionsClientOutputs{}.IsZero())
+	assert.Empty(t, AuthenticationExtensionsClientOutputs{}.Present())
+	assert.False(t, AuthenticationExtensionsClientOutputs{AppID: ptr(false)}.IsZero())
+	assert.False(t, AuthenticationExtensionsClientOutputs{Extra: map[string]any{"vendorThing": true}}.IsZero())
+
+	// A zero value must be omitted from a marshalled credential rather than serialised as an empty object; without
+	// the omitzero tag this would always emit "clientExtensionResults":{}.
+	data, err := json.Marshal(ParsedPublicKeyCredential{ParsedCredential: ParsedCredential{ID: "a", Type: "public-key"}})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "clientExtensionResults")
+
+	// A populated value must still be present.
+	data, err = json.Marshal(ParsedPublicKeyCredential{
+		ParsedCredential:       ParsedCredential{ID: "a", Type: "public-key"},
+		ClientExtensionResults: AuthenticationExtensionsClientOutputs{AppID: ptr(true)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"clientExtensionResults":{"appid":true}`)
+}

--- a/protocol/extensions_outputs_test.go
+++ b/protocol/extensions_outputs_test.go
@@ -138,3 +138,42 @@ func TestClientOutputsIsZero(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"clientExtensionResults":{"appid":true}`)
 }
+
+func TestClientOutputsMap(t *testing.T) {
+	// Map is the untyped view callers migrating from the previous map representation use, so it has to agree with
+	// the marshalled JSON, including the merged Extra members.
+	outputs := AuthenticationExtensionsClientOutputs{
+		AppID:     ptr(true),
+		CredProps: &CredentialPropertiesOutput{RK: ptr(false)},
+		Extra:     map[string]any{"vendorThing": "x"},
+	}
+
+	have, err := outputs.Map()
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"appid":       true,
+		"credProps":   map[string]any{"rk": false},
+		"vendorThing": "x",
+	}, have)
+}
+
+func TestClientOutputsMapPropagatesMarshalError(t *testing.T) {
+	// Map goes through MarshalJSON, so the collision check it performs has to surface rather than yielding a
+	// partial map.
+	outputs := AuthenticationExtensionsClientOutputs{Extra: map[string]any{ExtensionCredProps: true}}
+
+	have, err := outputs.Map()
+
+	assert.Nil(t, have)
+	assert.ErrorContains(t, err, "collides with a modelled extension")
+}
+
+func TestClientOutputsMarshalJSONExtraValueError(t *testing.T) {
+	// An Extra value which cannot be marshalled is reported against the extension that carries it, rather than
+	// failing with an error that does not say which member was at fault.
+	_, err := AuthenticationExtensionsClientOutputs{Extra: map[string]any{"vendorThing": make(chan int)}}.MarshalJSON()
+
+	assert.ErrorContains(t, err, "extension outputs")
+	assert.ErrorContains(t, err, `"vendorThing"`)
+}

--- a/protocol/extensions_session.go
+++ b/protocol/extensions_session.go
@@ -66,6 +66,13 @@ func (e SessionExtensions) IsZero() bool {
 //
 // Extra is cloned so the persisted session and the live options do not share a backing map; mutating the inputs
 // after the begin step must not retroactively change what the finish step verifies against.
+//
+// The clone is shallow. A value inside Extra which is itself a reference type stays shared with the inputs, so a
+// Relying Party which mutates a nested map or slice after the begin step does change what the finish step sees.
+// Extra holds Relying Party data rather than anything an attacker supplies, and a deep clone of an arbitrary value
+// cannot be done without either reflection or a serialisation round trip, so the boundary is documented instead of
+// widened. Persisting the session, as a Relying Party is required to do between the two steps, is itself a
+// serialisation and does not carry the sharing with it.
 func (e AuthenticationExtensions) Session() SessionExtensions {
 	return SessionExtensions{
 		Requested:                         e.Requested(),

--- a/protocol/extensions_session.go
+++ b/protocol/extensions_session.go
@@ -44,6 +44,11 @@ type SessionExtensions struct {
 	// EnforceCredentialProtectionPolicy records that the requested credential protection policy must be honoured.
 	EnforceCredentialProtectionPolicy bool `json:"enforceCredentialProtectionPolicy,omitempty"`
 
+	// CredBlob records that a blob was submitted for storage with the credential at registration. As with
+	// LargeBlobWrite only the intent is recorded, because the blob is Relying Party data with no verification role
+	// beyond this flag.
+	CredBlob bool `json:"credBlob,omitempty"`
+
 	// Extra carries the inputs of extensions this library does not model, so a Relying Party can verify the
 	// outputs of its own extensions. Whatever is placed here is persisted verbatim; keep it small.
 	Extra map[string]any `json:"extra,omitempty"`
@@ -53,7 +58,7 @@ type SessionExtensions struct {
 func (e SessionExtensions) IsZero() bool {
 	return len(e.Requested) == 0 && e.AppID == "" && e.AppIDExclude == "" && e.LargeBlob == "" && !e.LargeBlobRead &&
 		!e.LargeBlobWrite && e.CredentialProtectionPolicy == "" && !e.EnforceCredentialProtectionPolicy &&
-		len(e.Extra) == 0
+		!e.CredBlob && len(e.Extra) == 0
 }
 
 // Session returns the subset of these inputs that must be persisted in the session for the finish step of the
@@ -71,6 +76,7 @@ func (e AuthenticationExtensions) Session() SessionExtensions {
 		LargeBlobWrite:                    len(e.LargeBlob.Write) != 0,
 		CredentialProtectionPolicy:        e.CredentialProtectionPolicy,
 		EnforceCredentialProtectionPolicy: e.EnforceCredentialProtectionPolicy,
+		CredBlob:                          len(e.CredBlob) != 0,
 		Extra:                             maps.Clone(e.Extra),
 	}
 }

--- a/protocol/extensions_session.go
+++ b/protocol/extensions_session.go
@@ -1,0 +1,122 @@
+package protocol
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// SessionExtensions is the subset of [AuthenticationExtensions] a Relying Party must persist between the begin and
+// finish steps of a ceremony in order to verify the extension outputs it receives.
+//
+// The per-ceremony PRF salts and the large blob write payload are deliberately excluded. The salts are secrets with
+// no verification role and the payload can be large; both are represented by their identifier in Requested.
+type SessionExtensions struct {
+	// Requested lists the extension identifiers the Relying Party asked for, as reported by
+	// [AuthenticationExtensions.Requested]. An extension output whose identifier is absent from this list was not
+	// solicited.
+	Requested []string `json:"requested,omitempty"`
+
+	// AppID is the FIDO AppID Extension input, required to determine the Relying Party ID of a credential
+	// registered through the legacy FIDO U2F JavaScript API.
+	AppID string `json:"appid,omitempty"`
+
+	// AppIDExclude is the FIDO AppID Exclusion Extension input.
+	AppIDExclude string `json:"appidExclude,omitempty"`
+
+	// LargeBlob is the large blob support requirement requested at registration. A value of
+	// [LargeBlobSupportRequired] is asserted against the extension output.
+	LargeBlob LargeBlobSupport `json:"largeBlob,omitempty"`
+
+	// Extra carries the inputs of extensions this library does not model, so a Relying Party can verify the
+	// outputs of its own extensions. Whatever is placed here is persisted verbatim; keep it small.
+	Extra map[string]any `json:"extra,omitempty"`
+}
+
+// IsZero returns true when nothing needs to be persisted. It is used by the encoding/json omitzero tag option.
+func (e SessionExtensions) IsZero() bool {
+	return len(e.Requested) == 0 && e.AppID == "" && e.AppIDExclude == "" && e.LargeBlob == "" && len(e.Extra) == 0
+}
+
+// Session returns the subset of these inputs that must be persisted in the session for the finish step of the
+// ceremony to verify the extension outputs.
+//
+// Extra is cloned so the persisted session and the live options do not share a backing map; mutating the inputs
+// after the begin step must not retroactively change what the finish step verifies against.
+func (e AuthenticationExtensions) Session() SessionExtensions {
+	return SessionExtensions{
+		Requested:    e.Requested(),
+		AppID:        e.AppID,
+		AppIDExclude: e.AppIDExclude,
+		LargeBlob:    e.LargeBlob.Support,
+		Extra:        maps.Clone(e.Extra),
+	}
+}
+
+// UnsolicitedOutputPolicy determines how a client extension output that the Relying Party did not request is
+// handled during the finish step of a ceremony.
+type UnsolicitedOutputPolicy int
+
+const (
+	// UnsolicitedOutputPolicyReject fails the ceremony when the client returns an extension output the Relying
+	// Party did not request. This is the zero value and therefore the default.
+	UnsolicitedOutputPolicyReject UnsolicitedOutputPolicy = iota
+
+	// UnsolicitedOutputPolicyIgnore accepts and ignores extension outputs the Relying Party did not request. Use
+	// this only when a client is known to return outputs unprompted.
+	UnsolicitedOutputPolicyIgnore
+)
+
+// Verify checks these client extension outputs against the extensions recorded in the session.
+//
+// Two rules are enforced. First, every present output must correspond to an extension the Relying Party requested;
+// keys of [AuthenticationExtensionsClientOutputs.Extra] participate on equal terms with the modelled members. This
+// subsumes ceremony applicability, because an output that cannot be requested for a ceremony cannot have been
+// requested at all. Second, a registration that required large blob support must have received it.
+//
+// Every problem found is reported rather than only the first. The result is an [Error] whose details name every
+// problem and whose cause is the [errors.Join] of them, so [errors.As] and [errors.Is] reach each one individually.
+//
+// A ceremony which is neither [CreateCeremony] nor [AssertCeremony] is treated as a registration, so an unexpected
+// value fails closed against the required large blob support assertion rather than skipping it.
+//
+// The appid value path is not handled here; see [ParsedPublicKeyCredential.GetAppID].
+//
+// Specification: §7.1. Registering a New Credential (https://www.w3.org/TR/webauthn-3/#sctn-registering-a-new-credential)
+//
+// Specification: §7.2. Verifying an Authentication Assertion (https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion)
+func (o AuthenticationExtensionsClientOutputs) Verify(session SessionExtensions, ceremony CeremonyType, policy UnsolicitedOutputPolicy) error {
+	var errs []error
+
+	if policy != UnsolicitedOutputPolicyIgnore {
+		for _, name := range o.Present() {
+			if !slices.Contains(session.Requested, name) {
+				errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("Client returned the %q extension output which was not requested", name)))
+			}
+		}
+	}
+
+	// The guard is written against AssertCeremony rather than CreateCeremony so an unrecognised ceremony still has
+	// the required-support assertion applied, matching the policy guard above. Verify is exported, so the ceremony
+	// is not necessarily one this package produced.
+	if ceremony != AssertCeremony && session.LargeBlob == LargeBlobSupportRequired {
+		if o.LargeBlob == nil || o.LargeBlob.Supported == nil || !*o.LargeBlob.Supported {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with support required but the client did not report it as supported", ExtensionLargeBlob)))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// errors.Join always wraps, even for a single error, so returning it directly would make this the only failure
+	// path out of the finish step which does not yield an *Error. The joined error is kept as the cause, so
+	// errors.As and errors.Is still reach each individual problem, and every problem is also named in the details.
+	joined := errors.Join(errs...)
+
+	return ErrBadRequest.
+		WithDetails(fmt.Sprintf("Error validating the client extension outputs: %s", strings.ReplaceAll(joined.Error(), "\n", "; "))).
+		WithError(joined)
+}

--- a/protocol/extensions_session.go
+++ b/protocol/extensions_session.go
@@ -30,6 +30,20 @@ type SessionExtensions struct {
 	// [LargeBlobSupportRequired] is asserted against the extension output.
 	LargeBlob LargeBlobSupport `json:"largeBlob,omitempty"`
 
+	// LargeBlobRead records that a large blob read was requested at authentication.
+	LargeBlobRead bool `json:"largeBlobRead,omitempty"`
+
+	// LargeBlobWrite records that a large blob write was requested at authentication. Only the intent is recorded;
+	// the payload itself is excluded because it can be large and has no verification role beyond this flag.
+	LargeBlobWrite bool `json:"largeBlobWrite,omitempty"`
+
+	// CredentialProtectionPolicy is the CTAP credProtect policy requested at registration. It is asserted against
+	// the authenticator extension output when EnforceCredentialProtectionPolicy is set.
+	CredentialProtectionPolicy CredentialProtectionPolicy `json:"credentialProtectionPolicy,omitempty"`
+
+	// EnforceCredentialProtectionPolicy records that the requested credential protection policy must be honoured.
+	EnforceCredentialProtectionPolicy bool `json:"enforceCredentialProtectionPolicy,omitempty"`
+
 	// Extra carries the inputs of extensions this library does not model, so a Relying Party can verify the
 	// outputs of its own extensions. Whatever is placed here is persisted verbatim; keep it small.
 	Extra map[string]any `json:"extra,omitempty"`
@@ -37,7 +51,9 @@ type SessionExtensions struct {
 
 // IsZero returns true when nothing needs to be persisted. It is used by the encoding/json omitzero tag option.
 func (e SessionExtensions) IsZero() bool {
-	return len(e.Requested) == 0 && e.AppID == "" && e.AppIDExclude == "" && e.LargeBlob == "" && len(e.Extra) == 0
+	return len(e.Requested) == 0 && e.AppID == "" && e.AppIDExclude == "" && e.LargeBlob == "" && !e.LargeBlobRead &&
+		!e.LargeBlobWrite && e.CredentialProtectionPolicy == "" && !e.EnforceCredentialProtectionPolicy &&
+		len(e.Extra) == 0
 }
 
 // Session returns the subset of these inputs that must be persisted in the session for the finish step of the
@@ -47,11 +63,15 @@ func (e SessionExtensions) IsZero() bool {
 // after the begin step must not retroactively change what the finish step verifies against.
 func (e AuthenticationExtensions) Session() SessionExtensions {
 	return SessionExtensions{
-		Requested:    e.Requested(),
-		AppID:        e.AppID,
-		AppIDExclude: e.AppIDExclude,
-		LargeBlob:    e.LargeBlob.Support,
-		Extra:        maps.Clone(e.Extra),
+		Requested:                         e.Requested(),
+		AppID:                             e.AppID,
+		AppIDExclude:                      e.AppIDExclude,
+		LargeBlob:                         e.LargeBlob.Support,
+		LargeBlobRead:                     e.LargeBlob.Read,
+		LargeBlobWrite:                    len(e.LargeBlob.Write) != 0,
+		CredentialProtectionPolicy:        e.CredentialProtectionPolicy,
+		EnforceCredentialProtectionPolicy: e.EnforceCredentialProtectionPolicy,
+		Extra:                             maps.Clone(e.Extra),
 	}
 }
 
@@ -101,10 +121,14 @@ func (o AuthenticationExtensionsClientOutputs) Verify(session SessionExtensions,
 	// The guard is written against AssertCeremony rather than CreateCeremony so an unrecognised ceremony still has
 	// the required-support assertion applied, matching the policy guard above. Verify is exported, so the ceremony
 	// is not necessarily one this package produced.
-	if ceremony != AssertCeremony && session.LargeBlob == LargeBlobSupportRequired {
-		if o.LargeBlob == nil || o.LargeBlob.Supported == nil || !*o.LargeBlob.Supported {
-			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with support required but the client did not report it as supported", ExtensionLargeBlob)))
+	if ceremony != AssertCeremony {
+		if session.LargeBlob == LargeBlobSupportRequired {
+			if o.LargeBlob == nil || o.LargeBlob.Supported == nil || !*o.LargeBlob.Supported {
+				errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with support required but the client did not report it as supported", ExtensionLargeBlob)))
+			}
 		}
+	} else {
+		errs = append(errs, o.verifyLargeBlobAssertion(session)...)
 	}
 
 	if len(errs) == 0 {
@@ -119,4 +143,37 @@ func (o AuthenticationExtensionsClientOutputs) Verify(session SessionExtensions,
 	return ErrBadRequest.
 		WithDetails(fmt.Sprintf("Error validating the client extension outputs: %s", strings.ReplaceAll(joined.Error(), "\n", "; "))).
 		WithError(joined)
+}
+
+// verifyLargeBlobAssertion checks the large blob outputs of an authentication ceremony against the read or write
+// that was requested. The unsolicited output check only establishes that the extension was requested at all; the
+// read and write arms produce disjoint outputs, so which one was asked for still has to be asserted.
+//
+// A write that the client reports as not performed is an error. The assertion itself is cryptographically sound at
+// this point, so the alternative is to return a successful login to a Relying Party which believes its blob was
+// stored when it was not.
+//
+// A read is not required to produce a blob: a credential with nothing stored yields an empty output, which is a
+// legitimate result rather than a failure.
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+func (o AuthenticationExtensionsClientOutputs) verifyLargeBlobAssertion(session SessionExtensions) (errs []error) {
+	switch {
+	case session.LargeBlobWrite:
+		if o.LargeBlob == nil || o.LargeBlob.Written == nil {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with a blob to write but the client did not report whether it was written", ExtensionLargeBlob)))
+		} else if !*o.LargeBlob.Written {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with a blob to write but the client reported it was not written", ExtensionLargeBlob)))
+		}
+
+		if o.LargeBlob != nil && len(o.LargeBlob.Blob) != 0 {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with a blob to write but the client returned a blob it read", ExtensionLargeBlob)))
+		}
+	case session.LargeBlobRead:
+		if o.LargeBlob != nil && o.LargeBlob.Written != nil {
+			errs = append(errs, ErrBadRequest.WithDetails(fmt.Sprintf("The %q extension was requested with a blob to read but the client reported the outcome of a write", ExtensionLargeBlob)))
+		}
+	}
+
+	return errs
 }

--- a/protocol/extensions_session_test.go
+++ b/protocol/extensions_session_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -10,6 +11,16 @@ import (
 
 // The verification rules are only as good as what Session records for them, and the read and write arms are
 // derived rather than copied, so the derivation is asserted directly.
+// testOutputsFromJSON decodes outputs through the real codec, which is the only way to construct the presence
+// state a JSON null produces; a struct literal cannot express it.
+func testOutputsFromJSON(t *testing.T, data string) (outputs AuthenticationExtensionsClientOutputs) {
+	t.Helper()
+
+	require.NoError(t, json.Unmarshal([]byte(data), &outputs))
+
+	return outputs
+}
+
 func TestAuthenticationExtensionsSessionDerivation(t *testing.T) {
 	t.Run("LargeBlobRead", func(t *testing.T) {
 		session := AuthenticationExtensions{LargeBlob: LargeBlobInputs{Read: true}}.Session()
@@ -53,10 +64,16 @@ func TestAuthenticationExtensionsSessionDerivation(t *testing.T) {
 		assert.True(t, session.CredBlob)
 
 		// The blob is Relying Party data with no verification role beyond the flag, so it must not be persisted.
+		// It is a byte value, so the encoded forms have to be checked as well as the raw one; a raw-only assertion
+		// would pass even if the blob were persisted, because it would appear base64url encoded.
 		data, err := json.Marshal(session)
 		require.NoError(t, err)
 
-		assert.NotContains(t, string(data), "a blob")
+		blob := []byte("a blob")
+
+		assert.NotContains(t, string(data), string(blob))
+		assert.NotContains(t, string(data), base64.RawURLEncoding.EncodeToString(blob))
+		assert.NotContains(t, string(data), base64.URLEncoding.EncodeToString(blob))
 	})
 
 	t.Run("EveryNewMemberIsCoveredByIsZero", func(t *testing.T) {
@@ -107,6 +124,38 @@ func TestClientOutputsVerify(t *testing.T) {
 			session:  SessionExtensions{},
 			ceremony: CreateCeremony,
 			errs:     []string{"vendorThing"},
+		},
+		{
+			// A modelled member returned as null leaves the typed field nil. It must still be treated as returned,
+			// otherwise a null is a way around the unsolicited check that an unmodelled null does not have.
+			name:     "UnsolicitedModelledNull",
+			outputs:  testOutputsFromJSON(t, `{"credProps":null}`),
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			errs:     []string{"credProps"},
+		},
+		{
+			name:     "SolicitedModelledNull",
+			outputs:  testOutputsFromJSON(t, `{"credProps":null}`),
+			session:  SessionExtensions{Requested: []string{ExtensionCredProps}},
+			ceremony: CreateCeremony,
+		},
+		{
+			// The reject policy is what the null must not evade; the ignore policy still ignores it.
+			name:     "UnsolicitedModelledNullIgnored",
+			outputs:  testOutputsFromJSON(t, `{"credProps":null}`),
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			policy:   UnsolicitedOutputPolicyIgnore,
+		},
+		{
+			// encoding/json binds a case-variant key to the modelled field, so the null must be recorded under the
+			// canonical identifier rather than the key as it was written.
+			name:     "UnsolicitedModelledNullCaseVariant",
+			outputs:  testOutputsFromJSON(t, `{"CredProps":null}`),
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			errs:     []string{"credProps"},
 		},
 		{
 			name:     "UnsolicitedRemoteClientDataJSON",

--- a/protocol/extensions_session_test.go
+++ b/protocol/extensions_session_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,12 +47,25 @@ func TestAuthenticationExtensionsSessionDerivation(t *testing.T) {
 		assert.True(t, AuthenticationExtensions{}.Session().IsZero())
 	})
 
+	t.Run("CredBlob", func(t *testing.T) {
+		session := AuthenticationExtensions{CredBlob: []byte("a blob")}.Session()
+
+		assert.True(t, session.CredBlob)
+
+		// The blob is Relying Party data with no verification role beyond the flag, so it must not be persisted.
+		data, err := json.Marshal(session)
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(data), "a blob")
+	})
+
 	t.Run("EveryNewMemberIsCoveredByIsZero", func(t *testing.T) {
 		for name, session := range map[string]SessionExtensions{
 			"LargeBlobRead":                     {LargeBlobRead: true},
 			"LargeBlobWrite":                    {LargeBlobWrite: true},
 			"CredentialProtectionPolicy":        {CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationOptional},
 			"EnforceCredentialProtectionPolicy": {EnforceCredentialProtectionPolicy: true},
+			"CredBlob":                          {CredBlob: true},
 		} {
 			assert.Falsef(t, session.IsZero(), "IsZero must not report %s as empty", name)
 		}

--- a/protocol/extensions_session_test.go
+++ b/protocol/extensions_session_test.go
@@ -1,0 +1,179 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientOutputsVerify(t *testing.T) {
+	testCases := []struct {
+		name     string
+		outputs  AuthenticationExtensionsClientOutputs
+		session  SessionExtensions
+		ceremony CeremonyType
+		policy   UnsolicitedOutputPolicy
+		errs     []string
+	}{
+		{
+			name:     "Solicited",
+			outputs:  AuthenticationExtensionsClientOutputs{CredProps: &CredentialPropertiesOutput{RK: ptr(true)}},
+			session:  SessionExtensions{Requested: []string{ExtensionCredProps}},
+			ceremony: CreateCeremony,
+		},
+		{
+			name:     "Unsolicited",
+			outputs:  AuthenticationExtensionsClientOutputs{CredProps: &CredentialPropertiesOutput{RK: ptr(true)}},
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			errs:     []string{"credProps"},
+		},
+		{
+			name:     "UnsolicitedIgnored",
+			outputs:  AuthenticationExtensionsClientOutputs{CredProps: &CredentialPropertiesOutput{RK: ptr(true)}},
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			policy:   UnsolicitedOutputPolicyIgnore,
+		},
+		{
+			name:     "UnsolicitedExtra",
+			outputs:  AuthenticationExtensionsClientOutputs{Extra: map[string]any{"vendorThing": true}},
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			errs:     []string{"vendorThing"},
+		},
+		{
+			name:     "UnsolicitedRemoteClientDataJSON",
+			outputs:  AuthenticationExtensionsClientOutputs{RemoteClientDataJSON: ptr(true)},
+			session:  SessionExtensions{},
+			ceremony: AssertCeremony,
+			errs:     []string{"remoteClientDataJSON"},
+		},
+		{
+			name: "MultipleUnsolicitedAllReported",
+			outputs: AuthenticationExtensionsClientOutputs{
+				CredProps: &CredentialPropertiesOutput{},
+				PRF:       &PRFOutputs{Enabled: ptr(true)},
+			},
+			session:  SessionExtensions{},
+			ceremony: CreateCeremony,
+			errs:     []string{"credProps", "prf"},
+		},
+		{
+			name:     "LargeBlobRequiredUnsupported",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Supported: ptr(false)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportRequired},
+			ceremony: CreateCeremony,
+			errs:     []string{"largeBlob", "required"},
+		},
+		{
+			name:     "LargeBlobRequiredAbsent",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportRequired},
+			ceremony: CreateCeremony,
+			errs:     []string{"largeBlob"},
+		},
+		{
+			name:     "LargeBlobRequiredSupported",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Supported: ptr(true)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportRequired},
+			ceremony: CreateCeremony,
+		},
+		{
+			name:     "LargeBlobPreferredUnsupported",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Supported: ptr(false)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportPreferred},
+			ceremony: CreateCeremony,
+		},
+		{
+			// The required-support assertion is a registration rule, so an assertion legitimately skips it.
+			name:     "LargeBlobRequiredSkippedForAssertion",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Supported: ptr(false)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportRequired},
+			ceremony: AssertCeremony,
+		},
+		{
+			// An unrecognised ceremony must not skip it, i.e. the guard fails closed.
+			name:     "LargeBlobRequiredUnknownCeremony",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Supported: ptr(false)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportRequired},
+			ceremony: testCeremonyUnknown,
+			errs:     []string{"largeBlob", "required"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.outputs.Verify(tc.session, tc.ceremony, tc.policy)
+
+			if len(tc.errs) == 0 {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			for _, fragment := range tc.errs {
+				assert.ErrorContains(t, err, fragment)
+			}
+		})
+	}
+}
+
+// TestClientOutputsVerifyReturnsProtocolError pins that Verify fails with an *Error like every other failure path
+// out of the finish step, so a Relying Party which serialises Type, Details and DevInfo does not silently start
+// emitting a generic error, while every individual problem stays reachable through the error chain.
+func TestClientOutputsVerifyReturnsProtocolError(t *testing.T) {
+	testCases := []struct {
+		name    string
+		outputs AuthenticationExtensionsClientOutputs
+		causes  []string
+	}{
+		{
+			// errors.Join wraps even a single error, so the single-cause case is the one that regressed.
+			name:    "SingleCause",
+			outputs: AuthenticationExtensionsClientOutputs{CredProps: &CredentialPropertiesOutput{}},
+			causes:  []string{"credProps"},
+		},
+		{
+			name: "MultipleCauses",
+			outputs: AuthenticationExtensionsClientOutputs{
+				CredProps: &CredentialPropertiesOutput{},
+				PRF:       &PRFOutputs{Enabled: ptr(true)},
+			},
+			causes: []string{"credProps", "prf"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.outputs.Verify(SessionExtensions{}, CreateCeremony, UnsolicitedOutputPolicyReject)
+			require.Error(t, err)
+
+			var protocolError *Error
+
+			require.ErrorAs(t, err, &protocolError)
+			assert.Equal(t, ErrBadRequest.Type, protocolError.Type)
+
+			for _, cause := range tc.causes {
+				assert.Contains(t, protocolError.Details, cause)
+			}
+
+			// The all-problems-reported property survives: the cause is the join, and each individual problem is
+			// itself an *Error reachable through it.
+			var joined interface{ Unwrap() []error }
+
+			require.ErrorAs(t, err, &joined)
+
+			causes := joined.Unwrap()
+			require.Len(t, causes, len(tc.causes))
+
+			for i, cause := range causes {
+				var causeError *Error
+
+				require.ErrorAs(t, cause, &causeError)
+				assert.Contains(t, causeError.Details, tc.causes[i])
+			}
+		})
+	}
+}

--- a/protocol/extensions_session_test.go
+++ b/protocol/extensions_session_test.go
@@ -7,6 +7,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The verification rules are only as good as what Session records for them, and the read and write arms are
+// derived rather than copied, so the derivation is asserted directly.
+func TestAuthenticationExtensionsSessionDerivation(t *testing.T) {
+	t.Run("LargeBlobRead", func(t *testing.T) {
+		session := AuthenticationExtensions{LargeBlob: LargeBlobInputs{Read: true}}.Session()
+
+		assert.True(t, session.LargeBlobRead)
+		assert.False(t, session.LargeBlobWrite)
+	})
+
+	t.Run("LargeBlobWrite", func(t *testing.T) {
+		session := AuthenticationExtensions{LargeBlob: LargeBlobInputs{Write: []byte("blob")}}.Session()
+
+		assert.False(t, session.LargeBlobRead)
+		assert.True(t, session.LargeBlobWrite)
+	})
+
+	t.Run("LargeBlobSupportIsNotAWrite", func(t *testing.T) {
+		session := AuthenticationExtensions{LargeBlob: LargeBlobInputs{Support: LargeBlobSupportRequired}}.Session()
+
+		assert.False(t, session.LargeBlobRead)
+		assert.False(t, session.LargeBlobWrite)
+		assert.Equal(t, LargeBlobSupportRequired, session.LargeBlob)
+	})
+
+	t.Run("CredentialProtectionPolicy", func(t *testing.T) {
+		session := AuthenticationExtensions{
+			CredentialProtectionPolicy:        CredentialProtectionPolicyUserVerificationRequired,
+			EnforceCredentialProtectionPolicy: true,
+		}.Session()
+
+		assert.Equal(t, CredentialProtectionPolicyUserVerificationRequired, session.CredentialProtectionPolicy)
+		assert.True(t, session.EnforceCredentialProtectionPolicy)
+	})
+
+	t.Run("ZeroValue", func(t *testing.T) {
+		assert.True(t, AuthenticationExtensions{}.Session().IsZero())
+	})
+
+	t.Run("EveryNewMemberIsCoveredByIsZero", func(t *testing.T) {
+		for name, session := range map[string]SessionExtensions{
+			"LargeBlobRead":                     {LargeBlobRead: true},
+			"LargeBlobWrite":                    {LargeBlobWrite: true},
+			"CredentialProtectionPolicy":        {CredentialProtectionPolicy: CredentialProtectionPolicyUserVerificationOptional},
+			"EnforceCredentialProtectionPolicy": {EnforceCredentialProtectionPolicy: true},
+		} {
+			assert.Falsef(t, session.IsZero(), "IsZero must not report %s as empty", name)
+		}
+	})
+}
+
 func TestClientOutputsVerify(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -100,6 +151,70 @@ func TestClientOutputsVerify(t *testing.T) {
 			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlob: LargeBlobSupportRequired},
 			ceremony: testCeremonyUnknown,
 			errs:     []string{"largeBlob", "required"},
+		},
+		{
+			name:     "LargeBlobWritten",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Written: ptr(true)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobWrite: true},
+			ceremony: AssertCeremony,
+		},
+		{
+			// A write the client reports as not performed must not yield a successful ceremony.
+			name:     "LargeBlobNotWritten",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Written: ptr(false)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobWrite: true},
+			ceremony: AssertCeremony,
+			errs:     []string{"largeBlob", "was not written"},
+		},
+		{
+			// A client which omits the outcome entirely is treated the same as one reporting failure.
+			name:     "LargeBlobWriteOutcomeMissing",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobWrite: true},
+			ceremony: AssertCeremony,
+			errs:     []string{"largeBlob", "did not report whether it was written"},
+		},
+		{
+			name:     "LargeBlobWriteOutputAbsent",
+			outputs:  AuthenticationExtensionsClientOutputs{},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobWrite: true},
+			ceremony: AssertCeremony,
+			errs:     []string{"largeBlob", "did not report whether it was written"},
+		},
+		{
+			// The read and write arms produce disjoint outputs, so a blob returned for a write is incoherent.
+			name:     "LargeBlobWriteReturnedBlob",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Written: ptr(true), Blob: []byte("blob")}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobWrite: true},
+			ceremony: AssertCeremony,
+			errs:     []string{"largeBlob", "returned a blob it read"},
+		},
+		{
+			name:     "LargeBlobRead",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Blob: []byte("blob")}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobRead: true},
+			ceremony: AssertCeremony,
+		},
+		{
+			// A credential with nothing stored yields an empty output, which is a legitimate read result.
+			name:     "LargeBlobReadEmpty",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobRead: true},
+			ceremony: AssertCeremony,
+		},
+		{
+			name:     "LargeBlobReadReturnedWriteOutcome",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Written: ptr(true)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}, LargeBlobRead: true},
+			ceremony: AssertCeremony,
+			errs:     []string{"largeBlob", "outcome of a write"},
+		},
+		{
+			// Neither arm was requested, so the registration-shaped output is left to the unsolicited check.
+			name:     "LargeBlobNeitherReadNorWrite",
+			outputs:  AuthenticationExtensionsClientOutputs{LargeBlob: &LargeBlobOutputs{Written: ptr(false)}},
+			session:  SessionExtensions{Requested: []string{ExtensionLargeBlob}},
+			ceremony: AssertCeremony,
 		},
 	}
 

--- a/protocol/extensions_test.go
+++ b/protocol/extensions_test.go
@@ -1,0 +1,46 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtensionInputsIsZero(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     interface{ IsZero() bool }
+		expected bool
+	}{
+		{"PRFValuesZero", PRFValues{}, true},
+		{"PRFValuesFirst", PRFValues{First: []byte("a")}, false},
+		{"PRFValuesSecond", PRFValues{Second: []byte("a")}, false},
+		{"PRFInputsZero", PRFInputs{}, true},
+		{"PRFInputsEval", PRFInputs{Eval: PRFValues{First: []byte("a")}}, false},
+		{"PRFInputsByCredential", PRFInputs{EvalByCredential: map[string]PRFValues{"a": {}}}, false},
+		{"LargeBlobInputsZero", LargeBlobInputs{}, true},
+		{"LargeBlobInputsSupport", LargeBlobInputs{Support: LargeBlobSupportRequired}, false},
+		{"LargeBlobInputsRead", LargeBlobInputs{Read: true}, false},
+		{"LargeBlobInputsWrite", LargeBlobInputs{Write: []byte("a")}, false},
+		{"HMACGetSecretInputsZero", HMACGetSecretInputs{}, true},
+		{"HMACGetSecretInputsSalt1", HMACGetSecretInputs{Salt1: []byte("a")}, false},
+		{"HMACGetSecretInputsSalt2", HMACGetSecretInputs{Salt2: []byte("a")}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.IsZero())
+		})
+	}
+}
+
+func TestPtr(t *testing.T) {
+	value := ptr(true)
+
+	assert.NotNil(t, value)
+	assert.True(t, *value)
+
+	number := ptr(uint(4))
+
+	assert.Equal(t, uint(4), *number)
+}

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -39,7 +39,7 @@ type PublicKeyCredentialCreationOptions struct {
 	Hints                  []PublicKeyCredentialHints `json:"hints,omitempty"`
 	Attestation            ConveyancePreference       `json:"attestation,omitempty"`
 	AttestationFormats     []AttestationFormat        `json:"attestationFormats,omitempty"`
-	Extensions             AuthenticationExtensions   `json:"extensions,omitempty"`
+	Extensions             AuthenticationExtensions   `json:"extensions,omitzero"`
 }
 
 // The PublicKeyCredentialRequestOptions dictionary supplies get() with the data it needs to generate an assertion.
@@ -55,7 +55,7 @@ type PublicKeyCredentialRequestOptions struct {
 	AllowedCredentials []CredentialDescriptor      `json:"allowCredentials,omitempty"`
 	UserVerification   UserVerificationRequirement `json:"userVerification,omitempty"`
 	Hints              []PublicKeyCredentialHints  `json:"hints,omitempty"`
-	Extensions         AuthenticationExtensions    `json:"extensions,omitempty"`
+	Extensions         AuthenticationExtensions    `json:"extensions,omitzero"`
 }
 
 // CredentialDescriptor represents the PublicKeyCredentialDescriptor IDL.
@@ -110,12 +110,6 @@ const (
 	// PublicKeyCredentialType - Currently one credential type is defined, namely "public-key".
 	PublicKeyCredentialType CredentialType = "public-key"
 )
-
-// AuthenticationExtensions represents the AuthenticationExtensionsClientInputs IDL. This member contains additional
-// parameters requesting additional processing by the client and authenticator.
-//
-// Specification: §5.7.1. Authentication Extensions Client Inputs (https://www.w3.org/TR/webauthn/#iface-authentication-extensions-client-inputs)
-type AuthenticationExtensions map[string]any
 
 // AuthenticatorSelection represents the AuthenticatorSelectionCriteria IDL.
 //
@@ -278,11 +272,6 @@ func (a *PublicKeyCredentialRequestOptions) GetAllowedCredentialIDs() [][]byte {
 
 	return allowedCredentialIDs
 }
-
-// Extensions is a generic type for WebAuthn extensions. The actual contents are defined by each individual extension.
-//
-// Specification: §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn/#extensions)
-type Extensions any
 
 // ServerResponse is a response from a FIDO conformance server.
 type ServerResponse struct {

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -18,6 +18,12 @@ import (
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )
 
+// ptr returns a pointer to the given value. It exists so that the pointer-valued members of the extension output
+// structures, where an absent value must be distinguishable from a false or zero value, can be constructed inline.
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func mustParseX509Certificate(der []byte) *x509.Certificate {
 	cert, err := x509.ParseCertificate(der)
 	if err != nil {

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -63,6 +63,10 @@ func newCredentialExtensions(c *protocol.ParsedCredentialCreationData) (extensio
 		extensions.LargeBlobSupported = ptr(*outputs.LargeBlob.Supported)
 	}
 
+	if outputs.HMACCreateSecret != nil {
+		extensions.HMACSecret = ptr(*outputs.HMACCreateSecret)
+	}
+
 	if ext := c.Response.AttestationObject.AuthData.Ext; ext != nil {
 		if ext.CredProtect != nil {
 			extensions.CredProtect = *ext.CredProtect
@@ -70,6 +74,16 @@ func newCredentialExtensions(c *protocol.ParsedCredentialCreationData) (extensio
 
 		if ext.MinPinLength != nil {
 			extensions.MinPinLength = ptr(*ext.MinPinLength)
+		}
+
+		if ext.CredBlobSet != nil {
+			extensions.CredBlobSet = ptr(*ext.CredBlobSet)
+		}
+
+		// The authenticator output wins over the client's hmacCreateSecret because it is covered by the
+		// attestation signature; the client value assigned above stands only when the authenticator omits it.
+		if ext.HMACSecret != nil {
+			extensions.HMACSecret = ptr(*ext.HMACSecret)
 		}
 	}
 
@@ -152,6 +166,23 @@ type CredentialExtensions struct {
 
 	// LargeBlobSupported reports whether the credential supports large blob storage.
 	LargeBlobSupported *bool `json:"largeBlobSupported,omitempty" msg:"lbs,omitempty"`
+
+	// HMACSecret reports whether the authenticator provisioned a CTAP hmac-secret for this credential, which is
+	// what determines whether requesting [WithExtensionHMACGetSecret] at authentication can succeed.
+	//
+	// The value is taken from the authenticator extension outputs where present, because those are covered by the
+	// attestation signature, and from the client's 'hmacCreateSecret' output otherwise. The two are the signed and
+	// client-reported views of one capability rather than two separate properties, so they share a field.
+	//
+	// This is a sibling of PRFEnabled rather than a duplicate of it: the pseudo-random function extension is the
+	// WebAuthn level abstraction over the same authenticator capability, and a client may report either, both, or
+	// neither depending on which extension the Relying Party requested.
+	HMACSecret *bool `json:"hmacSecret,omitempty" msg:"hs,omitempty"`
+
+	// CredBlobSet reports whether the blob submitted with [WithExtensionCredBlob] at registration was stored by
+	// the authenticator, which is what determines whether requesting [WithExtensionGetCredBlob] at authentication
+	// can return anything.
+	CredBlobSet *bool `json:"credBlobSet,omitempty" msg:"cbs,omitempty"`
 }
 
 // UnmarshalJSON decodes a [Credential] from JSON, applying a backward-compatibility migration for records produced

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -13,6 +13,7 @@ import (
 //go:generate msgp
 
 //msgp:replace protocol.AuthenticatorTransport with:string
+//msgp:replace protocol.CredentialProtectionPolicy with:string
 //msgp:shim CredentialFlags as:byte using:(CredentialFlags).MsgpByte/CredentialFlagsFromMsgpByte
 //msgp:clearomitted
 
@@ -39,9 +40,40 @@ func NewCredential(clientDataHash []byte, c *protocol.ParsedCredentialCreationDa
 			PublicKeyAlgorithm: c.Raw.AttestationResponse.PublicKeyAlgorithm,
 			Object:             c.Raw.AttestationResponse.AttestationObject,
 		},
+		Extensions: newCredentialExtensions(c),
 	}
 
 	return credential, nil
+}
+
+// newCredentialExtensions selects the extension results worth persisting with the credential record from the
+// client and authenticator extension outputs of a registration ceremony.
+func newCredentialExtensions(c *protocol.ParsedCredentialCreationData) (extensions CredentialExtensions) {
+	outputs := c.ClientExtensionResults
+
+	if outputs.CredProps != nil && outputs.CredProps.RK != nil {
+		extensions.RK = ptr(*outputs.CredProps.RK)
+	}
+
+	if outputs.PRF != nil && outputs.PRF.Enabled != nil {
+		extensions.PRFEnabled = ptr(*outputs.PRF.Enabled)
+	}
+
+	if outputs.LargeBlob != nil && outputs.LargeBlob.Supported != nil {
+		extensions.LargeBlobSupported = ptr(*outputs.LargeBlob.Supported)
+	}
+
+	if ext := c.Response.AttestationObject.AuthData.Ext; ext != nil {
+		if ext.CredProtect != nil {
+			extensions.CredProtect = *ext.CredProtect
+		}
+
+		if ext.MinPinLength != nil {
+			extensions.MinPinLength = ptr(*ext.MinPinLength)
+		}
+	}
+
+	return extensions
 }
 
 // Credential contains all needed information about a WebAuthn credential for storage. This struct is effectively the
@@ -93,6 +125,33 @@ type Credential struct {
 
 	// The attestation values that can be used to validate this Credential via the MDS3 at a later date.
 	Attestation CredentialAttestation `json:"attestation" msg:"att"`
+
+	// Extensions holds the durable extension results reported during the registration ceremony. It is a curated
+	// subset: PRF results are secrets and are never persisted, and blobs and keys do not belong in a credential
+	// record.
+	Extensions CredentialExtensions `json:"extensions,omitzero" msg:"ext,omitempty"`
+}
+
+// CredentialExtensions holds the extension results recorded at registration which remain meaningful for the life
+// of the credential.
+type CredentialExtensions struct {
+	// RK reports whether the credential is client-side discoverable, from the credProps extension. A false value
+	// is meaningful and distinct from the client not reporting the property.
+	RK *bool `json:"rk,omitempty" msg:"rk,omitempty"`
+
+	// CredProtect is the credential protection policy applied by the authenticator. The empty value means the
+	// authenticator did not report one.
+	CredProtect protocol.CredentialProtectionPolicy `json:"credProtect,omitempty" msg:"cp,omitempty"`
+
+	// MinPinLength is the authenticator's minimum PIN length at the time of registration.
+	MinPinLength *uint `json:"minPinLength,omitempty" msg:"mpl,omitempty"`
+
+	// PRFEnabled reports whether the pseudo-random function is available for this credential. It is populated when
+	// the registration requested the extension, typically with [WithExtensionPRFSupport].
+	PRFEnabled *bool `json:"prfEnabled,omitempty" msg:"prf,omitempty"`
+
+	// LargeBlobSupported reports whether the credential supports large blob storage.
+	LargeBlobSupported *bool `json:"largeBlobSupported,omitempty" msg:"lbs,omitempty"`
 }
 
 // UnmarshalJSON decodes a [Credential] from JSON, applying a backward-compatibility migration for records produced

--- a/webauthn/credential_gen.go
+++ b/webauthn/credential_gen.go
@@ -17,7 +17,7 @@ func (z *Credential) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 3 bits */
+	var zb0001Mask uint8 /* 4 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -99,6 +99,13 @@ func (z *Credential) DecodeMsg(dc *msgp.Reader) (err error) {
 				err = msgp.WrapError(err, "Attestation")
 				return
 			}
+		case "ext":
+			err = z.Extensions.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "Extensions")
+				return
+			}
+			zb0001Mask |= 0x8
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -108,7 +115,7 @@ func (z *Credential) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7 {
+	if zb0001Mask != 0xf {
 		if (zb0001Mask & 0x1) == 0 {
 			z.AttestationType = ""
 		}
@@ -118,6 +125,9 @@ func (z *Credential) DecodeMsg(dc *msgp.Reader) (err error) {
 		if (zb0001Mask & 0x4) == 0 {
 			z.Transport = nil
 		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.Extensions = CredentialExtensions{}
+		}
 	}
 	return
 }
@@ -125,8 +135,8 @@ func (z *Credential) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *Credential) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(8)
-	var zb0001Mask uint8 /* 8 bits */
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
 	_ = zb0001Mask
 	if z.AttestationType == "" {
 		zb0001Len--
@@ -241,6 +251,16 @@ func (z *Credential) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "Attestation")
 			return
 		}
+		// write "ext"
+		err = en.Append(0xa3, 0x65, 0x78, 0x74)
+		if err != nil {
+			return
+		}
+		err = z.Extensions.EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Extensions")
+			return
+		}
 	}
 	return
 }
@@ -249,8 +269,8 @@ func (z *Credential) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *Credential) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(8)
-	var zb0001Mask uint8 /* 8 bits */
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
 	_ = zb0001Mask
 	if z.AttestationType == "" {
 		zb0001Len--
@@ -310,6 +330,13 @@ func (z *Credential) MarshalMsg(b []byte) (o []byte, err error) {
 			err = msgp.WrapError(err, "Attestation")
 			return
 		}
+		// string "ext"
+		o = append(o, 0xa3, 0x65, 0x78, 0x74)
+		o, err = z.Extensions.MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Extensions")
+			return
+		}
 	}
 	return
 }
@@ -324,7 +351,7 @@ func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 3 bits */
+	var zb0001Mask uint8 /* 4 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -406,6 +433,13 @@ func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "Attestation")
 				return
 			}
+		case "ext":
+			bts, err = z.Extensions.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Extensions")
+				return
+			}
+			zb0001Mask |= 0x8
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -415,7 +449,7 @@ func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7 {
+	if zb0001Mask != 0xf {
 		if (zb0001Mask & 0x1) == 0 {
 			z.AttestationType = ""
 		}
@@ -424,6 +458,9 @@ func (z *Credential) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if (zb0001Mask & 0x4) == 0 {
 			z.Transport = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.Extensions = CredentialExtensions{}
 		}
 	}
 	o = bts
@@ -436,7 +473,7 @@ func (z *Credential) Msgsize() (s int) {
 	for za0001 := range z.Transport {
 		s += msgp.StringPrefixSize + len(string(z.Transport[za0001]))
 	}
-	s += 4 + msgp.ByteSize + 2 + z.Authenticator.Msgsize() + 4 + z.Attestation.Msgsize()
+	s += 4 + msgp.ByteSize + 2 + z.Authenticator.Msgsize() + 4 + z.Attestation.Msgsize() + 4 + z.Extensions.Msgsize()
 	return
 }
 
@@ -771,6 +808,507 @@ func (z *CredentialAttestation) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *CredentialAttestation) Msgsize() (s int) {
 	s = 1 + 4 + msgp.BytesPrefixSize + len(z.ClientDataJSON) + 4 + msgp.BytesPrefixSize + len(z.ClientDataHash) + 5 + msgp.BytesPrefixSize + len(z.AuthenticatorData) + 4 + msgp.Int64Size + 4 + msgp.BytesPrefixSize + len(z.Object)
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *CredentialExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "rk":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "RK")
+					return
+				}
+				z.RK = nil
+			} else {
+				if z.RK == nil {
+					z.RK = new(bool)
+				}
+				*z.RK, err = dc.ReadBool()
+				if err != nil {
+					err = msgp.WrapError(err, "RK")
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "cp":
+			{
+				var zb0002 string
+				zb0002, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "CredProtect")
+					return
+				}
+				z.CredProtect = protocol.CredentialProtectionPolicy(zb0002)
+			}
+			zb0001Mask |= 0x2
+		case "mpl":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "MinPinLength")
+					return
+				}
+				z.MinPinLength = nil
+			} else {
+				if z.MinPinLength == nil {
+					z.MinPinLength = new(uint)
+				}
+				*z.MinPinLength, err = dc.ReadUint()
+				if err != nil {
+					err = msgp.WrapError(err, "MinPinLength")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "prf":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "PRFEnabled")
+					return
+				}
+				z.PRFEnabled = nil
+			} else {
+				if z.PRFEnabled == nil {
+					z.PRFEnabled = new(bool)
+				}
+				*z.PRFEnabled, err = dc.ReadBool()
+				if err != nil {
+					err = msgp.WrapError(err, "PRFEnabled")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "lbs":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "LargeBlobSupported")
+					return
+				}
+				z.LargeBlobSupported = nil
+			} else {
+				if z.LargeBlobSupported == nil {
+					z.LargeBlobSupported = new(bool)
+				}
+				*z.LargeBlobSupported, err = dc.ReadBool()
+				if err != nil {
+					err = msgp.WrapError(err, "LargeBlobSupported")
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x1f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.RK = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.CredProtect = ""
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.MinPinLength = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.PRFEnabled = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.LargeBlobSupported = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *CredentialExtensions) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	if z.RK == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.CredProtect == "" {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.MinPinLength == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.PRFEnabled == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.LargeBlobSupported == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "rk"
+			err = en.Append(0xa2, 0x72, 0x6b)
+			if err != nil {
+				return
+			}
+			if z.RK == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = en.WriteBool(*z.RK)
+				if err != nil {
+					err = msgp.WrapError(err, "RK")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "cp"
+			err = en.Append(0xa2, 0x63, 0x70)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(string(z.CredProtect))
+			if err != nil {
+				err = msgp.WrapError(err, "CredProtect")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "mpl"
+			err = en.Append(0xa3, 0x6d, 0x70, 0x6c)
+			if err != nil {
+				return
+			}
+			if z.MinPinLength == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = en.WriteUint(*z.MinPinLength)
+				if err != nil {
+					err = msgp.WrapError(err, "MinPinLength")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "prf"
+			err = en.Append(0xa3, 0x70, 0x72, 0x66)
+			if err != nil {
+				return
+			}
+			if z.PRFEnabled == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = en.WriteBool(*z.PRFEnabled)
+				if err != nil {
+					err = msgp.WrapError(err, "PRFEnabled")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "lbs"
+			err = en.Append(0xa3, 0x6c, 0x62, 0x73)
+			if err != nil {
+				return
+			}
+			if z.LargeBlobSupported == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = en.WriteBool(*z.LargeBlobSupported)
+				if err != nil {
+					err = msgp.WrapError(err, "LargeBlobSupported")
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *CredentialExtensions) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	if z.RK == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.CredProtect == "" {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.MinPinLength == nil {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.PRFEnabled == nil {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.LargeBlobSupported == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "rk"
+			o = append(o, 0xa2, 0x72, 0x6b)
+			if z.RK == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = msgp.AppendBool(o, *z.RK)
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "cp"
+			o = append(o, 0xa2, 0x63, 0x70)
+			o = msgp.AppendString(o, string(z.CredProtect))
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "mpl"
+			o = append(o, 0xa3, 0x6d, 0x70, 0x6c)
+			if z.MinPinLength == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = msgp.AppendUint(o, *z.MinPinLength)
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "prf"
+			o = append(o, 0xa3, 0x70, 0x72, 0x66)
+			if z.PRFEnabled == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = msgp.AppendBool(o, *z.PRFEnabled)
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "lbs"
+			o = append(o, 0xa3, 0x6c, 0x62, 0x73)
+			if z.LargeBlobSupported == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = msgp.AppendBool(o, *z.LargeBlobSupported)
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *CredentialExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "rk":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.RK = nil
+			} else {
+				if z.RK == nil {
+					z.RK = new(bool)
+				}
+				*z.RK, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "RK")
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "cp":
+			{
+				var zb0002 string
+				zb0002, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "CredProtect")
+					return
+				}
+				z.CredProtect = protocol.CredentialProtectionPolicy(zb0002)
+			}
+			zb0001Mask |= 0x2
+		case "mpl":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.MinPinLength = nil
+			} else {
+				if z.MinPinLength == nil {
+					z.MinPinLength = new(uint)
+				}
+				*z.MinPinLength, bts, err = msgp.ReadUintBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "MinPinLength")
+					return
+				}
+			}
+			zb0001Mask |= 0x4
+		case "prf":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.PRFEnabled = nil
+			} else {
+				if z.PRFEnabled == nil {
+					z.PRFEnabled = new(bool)
+				}
+				*z.PRFEnabled, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "PRFEnabled")
+					return
+				}
+			}
+			zb0001Mask |= 0x8
+		case "lbs":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.LargeBlobSupported = nil
+			} else {
+				if z.LargeBlobSupported == nil {
+					z.LargeBlobSupported = new(bool)
+				}
+				*z.LargeBlobSupported, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LargeBlobSupported")
+					return
+				}
+			}
+			zb0001Mask |= 0x10
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x1f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.RK = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.CredProtect = ""
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.MinPinLength = nil
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.PRFEnabled = nil
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.LargeBlobSupported = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *CredentialExtensions) Msgsize() (s int) {
+	s = 1 + 3
+	if z.RK == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.BoolSize
+	}
+	s += 3 + msgp.StringPrefixSize + len(string(z.CredProtect)) + 4
+	if z.MinPinLength == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.UintSize
+	}
+	s += 4
+	if z.PRFEnabled == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.BoolSize
+	}
+	s += 4
+	if z.LargeBlobSupported == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.BoolSize
+	}
 	return
 }
 

--- a/webauthn/credential_gen.go
+++ b/webauthn/credential_gen.go
@@ -821,7 +821,7 @@ func (z *CredentialExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -918,6 +918,44 @@ func (z *CredentialExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 			zb0001Mask |= 0x10
+		case "hs":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "HMACSecret")
+					return
+				}
+				z.HMACSecret = nil
+			} else {
+				if z.HMACSecret == nil {
+					z.HMACSecret = new(bool)
+				}
+				*z.HMACSecret, err = dc.ReadBool()
+				if err != nil {
+					err = msgp.WrapError(err, "HMACSecret")
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		case "cbs":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					err = msgp.WrapError(err, "CredBlobSet")
+					return
+				}
+				z.CredBlobSet = nil
+			} else {
+				if z.CredBlobSet == nil {
+					z.CredBlobSet = new(bool)
+				}
+				*z.CredBlobSet, err = dc.ReadBool()
+				if err != nil {
+					err = msgp.WrapError(err, "CredBlobSet")
+					return
+				}
+			}
+			zb0001Mask |= 0x40
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -927,7 +965,7 @@ func (z *CredentialExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.RK = nil
 		}
@@ -943,6 +981,12 @@ func (z *CredentialExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		if (zb0001Mask & 0x10) == 0 {
 			z.LargeBlobSupported = nil
 		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.HMACSecret = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.CredBlobSet = nil
+		}
 	}
 	return
 }
@@ -950,8 +994,8 @@ func (z *CredentialExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *CredentialExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(5)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	if z.RK == nil {
 		zb0001Len--
@@ -972,6 +1016,14 @@ func (z *CredentialExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.LargeBlobSupported == nil {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if z.HMACSecret == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.CredBlobSet == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -1069,6 +1121,44 @@ func (z *CredentialExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "hs"
+			err = en.Append(0xa2, 0x68, 0x73)
+			if err != nil {
+				return
+			}
+			if z.HMACSecret == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = en.WriteBool(*z.HMACSecret)
+				if err != nil {
+					err = msgp.WrapError(err, "HMACSecret")
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "cbs"
+			err = en.Append(0xa3, 0x63, 0x62, 0x73)
+			if err != nil {
+				return
+			}
+			if z.CredBlobSet == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = en.WriteBool(*z.CredBlobSet)
+				if err != nil {
+					err = msgp.WrapError(err, "CredBlobSet")
+					return
+				}
+			}
+		}
 	}
 	return
 }
@@ -1077,8 +1167,8 @@ func (z *CredentialExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *CredentialExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(5)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(7)
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	if z.RK == nil {
 		zb0001Len--
@@ -1099,6 +1189,14 @@ func (z *CredentialExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 	if z.LargeBlobSupported == nil {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if z.HMACSecret == nil {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.CredBlobSet == nil {
+		zb0001Len--
+		zb0001Mask |= 0x40
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -1146,6 +1244,24 @@ func (z *CredentialExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 				o = msgp.AppendBool(o, *z.LargeBlobSupported)
 			}
 		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "hs"
+			o = append(o, 0xa2, 0x68, 0x73)
+			if z.HMACSecret == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = msgp.AppendBool(o, *z.HMACSecret)
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "cbs"
+			o = append(o, 0xa3, 0x63, 0x62, 0x73)
+			if z.CredBlobSet == nil {
+				o = msgp.AppendNil(o)
+			} else {
+				o = msgp.AppendBool(o, *z.CredBlobSet)
+			}
+		}
 	}
 	return
 }
@@ -1160,7 +1276,7 @@ func (z *CredentialExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -1253,6 +1369,42 @@ func (z *CredentialExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 			zb0001Mask |= 0x10
+		case "hs":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.HMACSecret = nil
+			} else {
+				if z.HMACSecret == nil {
+					z.HMACSecret = new(bool)
+				}
+				*z.HMACSecret, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "HMACSecret")
+					return
+				}
+			}
+			zb0001Mask |= 0x20
+		case "cbs":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.CredBlobSet = nil
+			} else {
+				if z.CredBlobSet == nil {
+					z.CredBlobSet = new(bool)
+				}
+				*z.CredBlobSet, bts, err = msgp.ReadBoolBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "CredBlobSet")
+					return
+				}
+			}
+			zb0001Mask |= 0x40
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -1262,7 +1414,7 @@ func (z *CredentialExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.RK = nil
 		}
@@ -1277,6 +1429,12 @@ func (z *CredentialExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		if (zb0001Mask & 0x10) == 0 {
 			z.LargeBlobSupported = nil
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.HMACSecret = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.CredBlobSet = nil
 		}
 	}
 	o = bts
@@ -1305,6 +1463,18 @@ func (z *CredentialExtensions) Msgsize() (s int) {
 	}
 	s += 4
 	if z.LargeBlobSupported == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.BoolSize
+	}
+	s += 3
+	if z.HMACSecret == nil {
+		s += msgp.NilSize
+	} else {
+		s += msgp.BoolSize
+	}
+	s += 4
+	if z.CredBlobSet == nil {
 		s += msgp.NilSize
 	} else {
 		s += msgp.BoolSize

--- a/webauthn/credential_gen_test.go
+++ b/webauthn/credential_gen_test.go
@@ -235,6 +235,119 @@ func BenchmarkDecodeCredentialAttestation(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalCredentialExtensions(t *testing.T) {
+	v := CredentialExtensions{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgCredentialExtensions(b *testing.B) {
+	v := CredentialExtensions{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgCredentialExtensions(b *testing.B) {
+	v := CredentialExtensions{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalCredentialExtensions(b *testing.B) {
+	v := CredentialExtensions{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeCredentialExtensions(t *testing.T) {
+	v := CredentialExtensions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodeCredentialExtensions Msgsize() is inaccurate")
+	}
+
+	vn := CredentialExtensions{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeCredentialExtensions(b *testing.B) {
+	v := CredentialExtensions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeCredentialExtensions(b *testing.B) {
+	v := CredentialExtensions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalCredentials(t *testing.T) {
 	v := Credentials{}
 	bts, err := v.MarshalMsg(nil)

--- a/webauthn/credential_test.go
+++ b/webauthn/credential_test.go
@@ -482,6 +482,45 @@ func testCredentialFromNoneAttestation(t *testing.T) Credential {
 	}
 }
 
+// newTestParsedCredentialCreationData returns a fully populated [*protocol.ParsedCredentialCreationData] suitable
+// for [NewCredential], with no extension data set. Tests mutate the returned value's ClientExtensionResults and
+// Response.AttestationObject.AuthData.Ext fields to exercise extension handling.
+func newTestParsedCredentialCreationData(t *testing.T) *protocol.ParsedCredentialCreationData {
+	t.Helper()
+
+	return &protocol.ParsedCredentialCreationData{
+		ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
+			AuthenticatorAttachment: protocol.Platform,
+		},
+		Response: protocol.ParsedAttestationResponse{
+			AttestationObject: protocol.AttestationObject{
+				Format: "packed",
+				Type:   string(metadata.BasicFull),
+				AuthData: protocol.AuthenticatorData{
+					Counter: 1,
+					Flags:   protocol.FlagUserPresent | protocol.FlagUserVerified,
+					AttData: protocol.AttestedCredentialData{
+						AAGUID:              []byte("aaguid-value-here"),
+						CredentialID:        []byte("credential-id"),
+						CredentialPublicKey: []byte("public-key"),
+					},
+				},
+			},
+			Transports: []protocol.AuthenticatorTransport{protocol.USB},
+		},
+		Raw: protocol.CredentialCreationResponse{
+			AttestationResponse: protocol.AuthenticatorAttestationResponse{
+				AuthenticatorResponse: protocol.AuthenticatorResponse{
+					ClientDataJSON: []byte("client-data-json"),
+				},
+				AuthenticatorData:  []byte("auth-data"),
+				PublicKeyAlgorithm: -7,
+				AttestationObject:  []byte("attestation-object"),
+			},
+		},
+	}
+}
+
 func TestNewCredential(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -492,37 +531,7 @@ func TestNewCredential(t *testing.T) {
 		{
 			name:           "ShouldCreateCredential",
 			clientDataHash: []byte("client-data-hash"),
-			parsed: &protocol.ParsedCredentialCreationData{
-				ParsedPublicKeyCredential: protocol.ParsedPublicKeyCredential{
-					AuthenticatorAttachment: protocol.Platform,
-				},
-				Response: protocol.ParsedAttestationResponse{
-					AttestationObject: protocol.AttestationObject{
-						Format: "packed",
-						Type:   string(metadata.BasicFull),
-						AuthData: protocol.AuthenticatorData{
-							Counter: 1,
-							Flags:   protocol.FlagUserPresent | protocol.FlagUserVerified,
-							AttData: protocol.AttestedCredentialData{
-								AAGUID:              []byte("aaguid-value-here"),
-								CredentialID:        []byte("credential-id"),
-								CredentialPublicKey: []byte("public-key"),
-							},
-						},
-					},
-					Transports: []protocol.AuthenticatorTransport{protocol.USB},
-				},
-				Raw: protocol.CredentialCreationResponse{
-					AttestationResponse: protocol.AuthenticatorAttestationResponse{
-						AuthenticatorResponse: protocol.AuthenticatorResponse{
-							ClientDataJSON: []byte("client-data-json"),
-						},
-						AuthenticatorData:  []byte("auth-data"),
-						PublicKeyAlgorithm: -7,
-						AttestationObject:  []byte("attestation-object"),
-					},
-				},
-			},
+			parsed:         newTestParsedCredentialCreationData(t),
 			expected: &Credential{
 				ID:                []byte("credential-id"),
 				PublicKey:         []byte("public-key"),
@@ -581,6 +590,142 @@ func TestNewCredential(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestNewCredentialRecordsExtensionResults(t *testing.T) {
+	parsed := newTestParsedCredentialCreationData(t)
+
+	parsed.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		CredProps: &protocol.CredentialPropertiesOutput{RK: ptr(false)},
+		PRF:       &protocol.PRFOutputs{Enabled: ptr(true), Results: &protocol.PRFValues{First: []byte("secret")}},
+		LargeBlob: &protocol.LargeBlobOutputs{Supported: ptr(true)},
+	}
+	parsed.Response.AttestationObject.AuthData.Ext = &protocol.AuthenticatorExtensionOutputs{
+		CredProtect:  ptr(protocol.CredentialProtectionPolicyUserVerificationRequired),
+		MinPinLength: ptr(uint(6)),
+	}
+
+	credential, err := NewCredential(nil, parsed)
+	require.NoError(t, err)
+
+	require.NotNil(t, credential.Extensions.RK)
+	assert.False(t, *credential.Extensions.RK, "rk false must be recorded, not treated as absent")
+
+	require.NotNil(t, credential.Extensions.PRFEnabled)
+	assert.True(t, *credential.Extensions.PRFEnabled)
+
+	require.NotNil(t, credential.Extensions.LargeBlobSupported)
+	assert.True(t, *credential.Extensions.LargeBlobSupported)
+
+	assert.Equal(t, protocol.CredentialProtectionPolicyUserVerificationRequired, credential.Extensions.CredProtect)
+
+	require.NotNil(t, credential.Extensions.MinPinLength)
+	assert.Equal(t, uint(6), *credential.Extensions.MinPinLength)
+}
+
+func TestNewCredentialExtensionsDoNotAliasParsedResponse(t *testing.T) {
+	// Credential.Extensions must be an independent snapshot. A caller may retain the parsed response (it carries
+	// the attestation data an RP may want to re-verify later); if the stored record shared pointers with it,
+	// mutating the parsed response after registration would silently change the already-persisted credential.
+	rk := false
+	prfEnabled := true
+	largeBlobSupported := true
+	minPinLength := uint(6)
+
+	parsed := newTestParsedCredentialCreationData(t)
+
+	parsed.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		CredProps: &protocol.CredentialPropertiesOutput{RK: &rk},
+		PRF:       &protocol.PRFOutputs{Enabled: &prfEnabled},
+		LargeBlob: &protocol.LargeBlobOutputs{Supported: &largeBlobSupported},
+	}
+	parsed.Response.AttestationObject.AuthData.Ext = &protocol.AuthenticatorExtensionOutputs{
+		MinPinLength: &minPinLength,
+	}
+
+	credential, err := NewCredential(nil, parsed)
+	require.NoError(t, err)
+
+	require.NotNil(t, credential.Extensions.RK)
+	require.NotNil(t, credential.Extensions.PRFEnabled)
+	require.NotNil(t, credential.Extensions.LargeBlobSupported)
+	require.NotNil(t, credential.Extensions.MinPinLength)
+
+	assert.NotSame(t, &rk, credential.Extensions.RK)
+	assert.NotSame(t, &prfEnabled, credential.Extensions.PRFEnabled)
+	assert.NotSame(t, &largeBlobSupported, credential.Extensions.LargeBlobSupported)
+	assert.NotSame(t, &minPinLength, credential.Extensions.MinPinLength)
+
+	// Mutate the values through the original pointers, as a caller retaining the parsed response could.
+	rk = true
+	prfEnabled = false
+	largeBlobSupported = false
+	minPinLength = 4
+
+	assert.False(t, *credential.Extensions.RK, "credential must retain the value at construction time")
+	assert.True(t, *credential.Extensions.PRFEnabled, "credential must retain the value at construction time")
+	assert.True(t, *credential.Extensions.LargeBlobSupported, "credential must retain the value at construction time")
+	assert.Equal(t, uint(6), *credential.Extensions.MinPinLength, "credential must retain the value at construction time")
+}
+
+func TestNewCredentialDoesNotPersistPRFResults(t *testing.T) {
+	// PRF results are secrets. They must never reach the credential record.
+	parsed := newTestParsedCredentialCreationData(t)
+	parsed.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		PRF: &protocol.PRFOutputs{Enabled: ptr(true), Results: &protocol.PRFValues{First: []byte("secret-prf-output")}},
+	}
+
+	credential, err := NewCredential(nil, parsed)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(credential)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "secret-prf-output")
+}
+
+func TestCredentialExtensionsAbsentIsOmitted(t *testing.T) {
+	parsed := newTestParsedCredentialCreationData(t)
+
+	credential, err := NewCredential(nil, parsed)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(credential)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), `"extensions"`)
+}
+
+func TestCredentialExtensionsRoundTrip(t *testing.T) {
+	original := Credential{
+		ID:        []byte("credential"),
+		PublicKey: []byte("key"),
+		Extensions: CredentialExtensions{
+			RK:                 ptr(false),
+			CredProtect:        protocol.CredentialProtectionPolicyUserVerificationRequired,
+			MinPinLength:       ptr(uint(6)),
+			PRFEnabled:         ptr(true),
+			LargeBlobSupported: ptr(false),
+		},
+	}
+
+	data, err := original.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	var decoded Credential
+
+	_, err = decoded.UnmarshalMsg(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Extensions, decoded.Extensions)
+
+	encoded, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decodedJSON Credential
+
+	require.NoError(t, json.Unmarshal(encoded, &decodedJSON))
+	assert.Equal(t, original.Extensions, decodedJSON.Extensions)
 }
 
 func TestCredential_SignalUnknownCredential(t *testing.T) {

--- a/webauthn/credential_test.go
+++ b/webauthn/credential_test.go
@@ -603,6 +603,8 @@ func TestNewCredentialRecordsExtensionResults(t *testing.T) {
 	parsed.Response.AttestationObject.AuthData.Ext = &protocol.AuthenticatorExtensionOutputs{
 		CredProtect:  ptr(protocol.CredentialProtectionPolicyUserVerificationRequired),
 		MinPinLength: ptr(uint(6)),
+		CredBlobSet:  ptr(true),
+		HMACSecret:   ptr(true),
 	}
 
 	credential, err := NewCredential(nil, parsed)
@@ -621,6 +623,50 @@ func TestNewCredentialRecordsExtensionResults(t *testing.T) {
 
 	require.NotNil(t, credential.Extensions.MinPinLength)
 	assert.Equal(t, uint(6), *credential.Extensions.MinPinLength)
+
+	require.NotNil(t, credential.Extensions.CredBlobSet)
+	assert.True(t, *credential.Extensions.CredBlobSet)
+
+	require.NotNil(t, credential.Extensions.HMACSecret)
+	assert.True(t, *credential.Extensions.HMACSecret)
+}
+
+// The hmac-secret capability arrives on two channels. The authenticator output is covered by the attestation
+// signature, so it wins; the client's hmacCreateSecret stands only when the authenticator omits it.
+func TestNewCredentialRecordsHMACSecretFromEitherSource(t *testing.T) {
+	testCases := []struct {
+		name     string
+		client   *bool
+		signed   *bool
+		expected *bool
+	}{
+		{name: "NeitherSource"},
+		{name: "ClientOnly", client: ptr(true), expected: ptr(true)},
+		{name: "AuthenticatorOnly", signed: ptr(true), expected: ptr(true)},
+		{name: "AuthenticatorWins", client: ptr(true), signed: ptr(false), expected: ptr(false)},
+		{name: "FalseIsRecorded", client: ptr(false), expected: ptr(false)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := newTestParsedCredentialCreationData(t)
+
+			parsed.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{HMACCreateSecret: tc.client}
+			parsed.Response.AttestationObject.AuthData.Ext = &protocol.AuthenticatorExtensionOutputs{HMACSecret: tc.signed}
+
+			credential, err := NewCredential(nil, parsed)
+			require.NoError(t, err)
+
+			if tc.expected == nil {
+				assert.Nil(t, credential.Extensions.HMACSecret)
+
+				return
+			}
+
+			require.NotNil(t, credential.Extensions.HMACSecret)
+			assert.Equal(t, *tc.expected, *credential.Extensions.HMACSecret)
+		})
+	}
 }
 
 func TestNewCredentialExtensionsDoNotAliasParsedResponse(t *testing.T) {
@@ -706,6 +752,8 @@ func TestCredentialExtensionsRoundTrip(t *testing.T) {
 			MinPinLength:       ptr(uint(6)),
 			PRFEnabled:         ptr(true),
 			LargeBlobSupported: ptr(false),
+			HMACSecret:         ptr(true),
+			CredBlobSet:        ptr(false),
 		},
 	}
 

--- a/webauthn/doc.go
+++ b/webauthn/doc.go
@@ -57,6 +57,36 @@
 //  1. Using a client side library like [@simplewebauthn/browser].
 //  2. Some browsers support the [parseCreationOptionsFromJSON] static method on the WebAuthn object.
 //
+// # Extensions
+//
+// Extension inputs are requested with [WithExtensions] for a registration ceremony and [WithAssertionExtensions]
+// for an authentication ceremony, each taking one or more [ExtensionOption] values such as
+// [WithExtensionCredProps] or [WithExtensionPRF]. An identifier this library does not model is set with
+// [WithExtension], which carries the value to the client verbatim; [protocol.ExtensionLargeBlobKey] is a
+// deliberate example of such an identifier, see its documentation for why it has no dedicated option.
+//
+// The subset of the inputs required to verify the responses is recorded in [SessionData], specifically its
+// [protocol.SessionExtensions] member. This includes the list of extension identifiers that were requested: by
+// default a client extension output the relying party did not request fails the ceremony, so a relying party
+// which reconstructs [SessionData] by hand rather than persisting the value returned by the Begin functions
+// verbatim will see legitimate outputs rejected. See [Config.ExtensionsUnsolicitedOutputPolicy] to relax this.
+//
+// That check covers client extension outputs ([protocol.AuthenticationExtensionsClientOutputs]) only. Authenticator
+// extension outputs decoded from the authenticator data ([protocol.AuthenticatorData.Ext]) are never checked
+// against what was requested, deliberately: CTAP authenticators routinely return credProtect unsolicited because
+// they apply a default protection policy of their own, and rejecting an unsolicited authenticator output would
+// fail otherwise-conforming hardware rather than a misbehaving client.
+//
+// Extension results which remain meaningful for the life of a credential, such as whether it is discoverable, are
+// recorded on [Credential.Extensions] and should be persisted with it. Pseudo-random function results are secrets
+// and are never recorded.
+//
+// A JSON extension member whose key differs from a modelled name only by case (e.g. "AppID" for "appid") is bound
+// to the modelled field by encoding/json before this library ever sees the untyped member map; if the value has
+// the wrong type for that field the whole response fails to parse, rather than the member falling back to the
+// extension's Extra map. See [protocol.AuthenticationExtensions] and [protocol.AuthenticationExtensionsClientOutputs]
+// for details.
+//
 // # Storage
 //
 // This section describes how a Relying Party should persist the state produced by the library: the [Credential]
@@ -84,6 +114,11 @@
 // One persistence shape is supported for the [SessionData] struct which is to store it as bytes via encoding/json or
 // using MessagePack as bytes in whatever storage system you're using for user sessions. This data MUST be definitively
 // anchored to a user's active session, and it must be restored between the ceremony steps.
+//
+// The serialized shape of [SessionData.Extensions] changes across releases whenever the extensions this library
+// models change, in both its JSON and MessagePack encodings. A [SessionData] value serialized by an older release
+// will not decode cleanly after such an upgrade, so in-flight sessions must be drained or invalidated as part of
+// the deployment rather than carried across it.
 //
 // Whichever encoding is used, the bytes handed back to the decoder MUST be bytes this library serialized and which the
 // Relying Party has kept integrity protected at rest and in transit. This matters most for the MessagePack decoders:

--- a/webauthn/example_extensions_test.go
+++ b/webauthn/example_extensions_test.go
@@ -1,0 +1,52 @@
+package webauthn_test
+
+import (
+	"fmt"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/webauthn"
+)
+
+// ExampleWithExtensions demonstrates requesting extensions during a registration ceremony, including an extension
+// this library does not model.
+func ExampleWithExtensions() {
+	var options protocol.PublicKeyCredentialCreationOptions
+
+	err := webauthn.WithExtensions(
+		webauthn.WithExtensionCredProps(),
+		webauthn.WithExtensionLargeBlobSupport(protocol.LargeBlobSupportPreferred),
+		webauthn.WithExtension("vendorThing", true),
+	)(&options)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(options.Extensions.CredProps)
+	fmt.Println(options.Extensions.LargeBlob.Support)
+	fmt.Println(options.Extensions.Extra["vendorThing"])
+
+	// Output:
+	// true
+	// preferred
+	// true
+}
+
+// ExampleParseAuthenticationExtensions demonstrates migrating a map of extension inputs written against a previous
+// release. The conversion is explicit and fallible; no functional option accepts a map.
+func ExampleParseAuthenticationExtensions() {
+	extensions, err := protocol.ParseAuthenticationExtensions(map[string]any{"credProps": true})
+	if err != nil {
+		panic(err)
+	}
+
+	var options protocol.PublicKeyCredentialCreationOptions
+
+	if err = webauthn.WithExtensions(webauthn.WithExtensionInputs(extensions))(&options); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(options.Extensions.CredProps)
+
+	// Output:
+	// true
+}

--- a/webauthn/example_multifactor_test.go
+++ b/webauthn/example_multifactor_test.go
@@ -89,7 +89,7 @@ func handlerExampleMultiFactorCreateChallenge(w *webauthn.WebAuthn) func(rw http
 
 		opts := []webauthn.RegistrationOption{
 			webauthn.WithExclusions(webauthn.Credentials(user.WebAuthnCredentials()).CredentialDescriptors()),
-			webauthn.WithExtensions(map[string]any{"credProps": true}),
+			webauthn.WithExtensions(webauthn.WithExtensionCredProps()),
 		}
 
 		if creation, s, err = w.BeginMediatedRegistration(user, protocol.MediationDefault, opts...); err != nil {

--- a/webauthn/example_passkey_test.go
+++ b/webauthn/example_passkey_test.go
@@ -95,7 +95,7 @@ func handlerExamplePasskeyCreateChallenge(w *webauthn.WebAuthn) func(rw http.Res
 		opts := []webauthn.RegistrationOption{
 			webauthn.WithResidentKeyRequirement(protocol.ResidentKeyRequirementRequired),
 			webauthn.WithExclusions(webauthn.Credentials(user.WebAuthnCredentials()).CredentialDescriptors()),
-			webauthn.WithExtensions(map[string]any{"credProps": true}),
+			webauthn.WithExtensions(webauthn.WithExtensionCredProps()),
 		}
 
 		if creation, s, err = w.BeginMediatedRegistration(user, protocol.MediationDefault, opts...); err != nil {

--- a/webauthn/extensions_opt.go
+++ b/webauthn/extensions_opt.go
@@ -1,0 +1,332 @@
+package webauthn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-webauthn/webauthn/protocol"
+)
+
+// ExtensionOption configures a single WebAuthn extension. The ceremony is supplied so an option can reject use in
+// a ceremony the extension does not apply to.
+//
+// Options are applied through [WithExtensions] for a registration ceremony and [WithAssertionExtensions] for an
+// authentication ceremony, which is how one definition serves both.
+type ExtensionOption func(e *protocol.AuthenticationExtensions, c protocol.CeremonyType) error
+
+// WithExtensions applies the given extension options to a registration ceremony.
+//
+// Specification: §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn-3/#extensions)
+func WithExtensions(opts ...ExtensionOption) RegistrationOption {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
+		return applyExtensionOptions(&cco.Extensions, protocol.CreateCeremony, opts)
+	}
+}
+
+// WithAssertionExtensions applies the given extension options to an authentication ceremony.
+//
+// Specification: §9. WebAuthn Extensions (https://www.w3.org/TR/webauthn-3/#extensions)
+func WithAssertionExtensions(opts ...ExtensionOption) LoginOption {
+	return func(pkcro *protocol.PublicKeyCredentialRequestOptions) error {
+		return applyExtensionOptions(&pkcro.Extensions, protocol.AssertCeremony, opts)
+	}
+}
+
+// applyExtensionOptions applies each option in order and then validates the resulting inputs against the ceremony.
+// The trailing validation is what constrains [WithExtensionInputs], which accepts a whole structure and therefore
+// cannot be checked by the individual options.
+func applyExtensionOptions(exts *protocol.AuthenticationExtensions, ceremony protocol.CeremonyType, opts []ExtensionOption) (err error) {
+	for _, opt := range opts {
+		if err = opt(exts, ceremony); err != nil {
+			return err
+		}
+	}
+
+	return exts.Validate(ceremony)
+}
+
+// forCeremony returns an ExtensionOption which applies the given function only when the ceremony matches, and
+// which otherwise reports that the extension does not apply.
+func forCeremony(name string, ceremony protocol.CeremonyType, apply func(e *protocol.AuthenticationExtensions)) ExtensionOption {
+	return func(e *protocol.AuthenticationExtensions, c protocol.CeremonyType) error {
+		if c != ceremony {
+			if ceremony == protocol.CreateCeremony {
+				return fmt.Errorf("extension %q is a registration extension but was provided for an authentication ceremony", name)
+			}
+
+			return fmt.Errorf("extension %q is an authentication extension but was provided for a registration ceremony", name)
+		}
+
+		apply(e)
+
+		return nil
+	}
+}
+
+// forAnyCeremony returns an ExtensionOption which applies to both ceremonies.
+func forAnyCeremony(apply func(e *protocol.AuthenticationExtensions)) ExtensionOption {
+	return func(e *protocol.AuthenticationExtensions, _ protocol.CeremonyType) error {
+		apply(e)
+
+		return nil
+	}
+}
+
+// WithExtensionInputs sets the extension inputs wholesale. It is the counterpart to
+// [protocol.ParseAuthenticationExtensions] for callers migrating from the previous map-based representation, and
+// replaces any inputs set by earlier options.
+//
+// The inputs are validated against the ceremony by the enclosing [WithExtensions] or [WithAssertionExtensions].
+//
+// The AppID and AppIDExclude members are subject to the same unconditional pruning as [WithExtensionAppID] and
+// [WithExtensionAppIDExclude]: [WebAuthn.BeginLogin] and [WebAuthn.BeginRegistration] discard them when the
+// relevant credential list contains no fido-u2f credential. There is no path that bypasses that.
+func WithExtensionInputs(in protocol.AuthenticationExtensions) ExtensionOption {
+	return forAnyCeremony(func(e *protocol.AuthenticationExtensions) {
+		*e = in
+	})
+}
+
+// WithExtension sets an extension input this library does not model, carrying the value through to the client
+// verbatim. An identifier this library does model is rejected; use its dedicated option instead so the value is
+// typed and the ceremony is checked.
+//
+// The identifier comparison is case-insensitive, matching both JSON codecs. An exact comparison would accept a
+// case variant such as "CredProps", place it in the untyped inputs, report it from
+// [protocol.AuthenticationExtensions.Requested], and then fail the whole options object at marshalling time with a
+// collision error, rather than naming the dedicated option here.
+func WithExtension(name string, value any) ExtensionOption {
+	return func(e *protocol.AuthenticationExtensions, _ protocol.CeremonyType) error {
+		for modelled, suffix := range extensionOptionSuffixes {
+			if strings.EqualFold(modelled, name) {
+				return fmt.Errorf("extension %q is modelled by this library; use WithExtension%s instead of WithExtension", name, suffix)
+			}
+		}
+
+		if e.Extra == nil {
+			e.Extra = map[string]any{}
+		}
+
+		e.Extra[name] = value
+
+		return nil
+	}
+}
+
+// suffixProtectionPolicy is the option-name suffix shared by the two credProtect identifiers, because a single
+// option sets both the policy and its enforcement flag.
+const suffixProtectionPolicy = "CredentialProtectionPolicy"
+
+// extensionOptionSuffixes maps each extension identifier which has a dedicated option to the name suffix of that
+// option. [WithExtension] rejects any identifier present here and names the option the caller should use instead.
+var extensionOptionSuffixes = map[string]string{
+	protocol.ExtensionAppID:                             "AppID",
+	protocol.ExtensionAppIDExclude:                      "AppIDExclude",
+	protocol.ExtensionCredProps:                         "CredProps",
+	protocol.ExtensionPRF:                               "PRF, WithExtensionPRFSupport or WithExtensionPRFByCredential",
+	protocol.ExtensionLargeBlob:                         "LargeBlobSupport, WithExtensionLargeBlobRead or WithExtensionLargeBlobWrite",
+	protocol.ExtensionRemoteClientDataJSON:              "RemoteClientDataJSON",
+	protocol.ExtensionCredentialProtectionPolicy:        suffixProtectionPolicy,
+	protocol.ExtensionEnforceCredentialProtectionPolicy: suffixProtectionPolicy,
+	protocol.ExtensionMinPinLength:                      "MinPinLength",
+	protocol.ExtensionCredBlob:                          "CredBlob",
+	protocol.ExtensionGetCredBlob:                       "GetCredBlob",
+	protocol.ExtensionHMACCreateSecret:                  "HMACCreateSecret",
+	protocol.ExtensionHMACGetSecret:                     "HMACGetSecret",
+	protocol.ExtensionUVM:                               "UVM",
+}
+
+// The following options apply to both ceremonies.
+
+// WithExtensionPRFSupport requests the pseudo-random function extension without supplying any salt to evaluate,
+// which is the bare "prf":{} input. It asks the client whether the pseudo-random function is available for the
+// credential; the answer arrives as the 'enabled' client extension output and is recorded on the credential record
+// as [CredentialExtensions.PRFEnabled]. It is the canonical registration-time probe, though it is accepted for both
+// ceremonies.
+//
+// It leaves any values set by [WithExtensionPRF] or [WithExtensionPRFByCredential] untouched, so ordering relative
+// to those options does not matter.
+//
+// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+func WithExtensionPRFSupport() ExtensionOption {
+	return forAnyCeremony(func(e *protocol.AuthenticationExtensions) {
+		if e.PRF == nil {
+			e.PRF = &protocol.PRFInputs{}
+		}
+	})
+}
+
+// WithExtensionPRF requests evaluation of the pseudo-random function for the credential. A zero eval requests the
+// extension without any salt to evaluate, which is equivalent to [WithExtensionPRFSupport].
+//
+// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+func WithExtensionPRF(eval protocol.PRFValues) ExtensionOption {
+	return forAnyCeremony(func(e *protocol.AuthenticationExtensions) {
+		if e.PRF == nil {
+			e.PRF = &protocol.PRFInputs{}
+		}
+
+		e.PRF.Eval = eval
+	})
+}
+
+// WithExtensionRemoteClientDataJSON sets the remote client data JSON. This extension is intended for a remote
+// desktop web client and a Relying Party should not normally set it; a Relying Party which receives the matching
+// output should understand that the local client delegated every RP ID and origin check to a remote host.
+//
+// Specification: §10.1.6. Remote Client Data JSON extension (https://www.w3.org/TR/webauthn-3/#sctn-remote-client-data-json-extension)
+func WithExtensionRemoteClientDataJSON(clientDataJSON string) ExtensionOption {
+	return forAnyCeremony(func(e *protocol.AuthenticationExtensions) {
+		e.RemoteClientDataJSON = clientDataJSON
+	})
+}
+
+// WithExtensionUVM requests the user verification methods used for the operation.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionUVM() ExtensionOption {
+	return forAnyCeremony(func(e *protocol.AuthenticationExtensions) {
+		e.UVM = true
+	})
+}
+
+// The following options apply to a registration ceremony only.
+
+// WithExtensionCredProps requests that the client reports the properties of the newly created credential.
+//
+// Specification: §10.1.3. Credential Properties Extension (https://www.w3.org/TR/webauthn-3/#sctn-authenticator-credential-properties-extension)
+func WithExtensionCredProps() ExtensionOption {
+	return forCeremony(protocol.ExtensionCredProps, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.CredProps = true
+	})
+}
+
+// WithExtensionAppIDExclude sets the FIDO AppID used to exclude credentials registered through the legacy FIDO U2F
+// JavaScript API. The value is discarded by [WebAuthn.BeginRegistration] when the exclude list contains no
+// credential with the fido-u2f attestation format, so the ordering of this option relative to [WithExclusions]
+// does not matter.
+//
+// Specification: §10.1.2. FIDO AppID Exclusion Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-exclude-extension)
+func WithExtensionAppIDExclude(appid string) ExtensionOption {
+	return forCeremony(protocol.ExtensionAppIDExclude, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.AppIDExclude = appid
+	})
+}
+
+// WithExtensionLargeBlobSupport requests large blob storage support for the credential.
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+func WithExtensionLargeBlobSupport(support protocol.LargeBlobSupport) ExtensionOption {
+	return forCeremony(protocol.ExtensionLargeBlob, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.LargeBlob.Support = support
+	})
+}
+
+// WithExtensionCredentialProtectionPolicy requests a credential protection policy, optionally requiring that the
+// authenticator honours it.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionCredentialProtectionPolicy(policy protocol.CredentialProtectionPolicy, enforce bool) ExtensionOption {
+	return forCeremony(protocol.ExtensionCredentialProtectionPolicy, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.CredentialProtectionPolicy = policy
+		e.EnforceCredentialProtectionPolicy = enforce
+	})
+}
+
+// WithExtensionMinPinLength requests the authenticator's current minimum PIN length.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionMinPinLength() ExtensionOption {
+	return forCeremony(protocol.ExtensionMinPinLength, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.MinPinLength = true
+	})
+}
+
+// WithExtensionCredBlob requests that the given blob is stored with the credential.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionCredBlob(blob []byte) ExtensionOption {
+	return forCeremony(protocol.ExtensionCredBlob, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.CredBlob = blob
+	})
+}
+
+// WithExtensionHMACCreateSecret requests that the authenticator provisions an HMAC secret for the credential.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionHMACCreateSecret() ExtensionOption {
+	return forCeremony(protocol.ExtensionHMACCreateSecret, protocol.CreateCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.HMACCreateSecret = true
+	})
+}
+
+// The following options apply to an authentication ceremony only.
+
+// WithExtensionAppID sets the FIDO AppID for credentials registered through the legacy FIDO U2F JavaScript API.
+// The value is discarded by [WebAuthn.BeginLogin] when the allowed credentials contain no credential with the
+// fido-u2f attestation format, so the ordering of this option relative to [WithAllowedCredentials] does not matter.
+//
+// Specification: §10.1.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)
+func WithExtensionAppID(appid string) ExtensionOption {
+	return forCeremony(protocol.ExtensionAppID, protocol.AssertCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.AppID = appid
+	})
+}
+
+// WithExtensionPRFByCredential requests per-credential evaluation of the pseudo-random function. The keys of
+// byCredential are base64url encoded credential IDs which MUST each match an entry of the allowed credentials.
+// A non-nil fallback is used for allowed credentials with no entry in the map; a nil fallback leaves any eval
+// value set by an earlier [WithExtensionPRF] untouched rather than clearing it.
+//
+// Specification: §10.1.4. Pseudo-random function extension (https://www.w3.org/TR/webauthn-3/#prf-extension)
+func WithExtensionPRFByCredential(byCredential map[string]protocol.PRFValues, fallback *protocol.PRFValues) ExtensionOption {
+	return forCeremony(protocol.ExtensionPRF, protocol.AssertCeremony, func(e *protocol.AuthenticationExtensions) {
+		if e.PRF == nil {
+			e.PRF = &protocol.PRFInputs{}
+		}
+
+		e.PRF.EvalByCredential = byCredential
+
+		if fallback != nil {
+			e.PRF.Eval = *fallback
+		}
+	})
+}
+
+// WithExtensionLargeBlobRead requests the blob stored with the credential.
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+func WithExtensionLargeBlobRead() ExtensionOption {
+	return forCeremony(protocol.ExtensionLargeBlob, protocol.AssertCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.LargeBlob.Read = true
+	})
+}
+
+// WithExtensionLargeBlobWrite requests that the given blob is written to the credential. This is mutually
+// exclusive with [WithExtensionLargeBlobRead].
+//
+// Specification: §10.1.5. Large blob storage extension (https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension)
+func WithExtensionLargeBlobWrite(blob []byte) ExtensionOption {
+	return forCeremony(protocol.ExtensionLargeBlob, protocol.AssertCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.LargeBlob.Write = blob
+	})
+}
+
+// WithExtensionGetCredBlob requests the blob stored with the credential.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionGetCredBlob() ExtensionOption {
+	return forCeremony(protocol.ExtensionGetCredBlob, protocol.AssertCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.GetCredBlob = true
+	})
+}
+
+// WithExtensionHMACGetSecret requests evaluation of the credential's HMAC secret with the given salts. Salt2 may
+// be nil.
+//
+// Registry: https://www.iana.org/assignments/webauthn/webauthn.xhtml
+func WithExtensionHMACGetSecret(salt1, salt2 []byte) ExtensionOption {
+	return forCeremony(protocol.ExtensionHMACGetSecret, protocol.AssertCeremony, func(e *protocol.AuthenticationExtensions) {
+		e.HMACGetSecret = protocol.HMACGetSecretInputs{Salt1: salt1, Salt2: salt2}
+	})
+}

--- a/webauthn/extensions_opt_test.go
+++ b/webauthn/extensions_opt_test.go
@@ -1,0 +1,419 @@
+package webauthn
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/protocol"
+)
+
+// testCredentialIDB64 is the base64url encoding of "foo", used as a per-credential PRF map key. The keys of
+// evalByCredential are base64url encoded credential IDs.
+const testCredentialIDB64 = "Zm9v"
+
+func applyRegistration(t *testing.T, opts ...ExtensionOption) (protocol.AuthenticationExtensions, error) {
+	t.Helper()
+
+	var options protocol.PublicKeyCredentialCreationOptions
+
+	err := WithExtensions(opts...)(&options)
+
+	return options.Extensions, err
+}
+
+func applyAssertion(t *testing.T, opts ...ExtensionOption) (protocol.AuthenticationExtensions, error) {
+	t.Helper()
+
+	var options protocol.PublicKeyCredentialRequestOptions
+
+	err := WithAssertionExtensions(opts...)(&options)
+
+	return options.Extensions, err
+}
+
+func TestWithExtensionCredProps(t *testing.T) {
+	exts, err := applyRegistration(t, WithExtensionCredProps())
+
+	require.NoError(t, err)
+	assert.True(t, exts.CredProps)
+}
+
+func TestWithExtensionCredPropsRejectedForAssertion(t *testing.T) {
+	_, err := applyAssertion(t, WithExtensionCredProps())
+
+	assert.ErrorContains(t, err, "credProps")
+	assert.ErrorContains(t, err, "registration extension")
+}
+
+func TestWithExtensionPRFAppliesToBothCeremonies(t *testing.T) {
+	values := protocol.PRFValues{First: []byte("salt")}
+
+	registration, err := applyRegistration(t, WithExtensionPRF(values))
+	require.NoError(t, err)
+	assert.Equal(t, values, registration.PRF.Eval)
+
+	assertion, err := applyAssertion(t, WithExtensionPRF(values))
+	require.NoError(t, err)
+	assert.Equal(t, values, assertion.PRF.Eval)
+}
+
+// TestWithExtensionPRFSupportRequestsTheBareProbe pins the bare "prf":{} probe: it must be emitted as an empty
+// dictionary and must be reported by Requested so the resulting 'enabled' output is not rejected as unsolicited.
+func TestWithExtensionPRFSupportRequestsTheBareProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		apply func(t *testing.T, opts ...ExtensionOption) (protocol.AuthenticationExtensions, error)
+	}{
+		{"Registration", applyRegistration},
+		{"Assertion", applyAssertion},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, opt := range []struct {
+				name   string
+				option ExtensionOption
+			}{
+				{"Support", WithExtensionPRFSupport()},
+				{"ZeroEval", WithExtensionPRF(protocol.PRFValues{})},
+				{"Inputs", WithExtensionInputs(protocol.AuthenticationExtensions{PRF: &protocol.PRFInputs{}})},
+			} {
+				t.Run(opt.name, func(t *testing.T) {
+					exts, err := tc.apply(t, opt.option)
+
+					require.NoError(t, err)
+					require.NotNil(t, exts.PRF)
+					assert.True(t, exts.PRF.IsZero())
+					assert.Equal(t, []string{protocol.ExtensionPRF}, exts.Requested())
+
+					data, err := json.Marshal(exts)
+
+					require.NoError(t, err)
+					assert.Equal(t, `{"prf":{}}`, string(data))
+				})
+			}
+		})
+	}
+}
+
+// TestWithExtensionPRFSupportPreservesEval pins that the probe option only ensures the member is present; it never
+// discards salts set by another PRF option, in either order.
+func TestWithExtensionPRFSupportPreservesEval(t *testing.T) {
+	eval := protocol.PRFValues{First: []byte("salt")}
+
+	before, err := applyRegistration(t, WithExtensionPRF(eval), WithExtensionPRFSupport())
+	require.NoError(t, err)
+	assert.Equal(t, &protocol.PRFInputs{Eval: eval}, before.PRF)
+
+	after, err := applyRegistration(t, WithExtensionPRFSupport(), WithExtensionPRF(eval))
+	require.NoError(t, err)
+	assert.Equal(t, &protocol.PRFInputs{Eval: eval}, after.PRF)
+}
+
+func TestWithExtensionPRFByCredentialRejectedForRegistration(t *testing.T) {
+	_, err := applyRegistration(t, WithExtensionPRFByCredential(map[string]protocol.PRFValues{
+		testCredentialIDB64: {First: []byte("salt")},
+	}, nil))
+
+	assert.ErrorContains(t, err, "prf")
+}
+
+func TestWithExtensionLargeBlobCeremonySplit(t *testing.T) {
+	registration, err := applyRegistration(t, WithExtensionLargeBlobSupport(protocol.LargeBlobSupportRequired))
+	require.NoError(t, err)
+	assert.Equal(t, protocol.LargeBlobSupportRequired, registration.LargeBlob.Support)
+
+	_, err = applyAssertion(t, WithExtensionLargeBlobSupport(protocol.LargeBlobSupportRequired))
+	assert.ErrorContains(t, err, "largeBlob")
+
+	assertion, err := applyAssertion(t, WithExtensionLargeBlobRead())
+	require.NoError(t, err)
+	assert.True(t, assertion.LargeBlob.Read)
+
+	_, err = applyRegistration(t, WithExtensionLargeBlobRead())
+	assert.ErrorContains(t, err, "largeBlob")
+}
+
+func TestWithExtensionGeneric(t *testing.T) {
+	exts, err := applyRegistration(t, WithExtension("vendorThing", true))
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"vendorThing": true}, exts.Extra)
+}
+
+func TestWithExtensionGenericRejectsModelledIdentifier(t *testing.T) {
+	_, err := applyRegistration(t, WithExtension("credProps", true))
+
+	assert.ErrorContains(t, err, "credProps")
+	assert.ErrorContains(t, err, "WithExtensionCredProps")
+}
+
+// TestWithExtensionGenericRejectsCaseVariantModelledIdentifier pins that the guard is case-insensitive, like both
+// JSON codecs. An exact comparison accepted the variant, placed it in Extra, reported it from Requested, and then
+// failed the whole options object at marshalling time with a collision error instead of naming the right option.
+func TestWithExtensionGenericRejectsCaseVariantModelledIdentifier(t *testing.T) {
+	for _, name := range []string{"CredProps", "CREDPROPS", "credprops"} {
+		t.Run(name, func(t *testing.T) {
+			exts, err := applyRegistration(t, WithExtension(name, true))
+
+			assert.ErrorContains(t, err, name)
+			assert.ErrorContains(t, err, "WithExtensionCredProps")
+			assert.Empty(t, exts.Extra)
+		})
+	}
+}
+
+func TestWithExtensionInputsIsValidatedForTheCeremony(t *testing.T) {
+	// The whole-struct entry point cannot be constrained by the individual options, so the adapter must validate.
+	_, err := applyAssertion(t, WithExtensionInputs(protocol.AuthenticationExtensions{CredProps: true}))
+
+	assert.ErrorContains(t, err, "credProps")
+}
+
+// TestExtensionOptionAppliesToTheCorrectField covers every per-extension option along two dimensions: the exact
+// inputs it produces in the ceremony it belongs to, and its rejection in the ceremony it does not. The expected
+// value is the whole [protocol.AuthenticationExtensions] rather than the single field under test, so an option
+// that writes the wrong field, or writes more than its own, fails here rather than shipping green.
+func TestExtensionOptionAppliesToTheCorrectField(t *testing.T) {
+	var (
+		eval         = protocol.PRFValues{First: []byte("first"), Second: []byte("second")}
+		byCredential = map[string]protocol.PRFValues{testCredentialIDB64: {First: []byte("salt")}}
+	)
+
+	testCases := []struct {
+		name string
+		// ceremony is the one the option belongs to. The empty value means both, in which case the option is
+		// applied to each in turn and there is no rejection to assert.
+		ceremony protocol.CeremonyType
+		// identifier is the extension name the rejection error must name.
+		identifier string
+		option     ExtensionOption
+		expected   protocol.AuthenticationExtensions
+	}{
+		{
+			name:     "WithExtensionPRF",
+			option:   WithExtensionPRF(eval),
+			expected: protocol.AuthenticationExtensions{PRF: &protocol.PRFInputs{Eval: eval}},
+		},
+		{
+			name:     "WithExtensionRemoteClientDataJSON",
+			option:   WithExtensionRemoteClientDataJSON(`{"origin":"https://example.com"}`),
+			expected: protocol.AuthenticationExtensions{RemoteClientDataJSON: `{"origin":"https://example.com"}`},
+		},
+		{
+			name:     "WithExtensionUVM",
+			option:   WithExtensionUVM(),
+			expected: protocol.AuthenticationExtensions{UVM: true},
+		},
+		{
+			name:       "WithExtensionCredProps",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionCredProps,
+			option:     WithExtensionCredProps(),
+			expected:   protocol.AuthenticationExtensions{CredProps: true},
+		},
+		{
+			name:       "WithExtensionAppIDExclude",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionAppIDExclude,
+			option:     WithExtensionAppIDExclude("https://example.com"),
+			expected:   protocol.AuthenticationExtensions{AppIDExclude: "https://example.com"},
+		},
+		{
+			name:       "WithExtensionLargeBlobSupport",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionLargeBlob,
+			option:     WithExtensionLargeBlobSupport(protocol.LargeBlobSupportPreferred),
+			expected:   protocol.AuthenticationExtensions{LargeBlob: protocol.LargeBlobInputs{Support: protocol.LargeBlobSupportPreferred}},
+		},
+		{
+			name:       "WithExtensionCredentialProtectionPolicy",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionCredentialProtectionPolicy,
+			option:     WithExtensionCredentialProtectionPolicy(protocol.CredentialProtectionPolicyUserVerificationRequired, true),
+			expected: protocol.AuthenticationExtensions{
+				CredentialProtectionPolicy:        protocol.CredentialProtectionPolicyUserVerificationRequired,
+				EnforceCredentialProtectionPolicy: true,
+			},
+		},
+		{
+			// The enforce flag must not be set when it was not asked for.
+			name:       "WithExtensionCredentialProtectionPolicyWithoutEnforcement",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionCredentialProtectionPolicy,
+			option:     WithExtensionCredentialProtectionPolicy(protocol.CredentialProtectionPolicyUserVerificationOptional, false),
+			expected: protocol.AuthenticationExtensions{
+				CredentialProtectionPolicy: protocol.CredentialProtectionPolicyUserVerificationOptional,
+			},
+		},
+		{
+			name:       "WithExtensionMinPinLength",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionMinPinLength,
+			option:     WithExtensionMinPinLength(),
+			expected:   protocol.AuthenticationExtensions{MinPinLength: true},
+		},
+		{
+			name:       "WithExtensionCredBlob",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionCredBlob,
+			option:     WithExtensionCredBlob([]byte("blob")),
+			expected:   protocol.AuthenticationExtensions{CredBlob: []byte("blob")},
+		},
+		{
+			name:       "WithExtensionHMACCreateSecret",
+			ceremony:   protocol.CreateCeremony,
+			identifier: protocol.ExtensionHMACCreateSecret,
+			option:     WithExtensionHMACCreateSecret(),
+			expected:   protocol.AuthenticationExtensions{HMACCreateSecret: true},
+		},
+		{
+			name:       "WithExtensionAppID",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionAppID,
+			option:     WithExtensionAppID("https://example.com"),
+			expected:   protocol.AuthenticationExtensions{AppID: "https://example.com"},
+		},
+		{
+			name:       "WithExtensionPRFByCredential",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionPRF,
+			option:     WithExtensionPRFByCredential(byCredential, nil),
+			expected:   protocol.AuthenticationExtensions{PRF: &protocol.PRFInputs{EvalByCredential: byCredential}},
+		},
+		{
+			name:       "WithExtensionPRFByCredentialWithFallback",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionPRF,
+			option:     WithExtensionPRFByCredential(byCredential, &eval),
+			expected:   protocol.AuthenticationExtensions{PRF: &protocol.PRFInputs{Eval: eval, EvalByCredential: byCredential}},
+		},
+		{
+			name:       "WithExtensionLargeBlobRead",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionLargeBlob,
+			option:     WithExtensionLargeBlobRead(),
+			expected:   protocol.AuthenticationExtensions{LargeBlob: protocol.LargeBlobInputs{Read: true}},
+		},
+		{
+			name:       "WithExtensionLargeBlobWrite",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionLargeBlob,
+			option:     WithExtensionLargeBlobWrite([]byte("blob")),
+			expected:   protocol.AuthenticationExtensions{LargeBlob: protocol.LargeBlobInputs{Write: []byte("blob")}},
+		},
+		{
+			name:       "WithExtensionGetCredBlob",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionGetCredBlob,
+			option:     WithExtensionGetCredBlob(),
+			expected:   protocol.AuthenticationExtensions{GetCredBlob: true},
+		},
+		{
+			name:       "WithExtensionHMACGetSecret",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionHMACGetSecret,
+			option:     WithExtensionHMACGetSecret([]byte("salt1"), []byte("salt2")),
+			expected: protocol.AuthenticationExtensions{
+				HMACGetSecret: protocol.HMACGetSecretInputs{Salt1: []byte("salt1"), Salt2: []byte("salt2")},
+			},
+		},
+		{
+			// Salt2 is optional and must stay absent rather than becoming an empty non-nil slice.
+			name:       "WithExtensionHMACGetSecretWithoutSalt2",
+			ceremony:   protocol.AssertCeremony,
+			identifier: protocol.ExtensionHMACGetSecret,
+			option:     WithExtensionHMACGetSecret([]byte("salt1"), nil),
+			expected: protocol.AuthenticationExtensions{
+				HMACGetSecret: protocol.HMACGetSecretInputs{Salt1: []byte("salt1")},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.ceremony == "" {
+				require.Empty(t, tc.identifier, "an option valid in both ceremonies has no rejection to assert")
+
+				registration, err := applyRegistration(t, tc.option)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, registration)
+
+				assertion, err := applyAssertion(t, tc.option)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, assertion)
+
+				return
+			}
+
+			apply, reject := applyRegistration, applyAssertion
+			direction := "is a registration extension but was provided for an authentication ceremony"
+
+			if tc.ceremony == protocol.AssertCeremony {
+				apply, reject = applyAssertion, applyRegistration
+				direction = "is an authentication extension but was provided for a registration ceremony"
+			}
+
+			actual, err := apply(t, tc.option)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+
+			_, err = reject(t, tc.option)
+			assert.EqualError(t, err, fmt.Sprintf("extension %q %s", tc.identifier, direction))
+		})
+	}
+}
+
+// TestWithExtensionPRFByCredentialNilFallbackPreservesEval pins the documented behaviour of a nil fallback: it
+// leaves an eval set by an earlier option alone rather than clearing it.
+func TestWithExtensionPRFByCredentialNilFallbackPreservesEval(t *testing.T) {
+	var (
+		eval         = protocol.PRFValues{First: []byte("first")}
+		byCredential = map[string]protocol.PRFValues{testCredentialIDB64: {First: []byte("salt")}}
+	)
+
+	exts, err := applyAssertion(t, WithExtensionPRF(eval), WithExtensionPRFByCredential(byCredential, nil))
+
+	require.NoError(t, err)
+	assert.Equal(t, &protocol.PRFInputs{Eval: eval, EvalByCredential: byCredential}, exts.PRF)
+}
+
+// TestWithExtensionInputsReplacesEarlierOptions pins the documented clobbering: WithExtensionInputs assigns the
+// whole structure, so anything an earlier option set is discarded rather than merged.
+func TestWithExtensionInputsReplacesEarlierOptions(t *testing.T) {
+	exts, err := applyRegistration(t,
+		WithExtensionCredProps(),
+		WithExtensionInputs(protocol.AuthenticationExtensions{MinPinLength: true}),
+	)
+
+	require.NoError(t, err)
+	assert.False(t, exts.CredProps)
+	assert.True(t, exts.MinPinLength)
+	assert.Equal(t, protocol.AuthenticationExtensions{MinPinLength: true}, exts)
+}
+
+// TestWithExtensionLargeBlobKeyIsReachableAsAnUnmodelledExtension guards the decision recorded on
+// [protocol.ExtensionLargeBlobKey]: the identifier has no dedicated option because CTAP 2.1 §12.3 defines no
+// client extension input or output for it, so it must route through the generic escape hatch instead.
+func TestWithExtensionLargeBlobKeyIsReachableAsAnUnmodelledExtension(t *testing.T) {
+	exts, err := applyRegistration(t, WithExtension(protocol.ExtensionLargeBlobKey, true))
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{protocol.ExtensionLargeBlobKey: true}, exts.Extra)
+	assert.Equal(t, []string{protocol.ExtensionLargeBlobKey}, exts.Requested())
+}
+
+func TestWithExtensionsComposes(t *testing.T) {
+	exts, err := applyRegistration(t,
+		WithExtensionCredProps(),
+		WithExtensionMinPinLength(),
+		WithExtension("vendorCounter", 1),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, exts.CredProps)
+	assert.True(t, exts.MinPinLength)
+	assert.Equal(t, map[string]any{"vendorCounter": 1}, exts.Extra)
+}

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -15,7 +15,9 @@ import (
 // LoginOption is a functional option that modifies the [protocol.PublicKeyCredentialRequestOptions] sent to the
 // client during a login ceremony. Use the With* functions in this package (i.e. [WithUserVerification],
 // [WithAllowedCredentials]) to create login options.
-type LoginOption func(*protocol.PublicKeyCredentialRequestOptions)
+//
+// An option returns an error to reject the ceremony; [WebAuthn.BeginLogin] aborts on the first error.
+type LoginOption func(*protocol.PublicKeyCredentialRequestOptions) error
 
 // DiscoverableUserHandler is a callback function that the Relying Party must provide when performing a discoverable
 // (passkey) login. It is called with the rawID of the credential and the userHandle from the authenticator response,
@@ -91,7 +93,9 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 	}
 
 	for _, opt := range opts {
-		opt(&assertion.Response)
+		if err = opt(&assertion.Response); err != nil {
+			return nil, nil, fmt.Errorf("error applying login option: %w", err)
+		}
 	}
 
 	if len(assertion.Response.Challenge) == 0 {
@@ -122,13 +126,19 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 		}
 	}
 
+	// See the equivalent comment in BeginMediatedRegistration. A discoverable login has no allowed credentials and
+	// therefore never carries a FIDO U2F credential.
+	if !hasU2FCredential(assertion.Response.AllowedCredentials) {
+		assertion.Response.Extensions.AppID = ""
+	}
+
 	session = &SessionData{
 		Challenge:            assertion.Response.Challenge.String(),
 		RelyingPartyID:       assertion.Response.RelyingPartyID,
 		UserID:               userID,
 		AllowedCredentialIDs: assertion.Response.GetAllowedCredentialIDs(),
 		UserVerification:     assertion.Response.UserVerification,
-		Extensions:           assertion.Response.Extensions,
+		Extensions:           assertion.Response.Extensions.Session(),
 	}
 
 	if webauthn.Config.Timeouts.Login.Enforce {
@@ -364,6 +374,10 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 
 	// Handle steps 4 through 16.
 	if err = parsedResponse.Verify(session.Challenge, rpID, appID, rpOrigins, rpTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, credential.PublicKey, webauthn.Config.Signature); err != nil {
+		return nil, err
+	}
+
+	if err = parsedResponse.ClientExtensionResults.Verify(session.Extensions, protocol.AssertCeremony, webauthn.Config.ExtensionsUnsolicitedOutputPolicy); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/login_opt.go
+++ b/webauthn/login_opt.go
@@ -81,8 +81,9 @@ func WithAssertionPublicKeyCredentialHints(hints []protocol.PublicKeyCredentialH
 	}
 }
 
-// WithAppIdExtension automatically includes the specified appid if the AllowedCredentials contains a credential
-// with the fido-u2f attestation format.
+// WithAppIdExtension sets the specified appid as the FIDO AppID Extension input. The option itself always sets
+// it; [WebAuthn.BeginLogin] then discards it unless the AllowedCredentials contains a credential with the fido-u2f
+// attestation format, which is what makes the result independent of the order the options were supplied in.
 //
 // Specification: §5.5. Options for Assertion Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-extensions)
 //

--- a/webauthn/login_opt.go
+++ b/webauthn/login_opt.go
@@ -24,8 +24,10 @@ import "github.com/go-webauthn/webauthn/protocol"
 //
 // Specification: §13.4.3. Cryptographic Challenges (https://www.w3.org/TR/webauthn/#sctn-cryptographic-challenges)
 func WithChallenge(challenge []byte) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) error {
 		cco.Challenge = challenge
+
+		return nil
 	}
 }
 
@@ -33,8 +35,10 @@ func WithChallenge(challenge []byte) LoginOption {
 //
 // Specification: §5.5. Options for Assertion Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-rpid)
 func WithLoginRelyingPartyID(id string) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) error {
 		cco.RelyingPartyID = id
+
+		return nil
 	}
 }
 
@@ -45,8 +49,10 @@ func WithLoginRelyingPartyID(id string) LoginOption {
 //
 // Specification: §5.10.3. Credential Descriptor (https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor)
 func WithAllowedCredentials(allowList []protocol.CredentialDescriptor) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) error {
 		cco.AllowedCredentials = allowList
+
+		return nil
 	}
 }
 
@@ -54,8 +60,10 @@ func WithAllowedCredentials(allowList []protocol.CredentialDescriptor) LoginOpti
 //
 // Specification: §5.5. Options for Assertion Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-userverification)
 func WithUserVerification(userVerification protocol.UserVerificationRequirement) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) error {
 		cco.UserVerification = userVerification
+
+		return nil
 	}
 }
 
@@ -66,36 +74,22 @@ func WithUserVerification(userVerification protocol.UserVerificationRequirement)
 //
 // Specification: §5.5. Options for Assertion Generation (https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialrequestoptions-hints)
 func WithAssertionPublicKeyCredentialHints(hints []protocol.PublicKeyCredentialHints) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) error {
 		cco.Hints = hints
-	}
-}
 
-// WithAssertionExtensions adjusts the requested extensions by providing a [protocol.AuthenticationExtensions].
-//
-// Specification: §5.5. Options for Assertion Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-extensions)
-func WithAssertionExtensions(extensions protocol.AuthenticationExtensions) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
-		cco.Extensions = extensions
+		return nil
 	}
 }
 
 // WithAppIdExtension automatically includes the specified appid if the AllowedCredentials contains a credential
-// with the type `fido-u2f`.
+// with the fido-u2f attestation format.
 //
 // Specification: §5.5. Options for Assertion Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialrequestoptions-extensions)
+//
+// Specification: §10.1.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)
+//
+// Deprecated: use [WithAssertionExtensions] with [WithExtensionAppID], which is order-independent with respect to
+// [WithAllowedCredentials].
 func WithAppIdExtension(appid string) LoginOption {
-	return func(cco *protocol.PublicKeyCredentialRequestOptions) {
-		for _, credential := range cco.AllowedCredentials {
-			if credential.AttestationFormat == string(protocol.AttestationFormatFIDOUniversalSecondFactor) {
-				if cco.Extensions == nil {
-					cco.Extensions = map[string]any{}
-				}
-
-				cco.Extensions[protocol.ExtensionAppID] = appid
-
-				break
-			}
-		}
-	}
+	return WithAssertionExtensions(WithExtensionAppID(appid))
 }

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -1616,3 +1616,90 @@ func testDecodeHex(t *testing.T, s string) []byte {
 
 	return data
 }
+
+func TestValidateLoginExtensionOutputs(t *testing.T) {
+	userID := []byte(testUserID)
+
+	newFixture := func(t *testing.T, attestationFormat string) (*WebAuthn, *defaultUser, SessionData, *protocol.ParsedCredentialAssertionData) {
+		t.Helper()
+
+		parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
+
+		w := &WebAuthn{
+			Config: &Config{
+				RPID:      "example.org",
+				RPOrigins: []string{"https://example.org"},
+			},
+		}
+
+		user := &defaultUser{
+			id: userID,
+			credentials: []Credential{
+				{
+					ID:                credentialID,
+					PublicKey:         credPubKey,
+					AttestationFormat: attestationFormat,
+					Flags:             CredentialFlags{UserPresent: true, BackupEligible: true},
+				},
+			},
+		}
+
+		return w, user, SessionData{UserID: userID, Challenge: challenge}, parsedResponse
+	}
+
+	t.Run("AppIDWithoutSessionValue", func(t *testing.T) {
+		// The client says it acted on the FIDO AppID extension for a credential registered through the legacy U2F
+		// API, but the session records no appid, so there is no value to verify the assertion's RP ID against.
+		w, user, session, response := newFixture(t, string(protocol.AttestationFormatFIDOUniversalSecondFactor))
+
+		response.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{AppID: ptr(true)}
+
+		credential, err := w.ValidateLogin(user, session, response)
+
+		assert.Nil(t, credential)
+		assert.ErrorContains(t, err, "appid")
+	})
+
+	t.Run("UnsolicitedOutput", func(t *testing.T) {
+		// The same output against a credential which is not U2F leaves GetAppID with nothing to do, so the
+		// unsolicited check is what rejects it: the session never asked for the extension.
+		w, user, session, response := newFixture(t, string(protocol.AttestationFormatPacked))
+
+		response.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{AppID: ptr(true)}
+
+		credential, err := w.ValidateLogin(user, session, response)
+
+		assert.Nil(t, credential)
+		assert.ErrorContains(t, err, "was not requested")
+	})
+
+	t.Run("SolicitedOutput", func(t *testing.T) {
+		// The discriminating case: the same output passes once the session records that it was asked for.
+		w, user, session, response := newFixture(t, string(protocol.AttestationFormatPacked))
+
+		response.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{AppID: ptr(true)}
+		session.Extensions = protocol.SessionExtensions{Requested: []string{protocol.ExtensionAppID}}
+
+		credential, err := w.ValidateLogin(user, session, response)
+
+		require.NoError(t, err)
+		require.NotNil(t, credential)
+	})
+}
+
+func TestBeginLoginRejectsInvalidConfig(t *testing.T) {
+	// As with registration, the lazily validated configuration must stop the ceremony rather than producing
+	// request options from an incomplete configuration.
+	w := &WebAuthn{Config: &Config{}}
+
+	user := &defaultUser{
+		id:          []byte(testUserID),
+		credentials: []Credential{{ID: []byte("credential")}},
+	}
+
+	assertion, session, err := w.BeginLogin(user)
+
+	assert.Nil(t, assertion)
+	assert.Nil(t, session)
+	assert.ErrorContains(t, err, "error occurred validating the configuration")
+}

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -2,6 +2,7 @@ package webauthn
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -730,16 +731,19 @@ func TestLoginOptions(t *testing.T) {
 		},
 		{
 			name: "Extensions",
-			opts: []LoginOption{WithAssertionExtensions(protocol.AuthenticationExtensions{"example": "extension"})},
+			opts: []LoginOption{WithAssertionExtensions(WithExtensionGetCredBlob())},
 			expected: protocol.PublicKeyCredentialRequestOptions{
-				Extensions: protocol.AuthenticationExtensions{"example": "extension"},
+				Extensions: protocol.AuthenticationExtensions{GetCredBlob: true},
 			},
 		},
 		{
+			// The option itself no longer inspects the allowed credentials; the appid is discarded by
+			// BeginLogin instead, which TestBeginLoginAppIDPruning covers.
 			name: "AppIDExtensionWithoutU2F",
 			opts: []LoginOption{WithAllowedCredentials([]protocol.CredentialDescriptor{{Type: protocol.PublicKeyCredentialType, CredentialID: []byte("123")}}), WithAppIdExtension("example")},
 			expected: protocol.PublicKeyCredentialRequestOptions{
 				AllowedCredentials: []protocol.CredentialDescriptor{{Type: protocol.PublicKeyCredentialType, CredentialID: []byte("123")}},
+				Extensions:         protocol.AuthenticationExtensions{AppID: "example"},
 			},
 		},
 		{
@@ -747,7 +751,7 @@ func TestLoginOptions(t *testing.T) {
 			opts: []LoginOption{WithAllowedCredentials([]protocol.CredentialDescriptor{{Type: protocol.PublicKeyCredentialType, AttestationFormat: string(protocol.AttestationFormatFIDOUniversalSecondFactor), CredentialID: []byte("123")}}), WithAppIdExtension("example")},
 			expected: protocol.PublicKeyCredentialRequestOptions{
 				AllowedCredentials: []protocol.CredentialDescriptor{{Type: protocol.PublicKeyCredentialType, AttestationFormat: string(protocol.AttestationFormatFIDOUniversalSecondFactor), CredentialID: []byte("123")}},
-				Extensions:         protocol.AuthenticationExtensions{protocol.ExtensionAppID: "example"},
+				Extensions:         protocol.AuthenticationExtensions{AppID: "example"},
 			},
 		},
 		{
@@ -771,12 +775,116 @@ func TestLoginOptions(t *testing.T) {
 			opts := &tc.have
 
 			for _, opt := range tc.opts {
-				opt(opts)
+				require.NoError(t, opt(opts))
 			}
 
 			assert.Equal(t, tc.expected, *opts)
 		})
 	}
+}
+
+// newTestLoginUser returns a [User] with a single credential. [WebAuthn.BeginLogin] rejects a user with none, so
+// newTestUser cannot be used for an authentication ceremony.
+func newTestLoginUser(t *testing.T) User {
+	t.Helper()
+
+	return &defaultUser{
+		id:          []byte(testUserID),
+		credentials: []Credential{{ID: []byte("credential-id")}},
+	}
+}
+
+func TestBeginLoginAppIDPruning(t *testing.T) {
+	u2f := protocol.CredentialDescriptor{
+		Type:              protocol.PublicKeyCredentialType,
+		CredentialID:      []byte("u2f-credential"),
+		AttestationFormat: string(protocol.AttestationFormatFIDOUniversalSecondFactor),
+	}
+
+	packed := protocol.CredentialDescriptor{
+		Type:              protocol.PublicKeyCredentialType,
+		CredentialID:      []byte("packed-credential"),
+		AttestationFormat: string(protocol.AttestationFormatPacked),
+	}
+
+	testCases := []struct {
+		name     string
+		allow    []protocol.CredentialDescriptor
+		expected string
+	}{
+		{"U2FPresent", []protocol.CredentialDescriptor{packed, u2f}, "https://example.com"},
+		{"NoU2F", []protocol.CredentialDescriptor{packed}, ""},
+		{"Empty", nil, ""},
+	}
+
+	for _, tc := range testCases {
+		// Both orderings must produce identical results; the option previously read the allowed credentials at the
+		// moment it ran, so listing it first silently did nothing.
+		t.Run(tc.name+"/OptionAfterAllowedCredentials", func(t *testing.T) {
+			w := newTestWebAuthn(t)
+
+			assertion, session, err := w.BeginLogin(newTestLoginUser(t),
+				WithAllowedCredentials(tc.allow),
+				WithAssertionExtensions(WithExtensionAppID("https://example.com")),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, assertion.Response.Extensions.AppID)
+			assert.Equal(t, tc.expected, session.Extensions.AppID)
+		})
+
+		t.Run(tc.name+"/OptionBeforeAllowedCredentials", func(t *testing.T) {
+			w := newTestWebAuthn(t)
+
+			assertion, session, err := w.BeginLogin(newTestLoginUser(t),
+				WithAssertionExtensions(WithExtensionAppID("https://example.com")),
+				WithAllowedCredentials(tc.allow),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, assertion.Response.Extensions.AppID)
+			assert.Equal(t, tc.expected, session.Extensions.AppID)
+		})
+
+		// The deprecated wrapper delegates to the same option and must therefore be pruned identically.
+		t.Run(tc.name+"/DeprecatedWrapperBeforeAllowedCredentials", func(t *testing.T) {
+			w := newTestWebAuthn(t)
+
+			assertion, session, err := w.BeginLogin(newTestLoginUser(t),
+				WithAppIdExtension("https://example.com"),
+				WithAllowedCredentials(tc.allow),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, assertion.Response.Extensions.AppID)
+			assert.Equal(t, tc.expected, session.Extensions.AppID)
+		})
+	}
+}
+
+func TestBeginDiscoverableLoginAppIDPruning(t *testing.T) {
+	w := newTestWebAuthn(t)
+
+	// A discoverable login has no allowed credentials and so can never carry a FIDO U2F credential.
+	assertion, session, err := w.BeginDiscoverableLogin(WithAssertionExtensions(WithExtensionAppID("https://example.com")))
+
+	require.NoError(t, err)
+	assert.Empty(t, assertion.Response.AllowedCredentials)
+	assert.Empty(t, assertion.Response.Extensions.AppID)
+	assert.Empty(t, session.Extensions.AppID)
+}
+
+func TestBeginLoginAppIDPruningUpdatesRequested(t *testing.T) {
+	w := newTestWebAuthn(t)
+
+	_, session, err := w.BeginLogin(newTestLoginUser(t),
+		WithAllowedCredentials(nil),
+		WithAssertionExtensions(WithExtensionAppID("https://example.com"), WithExtensionGetCredBlob()),
+	)
+
+	require.NoError(t, err)
+	assert.NotContains(t, session.Extensions.Requested, protocol.ExtensionAppID)
+	assert.Contains(t, session.Extensions.Requested, protocol.ExtensionGetCredBlob)
 }
 
 func TestValidateLogin_Full(t *testing.T) {
@@ -789,7 +897,7 @@ func TestValidateLogin_Full(t *testing.T) {
 		},
 	}
 
-	userID := []byte("test-user-id")
+	userID := []byte(testUserID)
 
 	t.Run("ShouldSucceedNoAllowedCredentials", func(t *testing.T) {
 		user := &defaultUser{
@@ -1143,10 +1251,112 @@ func TestValidateLogin_Full(t *testing.T) {
 	})
 }
 
+func TestValidateLoginRejectsUnsolicitedExtensionOutput(t *testing.T) {
+	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
+
+	parsedResponse.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		AppID: ptr(true),
+	}
+
+	webauthn := &WebAuthn{
+		Config: &Config{
+			RPID:      "example.org",
+			RPOrigins: []string{"https://example.org"},
+		},
+	}
+
+	userID := []byte(testUserID)
+
+	user := &defaultUser{
+		id: userID,
+		credentials: []Credential{
+			{
+				ID:        credentialID,
+				PublicKey: credPubKey,
+				Flags: CredentialFlags{
+					UserPresent:    true,
+					BackupEligible: true,
+				},
+			},
+		},
+	}
+
+	session := SessionData{
+		UserID:     userID,
+		Challenge:  challenge,
+		Extensions: protocol.SessionExtensions{},
+	}
+
+	credential, err := webauthn.ValidateLogin(user, session, parsedResponse)
+	assert.Nil(t, credential)
+	assert.ErrorContains(t, err, "appid")
+}
+
+// TestValidateLoginAppIDFromSessionReplacesRPID asserts that an assertion whose authenticator data is scoped to the
+// RP ID is rejected once the session's appid is in play, rather than being accepted because the RP ID hash still
+// matches. The appid used is the one recorded in the session, so the failure is reported against the AppID hash.
+//
+// Specification: §10.1.1. FIDO AppID Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-extension)
+func TestValidateLoginAppIDFromSessionReplacesRPID(t *testing.T) {
+	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
+
+	parsedResponse.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		AppID: ptr(true),
+	}
+
+	webauthn := &WebAuthn{
+		Config: &Config{
+			RPID:      "example.org",
+			RPOrigins: []string{"https://example.org"},
+		},
+	}
+
+	userID := []byte(testUserID)
+
+	user := &defaultUser{
+		id: userID,
+		credentials: []Credential{
+			{
+				ID:        credentialID,
+				PublicKey: credPubKey,
+				// GetAppID only resolves the session appid for a credential which came from the legacy FIDO U2F
+				// JavaScript API.
+				AttestationFormat: string(protocol.AttestationFormatFIDOUniversalSecondFactor),
+				Flags: CredentialFlags{
+					UserPresent:    true,
+					BackupEligible: true,
+				},
+			},
+		},
+	}
+
+	session := SessionData{
+		UserID:    userID,
+		Challenge: challenge,
+		Extensions: protocol.SessionExtensions{
+			Requested: []string{protocol.ExtensionAppID},
+			AppID:     "https://appid.example.com",
+		},
+	}
+
+	credential, err := webauthn.ValidateLogin(user, session, parsedResponse)
+	assert.Nil(t, credential)
+	require.EqualError(t, err, "Error validating the authenticator response")
+
+	// The expected value is the hash of the session's appid, proving the RP ID hash is no longer accepted as an
+	// alternative once the extension applies.
+	appIDHash := sha256.Sum256([]byte(session.Extensions.AppID))
+
+	var e *protocol.Error
+
+	require.ErrorAs(t, err, &e)
+	assert.Equal(t, fmt.Sprintf("RP Hash mismatch. Expected %x and Received %x", appIDHash, parsedResponse.Response.AuthenticatorData.RPIDHash), e.DevInfo)
+}
+
 func TestValidatePasskeyLogin_Full(t *testing.T) {
 	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
 
-	userID := []byte("test-user-id")
+	userID := []byte(testUserID)
 	parsedResponse.Response.UserHandle = userID
 
 	t.Run("ShouldSucceed", func(t *testing.T) {
@@ -1222,7 +1432,7 @@ func TestValidatePasskeyLogin_Full(t *testing.T) {
 func TestFinishDiscoverableLogin_Success(t *testing.T) {
 	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
 
-	userID := []byte("test-user-id")
+	userID := []byte(testUserID)
 
 	body := map[string]any{
 		"id":    base64.RawURLEncoding.EncodeToString(credentialID),
@@ -1280,7 +1490,7 @@ func TestFinishDiscoverableLogin_Success(t *testing.T) {
 func TestFinishPasskeyLogin_Success(t *testing.T) {
 	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
 
-	userID := []byte("test-user-id")
+	userID := []byte(testUserID)
 
 	body := map[string]any{
 		"id":    base64.RawURLEncoding.EncodeToString(credentialID),
@@ -1381,6 +1591,21 @@ func testLoginSpecVectorNoneES256(t *testing.T) (parsedResponse *protocol.Parsed
 	require.NoError(t, err)
 
 	return parsedResponse, credPubKey, challenge, credentialID
+}
+
+func TestBeginLoginOptionError(t *testing.T) {
+	w, err := New(&Config{RPID: "example.com", RPDisplayName: "Test", RPOrigins: []string{"https://example.com"}})
+	require.NoError(t, err)
+
+	opt := func(pkcro *protocol.PublicKeyCredentialRequestOptions) error {
+		return fmt.Errorf("boom")
+	}
+
+	assertion, session, err := w.BeginDiscoverableLogin(opt)
+
+	assert.Nil(t, assertion)
+	assert.Nil(t, session)
+	assert.EqualError(t, err, "error applying login option: boom")
 }
 
 func testDecodeHex(t *testing.T, s string) []byte {

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -1,10 +1,10 @@
 package webauthn
 
 import (
-	"slices"
 	"bytes"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -226,8 +226,8 @@ func ValidateFilteredCredential(credential *Credential, filtering *FilteringConf
 			success = true
 		} else {
 			if slices.Contains(filtering.PermittedAAGUIDs, aaguid) {
-					success = true
-				}
+				success = true
+			}
 		}
 
 		if !success {
@@ -237,8 +237,8 @@ func ValidateFilteredCredential(credential *Credential, filtering *FilteringConf
 
 	if len(filtering.ProhibitedAAGUIDs) != 0 {
 		if slices.Contains(filtering.ProhibitedAAGUIDs, aaguid) {
-				return protocol.ErrPolicyRestriction.WithInfo("Credential has an AAGUID which is prohibited")
-			}
+			return protocol.ErrPolicyRestriction.WithInfo("Credential has an AAGUID which is prohibited")
+		}
 	}
 
 	return nil

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -1,6 +1,7 @@
 package webauthn
 
 import (
+	"slices"
 	"bytes"
 	"fmt"
 	"net/http"
@@ -171,6 +172,10 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 		return nil, err
 	}
 
+	if err = parsedResponse.Response.AttestationObject.AuthData.Ext.Verify(session.Extensions, protocol.CreateCeremony); err != nil {
+		return nil, err
+	}
+
 	if credential, err = NewCredential(clientDataHash, parsedResponse); err != nil {
 		return nil, err
 	}
@@ -220,13 +225,9 @@ func ValidateFilteredCredential(credential *Credential, filtering *FilteringConf
 		if aaguid == uuid.Nil {
 			success = true
 		} else {
-			for _, permitted := range filtering.PermittedAAGUIDs {
-				if permitted == aaguid {
+			if slices.Contains(filtering.PermittedAAGUIDs, aaguid) {
 					success = true
-
-					break
 				}
-			}
 		}
 
 		if !success {
@@ -235,11 +236,9 @@ func ValidateFilteredCredential(credential *Credential, filtering *FilteringConf
 	}
 
 	if len(filtering.ProhibitedAAGUIDs) != 0 {
-		for _, prohibited := range filtering.ProhibitedAAGUIDs {
-			if prohibited == aaguid {
+		if slices.Contains(filtering.ProhibitedAAGUIDs, aaguid) {
 				return protocol.ErrPolicyRestriction.WithInfo("Credential has an AAGUID which is prohibited")
 			}
-		}
 	}
 
 	return nil

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -220,17 +220,8 @@ func ValidateFilteredCredential(credential *Credential, filtering *FilteringConf
 	}
 
 	if len(filtering.PermittedAAGUIDs) != 0 {
-		var success = false
-
-		if aaguid == uuid.Nil {
-			success = true
-		} else {
-			if slices.Contains(filtering.PermittedAAGUIDs, aaguid) {
-				success = true
-			}
-		}
-
-		if !success {
+		// The zero AAGUID is never excluded by the permitted list; see the FilteringConfig contract.
+		if aaguid != uuid.Nil && !slices.Contains(filtering.PermittedAAGUIDs, aaguid) {
 			return protocol.ErrPolicyRestriction.WithInfo("Credential has an AAGUID which is not permitted")
 		}
 	}

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -14,7 +14,9 @@ import (
 // RegistrationOption is a functional option that modifies the [protocol.PublicKeyCredentialCreationOptions] sent
 // to the client during a registration ceremony. Use the With* functions in this package (i.e.
 // [WithConveyancePreference], [WithExclusions], [WithAuthenticatorSelection]) to create registration options.
-type RegistrationOption func(*protocol.PublicKeyCredentialCreationOptions)
+//
+// An option returns an error to reject the ceremony; [WebAuthn.BeginRegistration] aborts on the first error.
+type RegistrationOption func(*protocol.PublicKeyCredentialCreationOptions) error
 
 // BeginRegistration generates a new set of registration data to be sent to the client and authenticator. To set a
 // conditional mediation requirement for the registration see [WebAuthn.BeginMediatedRegistration].
@@ -74,7 +76,9 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 	}
 
 	for _, opt := range opts {
-		opt(&creation.Response)
+		if err = opt(&creation.Response); err != nil {
+			return nil, nil, fmt.Errorf("error applying registration option: %w", err)
+		}
 	}
 
 	if len(creation.Response.RelyingParty.ID) == 0 {
@@ -100,11 +104,19 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		}
 	}
 
+	// The FIDO AppID Exclusion Extension is only meaningful when the exclude list contains a credential registered
+	// through the legacy FIDO U2F JavaScript API. Pruning here rather than inside the option makes the result
+	// independent of the order the options were supplied in.
+	if !hasU2FCredential(creation.Response.CredentialExcludeList) {
+		creation.Response.Extensions.AppIDExclude = ""
+	}
+
 	session = &SessionData{
 		Challenge:        creation.Response.Challenge.String(),
 		RelyingPartyID:   creation.Response.RelyingParty.ID,
 		UserID:           user.WebAuthnID(),
 		UserVerification: creation.Response.AuthenticatorSelection.UserVerification,
+		Extensions:       creation.Response.Extensions.Session(),
 		CredParams:       creation.Response.Parameters,
 		Mediation:        creation.Mediation,
 	}
@@ -152,6 +164,10 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 	var clientDataHash []byte
 
 	if clientDataHash, err = parsedResponse.Verify(session.Challenge, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
+		return nil, err
+	}
+
+	if err = parsedResponse.ClientExtensionResults.Verify(session.Extensions, protocol.CreateCeremony, webauthn.Config.ExtensionsUnsolicitedOutputPolicy); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/registration_opt.go
+++ b/webauthn/registration_opt.go
@@ -96,8 +96,10 @@ func WithAttestationFormats(formats []protocol.AttestationFormat) RegistrationOp
 	}
 }
 
-// WithAppIdExcludeExtension automatically includes the specified appid if the CredentialExcludeList contains a
-// credential with the fido-u2f attestation format.
+// WithAppIdExcludeExtension sets the specified appid as the FIDO AppID Exclusion Extension input. The option
+// itself always sets it; [WebAuthn.BeginRegistration] then discards it unless the CredentialExcludeList contains a
+// credential with the fido-u2f attestation format, which is what makes the result independent of the order the
+// options were supplied in.
 //
 // Specification: §10.1.2. FIDO AppID Exclusion Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-exclude-extension)
 //

--- a/webauthn/registration_opt.go
+++ b/webauthn/registration_opt.go
@@ -6,8 +6,10 @@ import "github.com/go-webauthn/webauthn/protocol"
 //
 // Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-pubkeycredparams)
 func WithCredentialParameters(credentialParams []protocol.CredentialParameter) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.Parameters = credentialParams
+
+		return nil
 	}
 }
 
@@ -15,8 +17,10 @@ func WithCredentialParameters(credentialParams []protocol.CredentialParameter) R
 //
 // Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-excludecredentials)
 func WithExclusions(excludeList []protocol.CredentialDescriptor) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.CredentialExcludeList = excludeList
+
+		return nil
 	}
 }
 
@@ -27,8 +31,10 @@ func WithExclusions(excludeList []protocol.CredentialDescriptor) RegistrationOpt
 //
 // Specification: §5.4.4. Authenticator Selection Criteria (https://www.w3.org/TR/webauthn/#dictdef-authenticatorselectioncriteria)
 func WithAuthenticatorSelection(authenticatorSelection protocol.AuthenticatorSelection) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.AuthenticatorSelection = authenticatorSelection
+
+		return nil
 	}
 }
 
@@ -38,7 +44,7 @@ func WithAuthenticatorSelection(authenticatorSelection protocol.AuthenticatorSel
 //
 // Specification: §5.4.4. Authenticator Selection Criteria (https://www.w3.org/TR/webauthn/#dictdef-authenticatorselectioncriteria)
 func WithResidentKeyRequirement(requirement protocol.ResidentKeyRequirement) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.AuthenticatorSelection.ResidentKey = requirement
 
 		switch requirement {
@@ -47,6 +53,8 @@ func WithResidentKeyRequirement(requirement protocol.ResidentKeyRequirement) Reg
 		default:
 			cco.AuthenticatorSelection.RequireResidentKey = protocol.ResidentKeyNotRequired()
 		}
+
+		return nil
 	}
 }
 
@@ -56,8 +64,10 @@ func WithResidentKeyRequirement(requirement protocol.ResidentKeyRequirement) Reg
 //
 // Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-hints)
 func WithPublicKeyCredentialHints(hints []protocol.PublicKeyCredentialHints) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.Hints = hints
+
+		return nil
 	}
 }
 
@@ -66,8 +76,10 @@ func WithPublicKeyCredentialHints(hints []protocol.PublicKeyCredentialHints) Reg
 //
 // Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-attestation)
 func WithConveyancePreference(preference protocol.ConveyancePreference) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.Attestation = preference
+
+		return nil
 	}
 }
 
@@ -77,56 +89,38 @@ func WithConveyancePreference(preference protocol.ConveyancePreference) Registra
 //
 // Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-attestationformats)
 func WithAttestationFormats(formats []protocol.AttestationFormat) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.AttestationFormats = formats
+
+		return nil
 	}
 }
 
-// WithExtensions adjusts the extension parameter in the registration options.
+// WithAppIdExcludeExtension automatically includes the specified appid if the CredentialExcludeList contains a
+// credential with the fido-u2f attestation format.
 //
-// Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-extensions)
+// Specification: §10.1.2. FIDO AppID Exclusion Extension (https://www.w3.org/TR/webauthn-3/#sctn-appid-exclude-extension)
 //
-// Specification: §9. Extensions (https://www.w3.org/TR/webauthn/#webauthn-extensions)
-func WithExtensions(extension protocol.AuthenticationExtensions) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
-		cco.Extensions = extension
-	}
-}
-
-// WithAppIdExcludeExtension automatically includes the specified appid if the CredentialExcludeList contains a credential
-// with the type `fido-u2f`.
-//
-// Specification: §5.4. Parameters for Credential Generation (https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-extensions)
-//
-// Specification: §9. Extensions (https://www.w3.org/TR/webauthn/#webauthn-extensions)
-//
-// Specification: §10.1.2. FIDO AppID Exclusion Extension (https://www.w3.org/TR/webauthn/#sctn-appid-exclude-extension)
+// Deprecated: use [WithExtensions] with [WithExtensionAppIDExclude], which is order-independent with respect to
+// [WithExclusions].
 func WithAppIdExcludeExtension(appid string) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
-		for _, credential := range cco.CredentialExcludeList {
-			if credential.AttestationFormat == string(protocol.AttestationFormatFIDOUniversalSecondFactor) {
-				if cco.Extensions == nil {
-					cco.Extensions = map[string]any{}
-				}
-
-				cco.Extensions[protocol.ExtensionAppIDExclude] = appid
-
-				break
-			}
-		}
-	}
+	return WithExtensions(WithExtensionAppIDExclude(appid))
 }
 
 // WithRegistrationRelyingPartyID sets the relying party id for the registration.
 func WithRegistrationRelyingPartyID(id string) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.RelyingParty.ID = id
+
+		return nil
 	}
 }
 
 // WithRegistrationRelyingPartyName sets the relying party name for the registration.
 func WithRegistrationRelyingPartyName(name string) RegistrationOption {
-	return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 		cco.RelyingParty.Name = name
+
+		return nil
 	}
 }

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -1250,3 +1250,53 @@ func newRegistrationFixture(t *testing.T) (w *WebAuthn, session SessionData, res
 
 	return w, session, response
 }
+
+func TestCreateCredentialRejectsUnhonouredCredentialProtectionPolicy(t *testing.T) {
+	// End to end cover for the authenticator extension output check: the session required enforcement, and this
+	// authenticator's data carries no extension outputs at all, so it cannot have honoured the policy.
+	w, session, response := newRegistrationFixture(t)
+
+	session.Extensions = protocol.SessionExtensions{
+		Requested:                         []string{protocol.ExtensionCredentialProtectionPolicy},
+		CredentialProtectionPolicy:        protocol.CredentialProtectionPolicyUserVerificationRequired,
+		EnforceCredentialProtectionPolicy: true,
+	}
+
+	credential, err := w.CreateCredential(newTestUser(t), session, response)
+
+	assert.Nil(t, credential)
+	assert.ErrorContains(t, err, "credentialProtectionPolicy")
+	assert.ErrorContains(t, err, "did not report the policy")
+}
+
+func TestCreateCredentialPropagatesFilteringFailure(t *testing.T) {
+	// The filtering step runs after the credential is built, so its rejection has to reach the caller rather than
+	// yielding a credential the configuration prohibits.
+	w, session, response := newRegistrationFixture(t)
+
+	w.Config.Filtering = &FilteringConfig{ProhibitBackupEligibility: true}
+
+	credential, err := w.CreateCredential(newTestUser(t), session, response)
+
+	assert.Nil(t, credential)
+	require.NotNil(t, err)
+
+	// The rejection reason is carried in DevInfo rather than the message, which is deliberately generic.
+	var e *protocol.Error
+
+	require.ErrorAs(t, err, &e)
+	assert.Equal(t, protocol.ErrPolicyRestriction.Type, e.Type)
+	assert.Contains(t, e.DevInfo, "Backup Eligible")
+}
+
+func TestBeginMediatedRegistrationRejectsInvalidConfig(t *testing.T) {
+	// The configuration is validated lazily on first use, so a WebAuthn built without New must fail the ceremony
+	// rather than emitting creation options derived from an incomplete configuration.
+	w := &WebAuthn{Config: &Config{}}
+
+	creation, session, err := w.BeginRegistration(newTestUser(t))
+
+	assert.Nil(t, creation)
+	assert.Nil(t, session)
+	assert.ErrorContains(t, err, "error occurred validating the configuration")
+}

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -1170,6 +1170,25 @@ func TestCreateCredentialRejectsUnsolicitedExtensionOutput(t *testing.T) {
 	assert.ErrorContains(t, err, "credProps")
 }
 
+func TestCreateCredentialAcceptsSolicitedExtensionOutput(t *testing.T) {
+	// The sibling of the rejection case: the same output must pass once the session records that it was asked
+	// for, so the check is known to discriminate rather than to reject the extension outright.
+	w, session, response := newRegistrationFixture(t)
+
+	response.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		CredProps: &protocol.CredentialPropertiesOutput{RK: ptr(true)},
+	}
+	session.Extensions = protocol.SessionExtensions{Requested: []string{protocol.ExtensionCredProps}}
+
+	credential, err := w.CreateCredential(newTestUser(t), session, response)
+
+	require.NoError(t, err)
+	require.NotNil(t, credential)
+
+	require.NotNil(t, credential.Extensions.RK)
+	assert.True(t, *credential.Extensions.RK)
+}
+
 func testRegDecodeHex(t *testing.T, s string) []byte {
 	t.Helper()
 

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -302,8 +302,10 @@ func TestBeginMediatedRegistration_ChallengeLength(t *testing.T) {
 	// WithChallenge login option; no equivalent is exported for registration, so we synthesise one here to exercise
 	// the minimum-length guard.
 	withTestChallenge := func(challenge []byte) RegistrationOption {
-		return func(cco *protocol.PublicKeyCredentialCreationOptions) {
+		return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
 			cco.Challenge = challenge
+
+			return nil
 		}
 	}
 
@@ -515,15 +517,19 @@ func TestRegistrationOptions(t *testing.T) {
 		},
 		{
 			name: "Extensions",
-			opts: []RegistrationOption{WithExtensions(map[string]any{"appID": "example"})},
+			opts: []RegistrationOption{WithExtensions(WithExtensionCredProps())},
 			expected: protocol.PublicKeyCredentialCreationOptions{
-				Extensions: map[string]any{"appID": "example"},
+				Extensions: protocol.AuthenticationExtensions{CredProps: true},
 			},
 		},
 		{
-			name:     "AppIDExcludeExtensionWithNoExclusions",
-			opts:     []RegistrationOption{WithAppIdExcludeExtension("apple")},
-			expected: protocol.PublicKeyCredentialCreationOptions{},
+			// The option itself no longer inspects the exclude list; the appid is discarded by
+			// BeginRegistration instead, which TestBeginRegistrationAppIDExcludePruning covers.
+			name: "AppIDExcludeExtensionWithNoExclusions",
+			opts: []RegistrationOption{WithAppIdExcludeExtension("apple")},
+			expected: protocol.PublicKeyCredentialCreationOptions{
+				Extensions: protocol.AuthenticationExtensions{AppIDExclude: "apple"},
+			},
 		},
 		{
 			name: "AppIDExcludeExtensionWithExclusions",
@@ -534,7 +540,7 @@ func TestRegistrationOptions(t *testing.T) {
 				CredentialExcludeList: []protocol.CredentialDescriptor{
 					{Type: protocol.PublicKeyCredentialType, AttestationFormat: string(protocol.AttestationFormatFIDOUniversalSecondFactor), CredentialID: []byte("123"), Transport: []protocol.AuthenticatorTransport{protocol.Hybrid}},
 				},
-				Extensions: map[string]any{"appidExclude": "apple"},
+				Extensions: protocol.AuthenticationExtensions{AppIDExclude: "apple"},
 			},
 		},
 	}
@@ -544,7 +550,7 @@ func TestRegistrationOptions(t *testing.T) {
 			opts := &tc.have
 
 			for _, opt := range tc.opts {
-				opt(opts)
+				require.NoError(t, opt(opts))
 			}
 
 			assert.Equal(t, tc.expected, *opts)
@@ -739,7 +745,7 @@ func TestCreateCredential_Full(t *testing.T) {
 				challenge = tc.have.challenge
 			}
 
-			userID := []byte("test-user-id")
+			userID := []byte(testUserID)
 
 			config := &Config{
 				RPID:      "example.org",
@@ -787,7 +793,7 @@ func TestFinishRegistration_Success(t *testing.T) {
 	body, challenge, credentialID := testRegistrationSpecVectorNoneES256(t)
 	credParams := []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}}
 
-	userID := []byte("test-user-id")
+	userID := []byte(testUserID)
 
 	w := &WebAuthn{
 		Config: &Config{
@@ -1038,6 +1044,132 @@ func testRegistrationSpecVectorPackedSelfES256(t *testing.T) (body []byte, chall
 	return body, challenge, credentialID
 }
 
+func TestBeginRegistrationOptionError(t *testing.T) {
+	w, err := New(&Config{RPID: "example.com", RPDisplayName: "Test", RPOrigins: []string{"https://example.com"}})
+	require.NoError(t, err)
+
+	opt := func(cco *protocol.PublicKeyCredentialCreationOptions) error {
+		return fmt.Errorf("boom")
+	}
+
+	creation, session, err := w.BeginRegistration(&defaultUser{id: []byte("1234567890")}, opt)
+
+	assert.Nil(t, creation)
+	assert.Nil(t, session)
+	assert.EqualError(t, err, "error applying registration option: boom")
+}
+
+func TestBeginRegistration_StoresSessionExtensions(t *testing.T) {
+	w, err := New(&Config{RPID: "example.com", RPDisplayName: "Test", RPOrigins: []string{"https://example.com"}})
+	require.NoError(t, err)
+
+	_, session, err := w.BeginRegistration(&defaultUser{id: []byte("1234567890")}, WithExtensions(
+		WithExtensionCredProps(),
+		WithExtensionLargeBlobSupport(protocol.LargeBlobSupportRequired),
+	))
+	require.NoError(t, err)
+
+	// Registration ceremonies previously stored no extensions in the session at all.
+	assert.Equal(t, protocol.SessionExtensions{
+		Requested: []string{protocol.ExtensionCredProps, protocol.ExtensionLargeBlob},
+		LargeBlob: protocol.LargeBlobSupportRequired,
+	}, session.Extensions)
+}
+
+func TestBeginRegistrationAppIDExcludePruning(t *testing.T) {
+	u2f := protocol.CredentialDescriptor{
+		Type:              protocol.PublicKeyCredentialType,
+		CredentialID:      []byte("u2f-credential"),
+		AttestationFormat: string(protocol.AttestationFormatFIDOUniversalSecondFactor),
+	}
+
+	packed := protocol.CredentialDescriptor{
+		Type:              protocol.PublicKeyCredentialType,
+		CredentialID:      []byte("packed-credential"),
+		AttestationFormat: string(protocol.AttestationFormatPacked),
+	}
+
+	testCases := []struct {
+		name     string
+		exclude  []protocol.CredentialDescriptor
+		expected string
+	}{
+		{"U2FPresent", []protocol.CredentialDescriptor{packed, u2f}, "https://example.com"},
+		{"NoU2F", []protocol.CredentialDescriptor{packed}, ""},
+		{"Empty", nil, ""},
+	}
+
+	for _, tc := range testCases {
+		// Both orderings must produce identical results; the option previously read the exclude list at the moment
+		// it ran, so listing it first silently did nothing.
+		t.Run(tc.name+"/OptionAfterExclusions", func(t *testing.T) {
+			w := newTestWebAuthn(t)
+
+			creation, session, err := w.BeginRegistration(newTestUser(t),
+				WithExclusions(tc.exclude),
+				WithExtensions(WithExtensionAppIDExclude("https://example.com")),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, creation.Response.Extensions.AppIDExclude)
+			assert.Equal(t, tc.expected, session.Extensions.AppIDExclude)
+		})
+
+		t.Run(tc.name+"/OptionBeforeExclusions", func(t *testing.T) {
+			w := newTestWebAuthn(t)
+
+			creation, session, err := w.BeginRegistration(newTestUser(t),
+				WithExtensions(WithExtensionAppIDExclude("https://example.com")),
+				WithExclusions(tc.exclude),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, creation.Response.Extensions.AppIDExclude)
+			assert.Equal(t, tc.expected, session.Extensions.AppIDExclude)
+		})
+
+		// The deprecated wrapper delegates to the same option and must therefore be pruned identically.
+		t.Run(tc.name+"/DeprecatedWrapperBeforeExclusions", func(t *testing.T) {
+			w := newTestWebAuthn(t)
+
+			creation, session, err := w.BeginRegistration(newTestUser(t),
+				WithAppIdExcludeExtension("https://example.com"),
+				WithExclusions(tc.exclude),
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, creation.Response.Extensions.AppIDExclude)
+			assert.Equal(t, tc.expected, session.Extensions.AppIDExclude)
+		})
+	}
+}
+
+func TestBeginRegistrationAppIDExcludePruningUpdatesRequested(t *testing.T) {
+	w := newTestWebAuthn(t)
+
+	_, session, err := w.BeginRegistration(newTestUser(t),
+		WithExtensions(WithExtensionAppIDExclude("https://example.com"), WithExtensionCredProps()),
+	)
+
+	require.NoError(t, err)
+	assert.NotContains(t, session.Extensions.Requested, protocol.ExtensionAppIDExclude)
+	assert.Contains(t, session.Extensions.Requested, protocol.ExtensionCredProps)
+}
+
+func TestCreateCredentialRejectsUnsolicitedExtensionOutput(t *testing.T) {
+	w, session, response := newRegistrationFixture(t)
+
+	response.ClientExtensionResults = protocol.AuthenticationExtensionsClientOutputs{
+		CredProps: &protocol.CredentialPropertiesOutput{RK: ptr(true)},
+	}
+	session.Extensions = protocol.SessionExtensions{}
+
+	credential, err := w.CreateCredential(newTestUser(t), session, response)
+
+	assert.Nil(t, credential)
+	assert.ErrorContains(t, err, "credProps")
+}
+
 func testRegDecodeHex(t *testing.T, s string) []byte {
 	t.Helper()
 
@@ -1045,4 +1177,57 @@ func testRegDecodeHex(t *testing.T, s string) []byte {
 	require.NoError(t, err)
 
 	return data
+}
+
+// testUserID is the user handle shared by [newTestUser], [newRegistrationFixture] and the login tests.
+// [WebAuthn.CreateCredential] and [WebAuthn.ValidateLogin] both reject a user whose handle differs from the one in
+// the session, so these must agree.
+const testUserID = "test-user-id"
+
+// newTestUser returns the [User] matching the session and response produced by [newRegistrationFixture]. It has no
+// credentials and is therefore unsuitable for [WebAuthn.BeginLogin], which requires at least one.
+func newTestUser(t *testing.T) User {
+	t.Helper()
+
+	return &defaultUser{id: []byte(testUserID)}
+}
+
+// newTestWebAuthn returns a [*WebAuthn] with the minimal valid configuration used by the ceremony tests.
+func newTestWebAuthn(t *testing.T) *WebAuthn {
+	t.Helper()
+
+	w, err := New(&Config{RPID: "example.com", RPDisplayName: "Test", RPOrigins: []string{"https://example.com"}})
+	require.NoError(t, err)
+
+	return w
+}
+
+// newRegistrationFixture returns a configured [*WebAuthn], a [SessionData], and a
+// [*protocol.ParsedCredentialCreationData] that verifies cleanly against each other, for tests that need a
+// successful registration to then mutate.
+func newRegistrationFixture(t *testing.T) (w *WebAuthn, session SessionData, response *protocol.ParsedCredentialCreationData) {
+	t.Helper()
+
+	body, challenge, _ := testRegistrationSpecVectorNoneES256(t)
+	credParams := []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}}
+
+	userID := []byte(testUserID)
+
+	w = &WebAuthn{
+		Config: &Config{
+			RPID:      "example.org",
+			RPOrigins: []string{"https://example.org"},
+		},
+	}
+
+	session = SessionData{
+		Challenge:  challenge,
+		UserID:     userID,
+		CredParams: credParams,
+	}
+
+	response, err := protocol.ParseCredentialCreationResponseBytes(body)
+	require.NoError(t, err)
+
+	return w, session, response
 }

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -102,6 +102,17 @@ type Config struct {
 	// policy on the authenticators that are available to be registered with the Relying Party.
 	Filtering *FilteringConfig
 
+	// ExtensionsUnsolicitedOutputPolicy determines how a client extension output that was not requested by this
+	// Relying Party is handled during the finish step of a ceremony. The zero value
+	// ([protocol.UnsolicitedOutputPolicyReject]) fails the ceremony, which is the recommended setting. Set
+	// [protocol.UnsolicitedOutputPolicyIgnore] only if a client in your deployment is known to return extension
+	// outputs unprompted.
+	//
+	// A Relying Party which reconstructs [SessionData] by hand, rather than persisting the value returned by the
+	// Begin* functions verbatim, will lose the record of which extensions were requested and see legitimate
+	// outputs rejected.
+	ExtensionsUnsolicitedOutputPolicy protocol.UnsolicitedOutputPolicy
+
 	validated bool
 }
 

--- a/webauthn/types_msgp_test.go
+++ b/webauthn/types_msgp_test.go
@@ -1,0 +1,361 @@
+package webauthn
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tinylib/msgp/msgp"
+
+	"github.com/go-webauthn/webauthn/protocol"
+)
+
+// msgpCodec is the full set of methods msgp generates for a type. The generated code implements each of the four
+// entry points separately, so exercising only the buffer pair leaves the streaming pair untested even though both
+// are part of the persistence contract a Relying Party depends on.
+type msgpCodec interface {
+	msgp.Encodable
+	msgp.Decodable
+	msgp.Marshaler
+	msgp.Unmarshaler
+	msgp.Sizer
+}
+
+// exerciseMsgpCodec round trips a value through both the buffer pair (MarshalMsg/UnmarshalMsg) and the streaming
+// pair (EncodeMsg/DecodeMsg), asserting the two encoders agree and that each decoder reconstructs the original.
+//
+// fresh must return a zero value of the same concrete type, so the comparison is against a destination which
+// carried nothing over from the source.
+func exerciseMsgpCodec(t *testing.T, populated msgpCodec, fresh func() msgpCodec) []byte {
+	t.Helper()
+
+	marshalled, err := populated.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, len(marshalled), populated.Msgsize(),
+		"Msgsize must be an upper bound on the encoded size, otherwise callers sizing buffers from it under-allocate")
+
+	// Comparing the re-encoded form rather than the structs keeps the assertion on what the codec is responsible
+	// for. A time.Time round trips to an equal instant but not to a deeply equal value, because it carries an
+	// unexported location pointer and monotonic reading which the wire format neither holds nor should hold.
+	requireReEncodes := func(t *testing.T, decoded msgpCodec) {
+		t.Helper()
+
+		again, err := decoded.MarshalMsg(nil)
+		require.NoError(t, err)
+		assert.Equal(t, marshalled, again, "the decoded value must re-encode to the bytes it came from")
+	}
+
+	t.Run("BufferRoundTrip", func(t *testing.T) {
+		decoded := fresh()
+
+		left, err := decoded.UnmarshalMsg(marshalled)
+		require.NoError(t, err)
+		assert.Empty(t, left)
+		requireReEncodes(t, decoded)
+	})
+
+	t.Run("StreamRoundTrip", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		require.NoError(t, msgp.Encode(&buf, populated))
+
+		// The two encoders are generated separately from the same field list, so they are only known to agree if
+		// their output is compared; a field written by one and not the other would otherwise go unnoticed.
+		assert.Equal(t, marshalled, buf.Bytes(), "EncodeMsg and MarshalMsg must produce identical bytes")
+
+		decoded := fresh()
+
+		require.NoError(t, msgp.Decode(&buf, decoded))
+		requireReEncodes(t, decoded)
+	})
+
+	t.Run("DecodeTruncated", func(t *testing.T) {
+		// Every field read in the generated decoders is followed by an error branch that only a short buffer
+		// reaches. Sweeping the prefixes walks all of them for both decoders.
+		for limit := range len(marshalled) {
+			truncated := marshalled[:limit]
+
+			decoded := fresh()
+
+			_, err := decoded.UnmarshalMsg(truncated)
+			require.Errorf(t, err, "UnmarshalMsg must fail on a %d of %d byte prefix", limit, len(marshalled))
+
+			streamed := fresh()
+
+			require.Errorf(t, msgp.Decode(bytes.NewReader(truncated), streamed),
+				"DecodeMsg must fail on a %d of %d byte prefix", limit, len(marshalled))
+		}
+	})
+
+	return marshalled
+}
+
+func TestMsgpCodecs(t *testing.T) {
+	// Each value is fully populated: the generated encoders emit a field only when it is non-zero, so a zero value
+	// exercises the omitted branch of every field and nothing else. The generated tests cover that case already.
+	testCases := []struct {
+		name      string
+		populated msgpCodec
+		fresh     func() msgpCodec
+	}{
+		{
+			name:      "Credential",
+			populated: ptr(newPopulatedCredentialWithEverything()),
+			fresh:     func() msgpCodec { return &Credential{} },
+		},
+		{
+			name:      "CredentialZero",
+			populated: &Credential{},
+			fresh:     func() msgpCodec { return &Credential{} },
+		},
+		{
+			name:      "CredentialExtensions",
+			populated: ptr(newPopulatedCredentialExtensions()),
+			fresh:     func() msgpCodec { return &CredentialExtensions{} },
+		},
+		{
+			name:      "CredentialExtensionsZero",
+			populated: &CredentialExtensions{},
+			fresh:     func() msgpCodec { return &CredentialExtensions{} },
+		},
+		{
+			name:      "CredentialAttestation",
+			populated: ptr(newPopulatedCredentialWithEverything().Attestation),
+			fresh:     func() msgpCodec { return &CredentialAttestation{} },
+		},
+		{
+			name:      "CredentialFlags",
+			populated: &CredentialFlags{UserPresent: true, UserVerified: true, BackupEligible: true, BackupState: true},
+			fresh:     func() msgpCodec { return &CredentialFlags{} },
+		},
+		{
+			name:      "Credentials",
+			populated: &Credentials{newPopulatedCredentialWithEverything(), newPopulatedCredential()},
+			fresh:     func() msgpCodec { return &Credentials{} },
+		},
+		{
+			name:      "Authenticator",
+			populated: ptr(newPopulatedCredentialWithEverything().Authenticator),
+			fresh:     func() msgpCodec { return &Authenticator{} },
+		},
+		{
+			name:      "SessionData",
+			populated: ptr(newPopulatedSessionData()),
+			fresh:     func() msgpCodec { return &SessionData{} },
+		},
+		{
+			name:      "SessionDataZero",
+			populated: &SessionData{},
+			fresh:     func() msgpCodec { return &SessionData{} },
+		},
+		{
+			name:      "SessionExtensions",
+			populated: ptr(newPopulatedSessionExtensions()),
+			fresh:     func() msgpCodec { return &sessionExtensions{} },
+		},
+		{
+			name:      "SessionExtensionsZero",
+			populated: &sessionExtensions{},
+			fresh:     func() msgpCodec { return &sessionExtensions{} },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exerciseMsgpCodec(t, tc.populated, tc.fresh)
+		})
+	}
+}
+
+func TestMsgpEncodeErrorPaths(t *testing.T) {
+	// The encoders write each field through a writer which can fail at any point. Sweeping the failure offset
+	// reaches the error branch that follows every individual write.
+	testCases := []struct {
+		name      string
+		populated msgpCodec
+	}{
+		{"Credential", ptr(newPopulatedCredentialWithEverything())},
+		{"CredentialExtensions", ptr(newPopulatedCredentialExtensions())},
+		{"CredentialFlags", &CredentialFlags{UserPresent: true, UserVerified: true, BackupEligible: true, BackupState: true}},
+		{"Credentials", &Credentials{newPopulatedCredentialWithEverything()}},
+		{"Authenticator", ptr(newPopulatedCredentialWithEverything().Authenticator)},
+		{"SessionData", ptr(newPopulatedSessionData())},
+		{"SessionExtensions", ptr(newPopulatedSessionExtensions())},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := tc.populated.MarshalMsg(nil)
+			require.NoError(t, err)
+
+			exerciseEncodeMsgErrorPaths(t, tc.populated, marshalled)
+		})
+	}
+}
+
+// TestMsgpDecodeWrongFieldTypes covers the per-field type assertions in the decoders. A stored record whose field
+// carries the wrong type must be reported against that field rather than decoding to a silently wrong value.
+func TestMsgpDecodeWrongFieldTypes(t *testing.T) {
+	testCases := []struct {
+		name  string
+		key   string
+		value []byte
+		fresh func() msgpCodec
+	}{
+		{"CredentialID", "id", msgpString("not-bytes"), func() msgpCodec { return &Credential{} }},
+		{"CredentialAttestationType", "atttype", msgpInt64(1), func() msgpCodec { return &Credential{} }},
+		{"CredentialExtensionsRK", "rk", msgpString("yes"), func() msgpCodec { return &CredentialExtensions{} }},
+		{"CredentialExtensionsCredProtect", "cp", msgpInt64(3), func() msgpCodec { return &CredentialExtensions{} }},
+		{"CredentialExtensionsMinPinLength", "mpl", msgpString("six"), func() msgpCodec { return &CredentialExtensions{} }},
+		{"CredentialExtensionsPRF", "prf", msgpString("yes"), func() msgpCodec { return &CredentialExtensions{} }},
+		{"CredentialExtensionsLargeBlob", "lbs", msgpString("yes"), func() msgpCodec { return &CredentialExtensions{} }},
+		{"CredentialExtensionsHMACSecret", "hs", msgpString("yes"), func() msgpCodec { return &CredentialExtensions{} }},
+		{"CredentialExtensionsCredBlobSet", "cbs", msgpString("yes"), func() msgpCodec { return &CredentialExtensions{} }},
+		{"SessionDataChallenge", "c", msgpInt64(1), func() msgpCodec { return &SessionData{} }},
+		{"SessionExtensionsAppID", "appid", msgpInt64(1), func() msgpCodec { return &sessionExtensions{} }},
+		{"SessionExtensionsLargeBlobRead", "lbRead", msgpString("yes"), func() msgpCodec { return &sessionExtensions{} }},
+		{"SessionExtensionsCredProtect", "credProtect", msgpInt64(1), func() msgpCodec { return &sessionExtensions{} }},
+		{"SessionExtensionsCPEnforce", "cpEnforce", msgpString("yes"), func() msgpCodec { return &sessionExtensions{} }},
+		{"SessionExtensionsCredBlob", "credBlob", msgpString("yes"), func() msgpCodec { return &sessionExtensions{} }},
+		{"SessionExtensionsRequested", "req", msgpString("appid"), func() msgpCodec { return &sessionExtensions{} }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := msgpOneFieldMap(tc.key, tc.value)
+
+			decoded := tc.fresh()
+			_, err := decoded.UnmarshalMsg(payload)
+			require.Error(t, err, "UnmarshalMsg must reject the wrong type")
+
+			streamed := tc.fresh()
+			require.Error(t, msgp.Decode(bytes.NewReader(payload), streamed), "DecodeMsg must reject the wrong type")
+		})
+	}
+}
+
+// TestMsgpDecodeUnknownField covers the skip path both decoders take for a member they do not model, which is what
+// lets a record written by a newer release be read by an older one.
+func TestMsgpDecodeUnknownField(t *testing.T) {
+	testCases := []struct {
+		name  string
+		fresh func() msgpCodec
+	}{
+		{"Credential", func() msgpCodec { return &Credential{} }},
+		{"CredentialExtensions", func() msgpCodec { return &CredentialExtensions{} }},
+		{"Authenticator", func() msgpCodec { return &Authenticator{} }},
+		{"SessionData", func() msgpCodec { return &SessionData{} }},
+		{"SessionExtensions", func() msgpCodec { return &sessionExtensions{} }},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := msgpOneFieldMap("fieldFromANewerRelease", msgpString("x"))
+
+			decoded := tc.fresh()
+
+			left, err := decoded.UnmarshalMsg(payload)
+			require.NoError(t, err)
+			assert.Empty(t, left)
+
+			streamed := tc.fresh()
+			require.NoError(t, msgp.Decode(bytes.NewReader(payload), streamed))
+		})
+	}
+}
+
+func newPopulatedCredentialExtensions() CredentialExtensions {
+	return CredentialExtensions{
+		RK:                 ptr(true),
+		CredProtect:        protocol.CredentialProtectionPolicyUserVerificationRequired,
+		MinPinLength:       ptr(uint(6)),
+		PRFEnabled:         ptr(true),
+		LargeBlobSupported: ptr(true),
+		HMACSecret:         ptr(true),
+		CredBlobSet:        ptr(true),
+	}
+}
+
+func newPopulatedSessionExtensions() sessionExtensions {
+	return sessionExtensions{
+		Requested:                         []string{protocol.ExtensionAppID, protocol.ExtensionCredProps},
+		AppID:                             "https://example.com",
+		AppIDExclude:                      "https://exclude.example.com",
+		LargeBlob:                         protocol.LargeBlobSupportRequired,
+		LargeBlobRead:                     true,
+		LargeBlobWrite:                    true,
+		CredentialProtectionPolicy:        protocol.CredentialProtectionPolicyUserVerificationRequired,
+		EnforceCredentialProtectionPolicy: true,
+		CredBlob:                          true,
+		Extra:                             map[string]any{"vendorThing": "x"},
+	}
+}
+
+// newPopulatedCredentialWithEverything is newPopulatedCredential with every optional member set, so the encoders
+// emit each field rather than skipping it.
+func newPopulatedCredentialWithEverything() Credential {
+	credential := newPopulatedCredential()
+
+	credential.Extensions = newPopulatedCredentialExtensions()
+	credential.Authenticator.Attachment = protocol.CrossPlatform
+
+	return credential
+}
+
+// TestMsgpDecodeExplicitNil covers the nil arm of every pointer field in the decoders. The encoders omit a nil
+// pointer rather than writing one, so this shape is only produced by another writer, but both decoders accept it
+// and a record carrying explicit nils has to decode to the same value as one that omits the members.
+func TestMsgpDecodeExplicitNil(t *testing.T) {
+	payload := msgp.AppendMapHeader(nil, 7)
+
+	for _, key := range []string{"rk", "mpl", "prf", "lbs", "hs", "cbs"} {
+		payload = msgp.AppendString(payload, key)
+		payload = msgp.AppendNil(payload)
+	}
+
+	// CredProtect is a string rather than a pointer, so it carries an empty value rather than a nil.
+	payload = msgp.AppendString(payload, "cp")
+	payload = msgp.AppendString(payload, "")
+
+	t.Run("Buffer", func(t *testing.T) {
+		var decoded CredentialExtensions
+
+		left, err := decoded.UnmarshalMsg(payload)
+		require.NoError(t, err)
+		assert.Empty(t, left)
+		assert.Equal(t, CredentialExtensions{}, decoded)
+	})
+
+	t.Run("Stream", func(t *testing.T) {
+		var decoded CredentialExtensions
+
+		require.NoError(t, msgp.Decode(bytes.NewReader(payload), &decoded))
+		assert.Equal(t, CredentialExtensions{}, decoded)
+	})
+
+	t.Run("OverwritesAPopulatedDestination", func(t *testing.T) {
+		// The decoders assign through the existing pointer when one is already set, so a reused destination must
+		// still end up nil rather than retaining the previous record's value.
+		decoded := newPopulatedCredentialExtensions()
+
+		_, err := decoded.UnmarshalMsg(payload)
+		require.NoError(t, err)
+		assert.Equal(t, CredentialExtensions{}, decoded)
+	})
+
+	t.Run("Truncated", func(t *testing.T) {
+		for limit := range len(payload) {
+			var decoded CredentialExtensions
+
+			_, err := decoded.UnmarshalMsg(payload[:limit])
+			require.Errorf(t, err, "UnmarshalMsg must fail on a %d of %d byte prefix", limit, len(payload))
+
+			var streamed CredentialExtensions
+
+			require.Errorf(t, msgp.Decode(bytes.NewReader(payload[:limit]), &streamed),
+				"DecodeMsg must fail on a %d of %d byte prefix", limit, len(payload))
+		}
+	})
+}

--- a/webauthn/types_session.go
+++ b/webauthn/types_session.go
@@ -24,12 +24,12 @@ import (
 // The exts field of [SessionData] deliberately carries no omitempty tag option. msgp cannot test a replaced struct
 // for emptiness, so the option never suppressed the field on the wire, while //msgp:clearomitted additionally
 // emitted an assignment to the field's address which does not compile. Do not add it back (msgp v1.6.4).
-// A msg tag MUST NOT exceed 16 characters. The generated EncodeMsg emits each map key as a single
-// msgp.Writer.Append call carrying the fixstr header plus the tag, and that method silently truncates a payload
-// larger than the writer's buffer while still returning a nil error (msgp v1.6.4). The smallest buffer msgp will
-// construct is 18 bytes, so a tag of 18 characters or more corrupts the encoded session for any caller using
-// msgp.NewWriterSize with a small size. TestSessionData_MsgpEncodeErrorPaths encodes through an 18 byte writer and
-// fails if this is reintroduced.
+// A msg tag MUST NOT exceed 17 characters. The generated EncodeMsg emits each map key as a single
+// msgp.Writer.Append call carrying the one byte fixstr header plus the tag, and that method silently truncates a
+// payload larger than the writer's buffer while still returning a nil error (msgp v1.6.4). The smallest buffer msgp
+// will construct is 18 bytes, so 17 tag characters plus the header is the largest key that fits and a tag of 18
+// characters or more corrupts the encoded session for any caller using msgp.NewWriterSize with a small size.
+// TestSessionData_MsgpEncodeErrorPaths encodes through an 18 byte writer and fails if this is reintroduced.
 type sessionExtensions struct {
 	Requested                         []string                            `msg:"req,omitempty"`
 	AppID                             string                              `msg:"appid,omitempty"`

--- a/webauthn/types_session.go
+++ b/webauthn/types_session.go
@@ -6,12 +6,30 @@ import (
 	"github.com/go-webauthn/webauthn/protocol"
 )
 
-//go:generate msgp
+//go:generate msgp -unexported
 
 //msgp:replace protocol.UserVerificationRequirement with:string
-//msgp:replace protocol.AuthenticationExtensions with:map[string]any
 //msgp:replace protocol.CredentialMediationRequirement with:string
+//msgp:replace protocol.SessionExtensions with:sessionExtensions
+//msgp:replace protocol.LargeBlobSupport with:string
 //msgp:clearomitted
+
+// sessionExtensions shadows [protocol.SessionExtensions] for the msgp code generator, which cannot inspect types
+// in other packages. It MUST stay field-for-field convertible with [protocol.SessionExtensions]; the conversion in
+// the generated code fails to compile otherwise, and TestSessionExtensionsShadowMatches asserts it directly.
+//
+// The generator only visits unexported types when invoked with -unexported, hence the go:generate line above.
+//
+// The exts field of [SessionData] deliberately carries no omitempty tag option. msgp cannot test a replaced struct
+// for emptiness, so the option never suppressed the field on the wire, while //msgp:clearomitted additionally
+// emitted an assignment to the field's address which does not compile. Do not add it back (msgp v1.6.4).
+type sessionExtensions struct {
+	Requested    []string                  `msg:"req,omitempty"`
+	AppID        string                    `msg:"appid,omitempty"`
+	AppIDExclude string                    `msg:"appidExclude,omitempty"`
+	LargeBlob    protocol.LargeBlobSupport `msg:"largeBlob,omitempty"`
+	Extra        map[string]any            `msg:"extra,omitempty"`
+}
 
 // SessionData is the data that must be stored by the Relying Party between the Begin and Finish steps of a WebAuthn
 // ceremony. It contains the challenge and other parameters needed to verify the authenticator's response.
@@ -23,6 +41,10 @@ import (
 // Every field returned by the Begin* functions must be delivered to the matching Finish* / Validate* call with
 // the same values; if anything is dropped or reshaped in transit, verification will fail. Treat [SessionData] as
 // an atomic record between those two calls.
+//
+// Decode into a fresh [SessionData]. Unlike the other members, Extensions is not reset when the encoded payload
+// omits it, so decoding a payload that predates the field, or one written by a different producer, over a reused
+// destination leaves the previous ceremony's extension state in place.
 //
 // For consolidated persistence guidance; recommended schema shape, required lookup columns, and the rules
 // that also apply to [Credential] records; see the [Storage] section of the
@@ -37,7 +59,7 @@ type SessionData struct {
 	Expires              time.Time `json:"expires" msg:"exp"`
 
 	UserVerification protocol.UserVerificationRequirement    `json:"userVerification,omitempty" msg:"uv,omitempty"`
-	Extensions       protocol.AuthenticationExtensions       `json:"extensions,omitempty" msg:"exts,omitempty"`
+	Extensions       protocol.SessionExtensions              `json:"extensions,omitzero" msg:"exts"`
 	CredParams       []protocol.CredentialParameter          `json:"credParams,omitempty" msg:"params,omitempty"`
 	Mediation        protocol.CredentialMediationRequirement `json:"mediation,omitempty" msg:"cmr,omitempty"`
 }

--- a/webauthn/types_session.go
+++ b/webauthn/types_session.go
@@ -12,6 +12,7 @@ import (
 //msgp:replace protocol.CredentialMediationRequirement with:string
 //msgp:replace protocol.SessionExtensions with:sessionExtensions
 //msgp:replace protocol.LargeBlobSupport with:string
+//msgp:replace protocol.CredentialProtectionPolicy with:string
 //msgp:clearomitted
 
 // sessionExtensions shadows [protocol.SessionExtensions] for the msgp code generator, which cannot inspect types
@@ -23,12 +24,22 @@ import (
 // The exts field of [SessionData] deliberately carries no omitempty tag option. msgp cannot test a replaced struct
 // for emptiness, so the option never suppressed the field on the wire, while //msgp:clearomitted additionally
 // emitted an assignment to the field's address which does not compile. Do not add it back (msgp v1.6.4).
+// A msg tag MUST NOT exceed 16 characters. The generated EncodeMsg emits each map key as a single
+// msgp.Writer.Append call carrying the fixstr header plus the tag, and that method silently truncates a payload
+// larger than the writer's buffer while still returning a nil error (msgp v1.6.4). The smallest buffer msgp will
+// construct is 18 bytes, so a tag of 18 characters or more corrupts the encoded session for any caller using
+// msgp.NewWriterSize with a small size. TestSessionData_MsgpEncodeErrorPaths encodes through an 18 byte writer and
+// fails if this is reintroduced.
 type sessionExtensions struct {
-	Requested    []string                  `msg:"req,omitempty"`
-	AppID        string                    `msg:"appid,omitempty"`
-	AppIDExclude string                    `msg:"appidExclude,omitempty"`
-	LargeBlob    protocol.LargeBlobSupport `msg:"largeBlob,omitempty"`
-	Extra        map[string]any            `msg:"extra,omitempty"`
+	Requested                         []string                            `msg:"req,omitempty"`
+	AppID                             string                              `msg:"appid,omitempty"`
+	AppIDExclude                      string                              `msg:"appidExclude,omitempty"`
+	LargeBlob                         protocol.LargeBlobSupport           `msg:"largeBlob,omitempty"`
+	LargeBlobRead                     bool                                `msg:"lbRead,omitempty"`
+	LargeBlobWrite                    bool                                `msg:"lbWrite,omitempty"`
+	CredentialProtectionPolicy        protocol.CredentialProtectionPolicy `msg:"credProtect,omitempty"`
+	EnforceCredentialProtectionPolicy bool                                `msg:"cpEnforce,omitempty"`
+	Extra                             map[string]any                      `msg:"extra,omitempty"`
 }
 
 // SessionData is the data that must be stored by the Relying Party between the Begin and Finish steps of a WebAuthn

--- a/webauthn/types_session.go
+++ b/webauthn/types_session.go
@@ -39,6 +39,7 @@ type sessionExtensions struct {
 	LargeBlobWrite                    bool                                `msg:"lbWrite,omitempty"`
 	CredentialProtectionPolicy        protocol.CredentialProtectionPolicy `msg:"credProtect,omitempty"`
 	EnforceCredentialProtectionPolicy bool                                `msg:"cpEnforce,omitempty"`
+	CredBlob                          bool                                `msg:"credBlob,omitempty"`
 	Extra                             map[string]any                      `msg:"extra,omitempty"`
 }
 

--- a/webauthn/types_session_gen.go
+++ b/webauthn/types_session_gen.go
@@ -17,7 +17,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 7 bits */
+	var zb0001Mask uint8 /* 6 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -59,10 +59,10 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 			} else {
 				z.AllowedCredentialIDs = make([][]byte, zb0002)
 			}
-			for za0003 := range z.AllowedCredentialIDs {
-				z.AllowedCredentialIDs[za0003], err = dc.ReadBytes(z.AllowedCredentialIDs[za0003])
+			for za0001 := range z.AllowedCredentialIDs {
+				z.AllowedCredentialIDs[za0001], err = dc.ReadBytes(z.AllowedCredentialIDs[za0001])
 				if err != nil {
-					err = msgp.WrapError(err, "AllowedCredentialIDs", za0003)
+					err = msgp.WrapError(err, "AllowedCredentialIDs", za0001)
 					return
 				}
 			}
@@ -85,65 +85,42 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 			}
 			zb0001Mask |= 0x8
 		case "exts":
-			var zb0004 uint32
-			zb0004, err = dc.ReadMapHeader()
+			err = (*sessionExtensions)(&z.Extensions).DecodeMsg(dc)
 			if err != nil {
 				err = msgp.WrapError(err, "Extensions")
 				return
 			}
-			if z.Extensions == nil {
-				z.Extensions = make(map[string]interface{}, zb0004)
-			} else if len(z.Extensions) > 0 {
-				clear(z.Extensions)
-			}
-			for zb0004 > 0 {
-				zb0004--
-				var za0004 string
-				za0004, err = dc.ReadString()
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions")
-					return
-				}
-				var za0005 interface{}
-				za0005, err = dc.ReadIntf()
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions", za0004)
-					return
-				}
-				z.Extensions[za0004] = za0005
-			}
-			zb0001Mask |= 0x10
 		case "params":
-			var zb0005 uint32
-			zb0005, err = dc.ReadArrayHeader()
+			var zb0004 uint32
+			zb0004, err = dc.ReadArrayHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "CredParams")
 				return
 			}
-			if cap(z.CredParams) >= int(zb0005) {
-				z.CredParams = (z.CredParams)[:zb0005]
+			if cap(z.CredParams) >= int(zb0004) {
+				z.CredParams = (z.CredParams)[:zb0004]
 			} else {
-				z.CredParams = make([]protocol.CredentialParameter, zb0005)
+				z.CredParams = make([]protocol.CredentialParameter, zb0004)
 			}
-			for za0006 := range z.CredParams {
-				err = z.CredParams[za0006].DecodeMsg(dc)
+			for za0002 := range z.CredParams {
+				err = z.CredParams[za0002].DecodeMsg(dc)
 				if err != nil {
-					err = msgp.WrapError(err, "CredParams", za0006)
+					err = msgp.WrapError(err, "CredParams", za0002)
 					return
 				}
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x10
 		case "cmr":
 			{
-				var zb0006 string
-				zb0006, err = dc.ReadString()
+				var zb0005 string
+				zb0005, err = dc.ReadString()
 				if err != nil {
 					err = msgp.WrapError(err, "Mediation")
 					return
 				}
-				z.Mediation = protocol.CredentialMediationRequirement(zb0006)
+				z.Mediation = protocol.CredentialMediationRequirement(zb0005)
 			}
-			zb0001Mask |= 0x40
+			zb0001Mask |= 0x20
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -153,7 +130,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7f {
+	if zb0001Mask != 0x3f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.RelyingPartyID = ""
 		}
@@ -167,12 +144,9 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.UserVerification = ""
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.Extensions = nil
-		}
-		if (zb0001Mask & 0x20) == 0 {
 			z.CredParams = nil
 		}
-		if (zb0001Mask & 0x40) == 0 {
+		if (zb0001Mask & 0x20) == 0 {
 			z.Mediation = ""
 		}
 	}
@@ -200,10 +174,6 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 	if z.UserVerification == "" {
 		zb0001Len--
 		zb0001Mask |= 0x20
-	}
-	if z.Extensions == nil {
-		zb0001Len--
-		zb0001Mask |= 0x40
 	}
 	if z.CredParams == nil {
 		zb0001Len--
@@ -266,10 +236,10 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 				err = msgp.WrapError(err, "AllowedCredentialIDs")
 				return
 			}
-			for za0003 := range z.AllowedCredentialIDs {
-				err = en.WriteBytes(z.AllowedCredentialIDs[za0003])
+			for za0001 := range z.AllowedCredentialIDs {
+				err = en.WriteBytes(z.AllowedCredentialIDs[za0001])
 				if err != nil {
-					err = msgp.WrapError(err, "AllowedCredentialIDs", za0003)
+					err = msgp.WrapError(err, "AllowedCredentialIDs", za0001)
 					return
 				}
 			}
@@ -296,29 +266,15 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// write "exts"
-			err = en.Append(0xa4, 0x65, 0x78, 0x74, 0x73)
-			if err != nil {
-				return
-			}
-			err = en.WriteMapHeader(uint32(len(z.Extensions)))
-			if err != nil {
-				err = msgp.WrapError(err, "Extensions")
-				return
-			}
-			for za0004, za0005 := range z.Extensions {
-				err = en.WriteString(za0004)
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions")
-					return
-				}
-				err = en.WriteIntf(za0005)
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions", za0004)
-					return
-				}
-			}
+		// write "exts"
+		err = en.Append(0xa4, 0x65, 0x78, 0x74, 0x73)
+		if err != nil {
+			return
+		}
+		err = (*sessionExtensions)(&z.Extensions).EncodeMsg(en)
+		if err != nil {
+			err = msgp.WrapError(err, "Extensions")
+			return
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// write "params"
@@ -331,10 +287,10 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 				err = msgp.WrapError(err, "CredParams")
 				return
 			}
-			for za0006 := range z.CredParams {
-				err = z.CredParams[za0006].EncodeMsg(en)
+			for za0002 := range z.CredParams {
+				err = z.CredParams[za0002].EncodeMsg(en)
 				if err != nil {
-					err = msgp.WrapError(err, "CredParams", za0006)
+					err = msgp.WrapError(err, "CredParams", za0002)
 					return
 				}
 			}
@@ -378,10 +334,6 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x20
 	}
-	if z.Extensions == nil {
-		zb0001Len--
-		zb0001Mask |= 0x40
-	}
 	if z.CredParams == nil {
 		zb0001Len--
 		zb0001Mask |= 0x80
@@ -412,8 +364,8 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 			// string "allow"
 			o = append(o, 0xa5, 0x61, 0x6c, 0x6c, 0x6f, 0x77)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.AllowedCredentialIDs)))
-			for za0003 := range z.AllowedCredentialIDs {
-				o = msgp.AppendBytes(o, z.AllowedCredentialIDs[za0003])
+			for za0001 := range z.AllowedCredentialIDs {
+				o = msgp.AppendBytes(o, z.AllowedCredentialIDs[za0001])
 			}
 		}
 		// string "exp"
@@ -424,27 +376,21 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 			o = append(o, 0xa2, 0x75, 0x76)
 			o = msgp.AppendString(o, string(z.UserVerification))
 		}
-		if (zb0001Mask & 0x40) == 0 { // if not omitted
-			// string "exts"
-			o = append(o, 0xa4, 0x65, 0x78, 0x74, 0x73)
-			o = msgp.AppendMapHeader(o, uint32(len(z.Extensions)))
-			for za0004, za0005 := range z.Extensions {
-				o = msgp.AppendString(o, za0004)
-				o, err = msgp.AppendIntf(o, za0005)
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions", za0004)
-					return
-				}
-			}
+		// string "exts"
+		o = append(o, 0xa4, 0x65, 0x78, 0x74, 0x73)
+		o, err = (*sessionExtensions)(&z.Extensions).MarshalMsg(o)
+		if err != nil {
+			err = msgp.WrapError(err, "Extensions")
+			return
 		}
 		if (zb0001Mask & 0x80) == 0 { // if not omitted
 			// string "params"
 			o = append(o, 0xa6, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.CredParams)))
-			for za0006 := range z.CredParams {
-				o, err = z.CredParams[za0006].MarshalMsg(o)
+			for za0002 := range z.CredParams {
+				o, err = z.CredParams[za0002].MarshalMsg(o)
 				if err != nil {
-					err = msgp.WrapError(err, "CredParams", za0006)
+					err = msgp.WrapError(err, "CredParams", za0002)
 					return
 				}
 			}
@@ -468,7 +414,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 7 bits */
+	var zb0001Mask uint8 /* 6 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -510,10 +456,10 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			} else {
 				z.AllowedCredentialIDs = make([][]byte, zb0002)
 			}
-			for za0003 := range z.AllowedCredentialIDs {
-				z.AllowedCredentialIDs[za0003], bts, err = msgp.ReadBytesBytes(bts, z.AllowedCredentialIDs[za0003])
+			for za0001 := range z.AllowedCredentialIDs {
+				z.AllowedCredentialIDs[za0001], bts, err = msgp.ReadBytesBytes(bts, z.AllowedCredentialIDs[za0001])
 				if err != nil {
-					err = msgp.WrapError(err, "AllowedCredentialIDs", za0003)
+					err = msgp.WrapError(err, "AllowedCredentialIDs", za0001)
 					return
 				}
 			}
@@ -536,65 +482,42 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			}
 			zb0001Mask |= 0x8
 		case "exts":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			bts, err = (*sessionExtensions)(&z.Extensions).UnmarshalMsg(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Extensions")
 				return
 			}
-			if z.Extensions == nil {
-				z.Extensions = make(map[string]interface{}, zb0004)
-			} else if len(z.Extensions) > 0 {
-				clear(z.Extensions)
-			}
-			for zb0004 > 0 {
-				var za0005 interface{}
-				zb0004--
-				var za0004 string
-				za0004, bts, err = msgp.ReadStringBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions")
-					return
-				}
-				za0005, bts, err = msgp.ReadIntfBytes(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Extensions", za0004)
-					return
-				}
-				z.Extensions[za0004] = za0005
-			}
-			zb0001Mask |= 0x10
 		case "params":
-			var zb0005 uint32
-			zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "CredParams")
 				return
 			}
-			if cap(z.CredParams) >= int(zb0005) {
-				z.CredParams = (z.CredParams)[:zb0005]
+			if cap(z.CredParams) >= int(zb0004) {
+				z.CredParams = (z.CredParams)[:zb0004]
 			} else {
-				z.CredParams = make([]protocol.CredentialParameter, zb0005)
+				z.CredParams = make([]protocol.CredentialParameter, zb0004)
 			}
-			for za0006 := range z.CredParams {
-				bts, err = z.CredParams[za0006].UnmarshalMsg(bts)
+			for za0002 := range z.CredParams {
+				bts, err = z.CredParams[za0002].UnmarshalMsg(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "CredParams", za0006)
+					err = msgp.WrapError(err, "CredParams", za0002)
 					return
 				}
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x10
 		case "cmr":
 			{
-				var zb0006 string
-				zb0006, bts, err = msgp.ReadStringBytes(bts)
+				var zb0005 string
+				zb0005, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "Mediation")
 					return
 				}
-				z.Mediation = protocol.CredentialMediationRequirement(zb0006)
+				z.Mediation = protocol.CredentialMediationRequirement(zb0005)
 			}
-			zb0001Mask |= 0x40
+			zb0001Mask |= 0x20
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -604,7 +527,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x7f {
+	if zb0001Mask != 0x3f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.RelyingPartyID = ""
 		}
@@ -618,12 +541,9 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.UserVerification = ""
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.Extensions = nil
-		}
-		if (zb0001Mask & 0x20) == 0 {
 			z.CredParams = nil
 		}
-		if (zb0001Mask & 0x40) == 0 {
+		if (zb0001Mask & 0x20) == 0 {
 			z.Mediation = ""
 		}
 	}
@@ -634,20 +554,465 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SessionData) Msgsize() (s int) {
 	s = 1 + 2 + msgp.StringPrefixSize + len(z.Challenge) + 2 + msgp.StringPrefixSize + len(z.RelyingPartyID) + 2 + msgp.BytesPrefixSize + len(z.UserID) + 6 + msgp.ArrayHeaderSize
-	for za0003 := range z.AllowedCredentialIDs {
-		s += msgp.BytesPrefixSize + len(z.AllowedCredentialIDs[za0003])
+	for za0001 := range z.AllowedCredentialIDs {
+		s += msgp.BytesPrefixSize + len(z.AllowedCredentialIDs[za0001])
 	}
-	s += 4 + msgp.TimeSize + 3 + msgp.StringPrefixSize + len(string(z.UserVerification)) + 5 + msgp.MapHeaderSize
-	if z.Extensions != nil {
-		for za0004, za0005 := range z.Extensions {
-			_ = za0005
-			s += msgp.StringPrefixSize + len(za0004) + msgp.GuessSize(za0005)
-		}
-	}
-	s += 7 + msgp.ArrayHeaderSize
-	for za0006 := range z.CredParams {
-		s += z.CredParams[za0006].Msgsize()
+	s += 4 + msgp.TimeSize + 3 + msgp.StringPrefixSize + len(string(z.UserVerification)) + 5 + (*sessionExtensions)(&z.Extensions).Msgsize() + 7 + msgp.ArrayHeaderSize
+	for za0002 := range z.CredParams {
+		s += z.CredParams[za0002].Msgsize()
 	}
 	s += 4 + msgp.StringPrefixSize + len(string(z.Mediation))
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "req":
+			var zb0002 uint32
+			zb0002, err = dc.ReadArrayHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Requested")
+				return
+			}
+			if cap(z.Requested) >= int(zb0002) {
+				z.Requested = (z.Requested)[:zb0002]
+			} else {
+				z.Requested = make([]string, zb0002)
+			}
+			for za0001 := range z.Requested {
+				z.Requested[za0001], err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Requested", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "appid":
+			z.AppID, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "AppID")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "appidExclude":
+			z.AppIDExclude, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "AppIDExclude")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "largeBlob":
+			{
+				var zb0003 string
+				zb0003, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "LargeBlob")
+					return
+				}
+				z.LargeBlob = protocol.LargeBlobSupport(zb0003)
+			}
+			zb0001Mask |= 0x8
+		case "extra":
+			var zb0004 uint32
+			zb0004, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "Extra")
+				return
+			}
+			if z.Extra == nil {
+				z.Extra = make(map[string]interface{}, zb0004)
+			} else if len(z.Extra) > 0 {
+				clear(z.Extra)
+			}
+			for zb0004 > 0 {
+				zb0004--
+				var za0002 string
+				za0002, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "Extra")
+					return
+				}
+				var za0003 interface{}
+				za0003, err = dc.ReadIntf()
+				if err != nil {
+					err = msgp.WrapError(err, "Extra", za0002)
+					return
+				}
+				z.Extra[za0002] = za0003
+			}
+			zb0001Mask |= 0x10
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x1f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Requested = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.AppID = ""
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.AppIDExclude = ""
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LargeBlob = ""
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.Extra = nil
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
+	// check for omitted fields
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	if z.Requested == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.AppID == "" {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.AppIDExclude == "" {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LargeBlob == "" {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.Extra == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	// variable map header, size zb0001Len
+	err = en.Append(0x80 | uint8(zb0001Len))
+	if err != nil {
+		return
+	}
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// write "req"
+			err = en.Append(0xa3, 0x72, 0x65, 0x71)
+			if err != nil {
+				return
+			}
+			err = en.WriteArrayHeader(uint32(len(z.Requested)))
+			if err != nil {
+				err = msgp.WrapError(err, "Requested")
+				return
+			}
+			for za0001 := range z.Requested {
+				err = en.WriteString(z.Requested[za0001])
+				if err != nil {
+					err = msgp.WrapError(err, "Requested", za0001)
+					return
+				}
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// write "appid"
+			err = en.Append(0xa5, 0x61, 0x70, 0x70, 0x69, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(z.AppID)
+			if err != nil {
+				err = msgp.WrapError(err, "AppID")
+				return
+			}
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "appidExclude"
+			err = en.Append(0xac, 0x61, 0x70, 0x70, 0x69, 0x64, 0x45, 0x78, 0x63, 0x6c, 0x75, 0x64, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(z.AppIDExclude)
+			if err != nil {
+				err = msgp.WrapError(err, "AppIDExclude")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// write "largeBlob"
+			err = en.Append(0xa9, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x42, 0x6c, 0x6f, 0x62)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(string(z.LargeBlob))
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlob")
+				return
+			}
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "extra"
+			err = en.Append(0xa5, 0x65, 0x78, 0x74, 0x72, 0x61)
+			if err != nil {
+				return
+			}
+			err = en.WriteMapHeader(uint32(len(z.Extra)))
+			if err != nil {
+				err = msgp.WrapError(err, "Extra")
+				return
+			}
+			for za0002, za0003 := range z.Extra {
+				err = en.WriteString(za0002)
+				if err != nil {
+					err = msgp.WrapError(err, "Extra")
+					return
+				}
+				err = en.WriteIntf(za0003)
+				if err != nil {
+					err = msgp.WrapError(err, "Extra", za0002)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// check for omitted fields
+	zb0001Len := uint32(5)
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	if z.Requested == nil {
+		zb0001Len--
+		zb0001Mask |= 0x1
+	}
+	if z.AppID == "" {
+		zb0001Len--
+		zb0001Mask |= 0x2
+	}
+	if z.AppIDExclude == "" {
+		zb0001Len--
+		zb0001Mask |= 0x4
+	}
+	if z.LargeBlob == "" {
+		zb0001Len--
+		zb0001Mask |= 0x8
+	}
+	if z.Extra == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
+	// variable map header, size zb0001Len
+	o = append(o, 0x80|uint8(zb0001Len))
+
+	// skip if no fields are to be emitted
+	if zb0001Len != 0 {
+		if (zb0001Mask & 0x1) == 0 { // if not omitted
+			// string "req"
+			o = append(o, 0xa3, 0x72, 0x65, 0x71)
+			o = msgp.AppendArrayHeader(o, uint32(len(z.Requested)))
+			for za0001 := range z.Requested {
+				o = msgp.AppendString(o, z.Requested[za0001])
+			}
+		}
+		if (zb0001Mask & 0x2) == 0 { // if not omitted
+			// string "appid"
+			o = append(o, 0xa5, 0x61, 0x70, 0x70, 0x69, 0x64)
+			o = msgp.AppendString(o, z.AppID)
+		}
+		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "appidExclude"
+			o = append(o, 0xac, 0x61, 0x70, 0x70, 0x69, 0x64, 0x45, 0x78, 0x63, 0x6c, 0x75, 0x64, 0x65)
+			o = msgp.AppendString(o, z.AppIDExclude)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
+			// string "largeBlob"
+			o = append(o, 0xa9, 0x6c, 0x61, 0x72, 0x67, 0x65, 0x42, 0x6c, 0x6f, 0x62)
+			o = msgp.AppendString(o, string(z.LargeBlob))
+		}
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "extra"
+			o = append(o, 0xa5, 0x65, 0x78, 0x74, 0x72, 0x61)
+			o = msgp.AppendMapHeader(o, uint32(len(z.Extra)))
+			for za0002, za0003 := range z.Extra {
+				o = msgp.AppendString(o, za0002)
+				o, err = msgp.AppendIntf(o, za0003)
+				if err != nil {
+					err = msgp.WrapError(err, "Extra", za0002)
+					return
+				}
+			}
+		}
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	var zb0001Mask uint8 /* 5 bits */
+	_ = zb0001Mask
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "req":
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Requested")
+				return
+			}
+			if cap(z.Requested) >= int(zb0002) {
+				z.Requested = (z.Requested)[:zb0002]
+			} else {
+				z.Requested = make([]string, zb0002)
+			}
+			for za0001 := range z.Requested {
+				z.Requested[za0001], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Requested", za0001)
+					return
+				}
+			}
+			zb0001Mask |= 0x1
+		case "appid":
+			z.AppID, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AppID")
+				return
+			}
+			zb0001Mask |= 0x2
+		case "appidExclude":
+			z.AppIDExclude, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AppIDExclude")
+				return
+			}
+			zb0001Mask |= 0x4
+		case "largeBlob":
+			{
+				var zb0003 string
+				zb0003, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "LargeBlob")
+					return
+				}
+				z.LargeBlob = protocol.LargeBlobSupport(zb0003)
+			}
+			zb0001Mask |= 0x8
+		case "extra":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Extra")
+				return
+			}
+			if z.Extra == nil {
+				z.Extra = make(map[string]interface{}, zb0004)
+			} else if len(z.Extra) > 0 {
+				clear(z.Extra)
+			}
+			for zb0004 > 0 {
+				var za0003 interface{}
+				zb0004--
+				var za0002 string
+				za0002, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Extra")
+					return
+				}
+				za0003, bts, err = msgp.ReadIntfBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Extra", za0002)
+					return
+				}
+				z.Extra[za0002] = za0003
+			}
+			zb0001Mask |= 0x10
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	// Clear omitted fields.
+	if zb0001Mask != 0x1f {
+		if (zb0001Mask & 0x1) == 0 {
+			z.Requested = nil
+		}
+		if (zb0001Mask & 0x2) == 0 {
+			z.AppID = ""
+		}
+		if (zb0001Mask & 0x4) == 0 {
+			z.AppIDExclude = ""
+		}
+		if (zb0001Mask & 0x8) == 0 {
+			z.LargeBlob = ""
+		}
+		if (zb0001Mask & 0x10) == 0 {
+			z.Extra = nil
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *sessionExtensions) Msgsize() (s int) {
+	s = 1 + 4 + msgp.ArrayHeaderSize
+	for za0001 := range z.Requested {
+		s += msgp.StringPrefixSize + len(z.Requested[za0001])
+	}
+	s += 6 + msgp.StringPrefixSize + len(z.AppID) + 13 + msgp.StringPrefixSize + len(z.AppIDExclude) + 10 + msgp.StringPrefixSize + len(string(z.LargeBlob)) + 6 + msgp.MapHeaderSize
+	if z.Extra != nil {
+		for za0002, za0003 := range z.Extra {
+			_ = za0003
+			s += msgp.StringPrefixSize + len(za0002) + msgp.GuessSize(za0003)
+		}
+	}
 	return
 }

--- a/webauthn/types_session_gen.go
+++ b/webauthn/types_session_gen.go
@@ -575,7 +575,7 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 9 bits */
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -662,6 +662,13 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			zb0001Mask |= 0x80
+		case "credBlob":
+			z.CredBlob, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "CredBlob")
+				return
+			}
+			zb0001Mask |= 0x100
 		case "extra":
 			var zb0005 uint32
 			zb0005, err = dc.ReadMapHeader()
@@ -690,7 +697,7 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Extra[za0002] = za0003
 			}
-			zb0001Mask |= 0x100
+			zb0001Mask |= 0x200
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -700,7 +707,7 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1ff {
+	if zb0001Mask != 0x3ff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Requested = nil
 		}
@@ -726,6 +733,9 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.EnforceCredentialProtectionPolicy = false
 		}
 		if (zb0001Mask & 0x100) == 0 {
+			z.CredBlob = false
+		}
+		if (zb0001Mask & 0x200) == 0 {
 			z.Extra = nil
 		}
 	}
@@ -735,8 +745,8 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(9)
-	var zb0001Mask uint16 /* 9 bits */
+	zb0001Len := uint32(10)
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	if z.Requested == nil {
 		zb0001Len--
@@ -770,9 +780,13 @@ func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if z.Extra == nil {
+	if z.CredBlob == false {
 		zb0001Len--
 		zb0001Mask |= 0x100
+	}
+	if z.Extra == nil {
+		zb0001Len--
+		zb0001Mask |= 0x200
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -886,6 +900,18 @@ func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// write "credBlob"
+			err = en.Append(0xa8, 0x63, 0x72, 0x65, 0x64, 0x42, 0x6c, 0x6f, 0x62)
+			if err != nil {
+				return
+			}
+			err = en.WriteBool(z.CredBlob)
+			if err != nil {
+				err = msgp.WrapError(err, "CredBlob")
+				return
+			}
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// write "extra"
 			err = en.Append(0xa5, 0x65, 0x78, 0x74, 0x72, 0x61)
 			if err != nil {
@@ -917,8 +943,8 @@ func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(9)
-	var zb0001Mask uint16 /* 9 bits */
+	zb0001Len := uint32(10)
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	if z.Requested == nil {
 		zb0001Len--
@@ -952,9 +978,13 @@ func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x80
 	}
-	if z.Extra == nil {
+	if z.CredBlob == false {
 		zb0001Len--
 		zb0001Mask |= 0x100
+	}
+	if z.Extra == nil {
+		zb0001Len--
+		zb0001Mask |= 0x200
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -1005,6 +1035,11 @@ func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendBool(o, z.EnforceCredentialProtectionPolicy)
 		}
 		if (zb0001Mask & 0x100) == 0 { // if not omitted
+			// string "credBlob"
+			o = append(o, 0xa8, 0x63, 0x72, 0x65, 0x64, 0x42, 0x6c, 0x6f, 0x62)
+			o = msgp.AppendBool(o, z.CredBlob)
+		}
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// string "extra"
 			o = append(o, 0xa5, 0x65, 0x78, 0x74, 0x72, 0x61)
 			o = msgp.AppendMapHeader(o, uint32(len(z.Extra)))
@@ -1031,7 +1066,7 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint16 /* 9 bits */
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -1118,6 +1153,13 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			zb0001Mask |= 0x80
+		case "credBlob":
+			z.CredBlob, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CredBlob")
+				return
+			}
+			zb0001Mask |= 0x100
 		case "extra":
 			var zb0005 uint32
 			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
@@ -1146,7 +1188,7 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Extra[za0002] = za0003
 			}
-			zb0001Mask |= 0x100
+			zb0001Mask |= 0x200
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -1156,7 +1198,7 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1ff {
+	if zb0001Mask != 0x3ff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Requested = nil
 		}
@@ -1182,6 +1224,9 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.EnforceCredentialProtectionPolicy = false
 		}
 		if (zb0001Mask & 0x100) == 0 {
+			z.CredBlob = false
+		}
+		if (zb0001Mask & 0x200) == 0 {
 			z.Extra = nil
 		}
 	}
@@ -1195,7 +1240,7 @@ func (z *sessionExtensions) Msgsize() (s int) {
 	for za0001 := range z.Requested {
 		s += msgp.StringPrefixSize + len(z.Requested[za0001])
 	}
-	s += 6 + msgp.StringPrefixSize + len(z.AppID) + 13 + msgp.StringPrefixSize + len(z.AppIDExclude) + 10 + msgp.StringPrefixSize + len(string(z.LargeBlob)) + 7 + msgp.BoolSize + 8 + msgp.BoolSize + 12 + msgp.StringPrefixSize + len(string(z.CredentialProtectionPolicy)) + 10 + msgp.BoolSize + 6 + msgp.MapHeaderSize
+	s += 6 + msgp.StringPrefixSize + len(z.AppID) + 13 + msgp.StringPrefixSize + len(z.AppIDExclude) + 10 + msgp.StringPrefixSize + len(string(z.LargeBlob)) + 7 + msgp.BoolSize + 8 + msgp.BoolSize + 12 + msgp.StringPrefixSize + len(string(z.CredentialProtectionPolicy)) + 10 + msgp.BoolSize + 9 + msgp.BoolSize + 6 + msgp.MapHeaderSize
 	if z.Extra != nil {
 		for za0002, za0003 := range z.Extra {
 			_ = za0003

--- a/webauthn/types_session_gen.go
+++ b/webauthn/types_session_gen.go
@@ -575,7 +575,7 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint16 /* 9 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -630,20 +630,52 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.LargeBlob = protocol.LargeBlobSupport(zb0003)
 			}
 			zb0001Mask |= 0x8
+		case "lbRead":
+			z.LargeBlobRead, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlobRead")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "lbWrite":
+			z.LargeBlobWrite, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlobWrite")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "credProtect":
+			{
+				var zb0004 string
+				zb0004, err = dc.ReadString()
+				if err != nil {
+					err = msgp.WrapError(err, "CredentialProtectionPolicy")
+					return
+				}
+				z.CredentialProtectionPolicy = protocol.CredentialProtectionPolicy(zb0004)
+			}
+			zb0001Mask |= 0x40
+		case "cpEnforce":
+			z.EnforceCredentialProtectionPolicy, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "EnforceCredentialProtectionPolicy")
+				return
+			}
+			zb0001Mask |= 0x80
 		case "extra":
-			var zb0004 uint32
-			zb0004, err = dc.ReadMapHeader()
+			var zb0005 uint32
+			zb0005, err = dc.ReadMapHeader()
 			if err != nil {
 				err = msgp.WrapError(err, "Extra")
 				return
 			}
 			if z.Extra == nil {
-				z.Extra = make(map[string]interface{}, zb0004)
+				z.Extra = make(map[string]interface{}, zb0005)
 			} else if len(z.Extra) > 0 {
 				clear(z.Extra)
 			}
-			for zb0004 > 0 {
-				zb0004--
+			for zb0005 > 0 {
+				zb0005--
 				var za0002 string
 				za0002, err = dc.ReadString()
 				if err != nil {
@@ -658,7 +690,7 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Extra[za0002] = za0003
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x100
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -668,7 +700,7 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x1ff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Requested = nil
 		}
@@ -682,6 +714,18 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 			z.LargeBlob = ""
 		}
 		if (zb0001Mask & 0x10) == 0 {
+			z.LargeBlobRead = false
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.LargeBlobWrite = false
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.CredentialProtectionPolicy = ""
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.EnforceCredentialProtectionPolicy = false
+		}
+		if (zb0001Mask & 0x100) == 0 {
 			z.Extra = nil
 		}
 	}
@@ -691,8 +735,8 @@ func (z *sessionExtensions) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(5)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
 	_ = zb0001Mask
 	if z.Requested == nil {
 		zb0001Len--
@@ -710,9 +754,25 @@ func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.Extra == nil {
+	if z.LargeBlobRead == false {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if z.LargeBlobWrite == false {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.CredentialProtectionPolicy == "" {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.EnforceCredentialProtectionPolicy == false {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.Extra == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -778,6 +838,54 @@ func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// write "lbRead"
+			err = en.Append(0xa6, 0x6c, 0x62, 0x52, 0x65, 0x61, 0x64)
+			if err != nil {
+				return
+			}
+			err = en.WriteBool(z.LargeBlobRead)
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlobRead")
+				return
+			}
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// write "lbWrite"
+			err = en.Append(0xa7, 0x6c, 0x62, 0x57, 0x72, 0x69, 0x74, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteBool(z.LargeBlobWrite)
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlobWrite")
+				return
+			}
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// write "credProtect"
+			err = en.Append(0xab, 0x63, 0x72, 0x65, 0x64, 0x50, 0x72, 0x6f, 0x74, 0x65, 0x63, 0x74)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(string(z.CredentialProtectionPolicy))
+			if err != nil {
+				err = msgp.WrapError(err, "CredentialProtectionPolicy")
+				return
+			}
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// write "cpEnforce"
+			err = en.Append(0xa9, 0x63, 0x70, 0x45, 0x6e, 0x66, 0x6f, 0x72, 0x63, 0x65)
+			if err != nil {
+				return
+			}
+			err = en.WriteBool(z.EnforceCredentialProtectionPolicy)
+			if err != nil {
+				err = msgp.WrapError(err, "EnforceCredentialProtectionPolicy")
+				return
+			}
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// write "extra"
 			err = en.Append(0xa5, 0x65, 0x78, 0x74, 0x72, 0x61)
 			if err != nil {
@@ -809,8 +917,8 @@ func (z *sessionExtensions) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(5)
-	var zb0001Mask uint8 /* 5 bits */
+	zb0001Len := uint32(9)
+	var zb0001Mask uint16 /* 9 bits */
 	_ = zb0001Mask
 	if z.Requested == nil {
 		zb0001Len--
@@ -828,9 +936,25 @@ func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
-	if z.Extra == nil {
+	if z.LargeBlobRead == false {
 		zb0001Len--
 		zb0001Mask |= 0x10
+	}
+	if z.LargeBlobWrite == false {
+		zb0001Len--
+		zb0001Mask |= 0x20
+	}
+	if z.CredentialProtectionPolicy == "" {
+		zb0001Len--
+		zb0001Mask |= 0x40
+	}
+	if z.EnforceCredentialProtectionPolicy == false {
+		zb0001Len--
+		zb0001Mask |= 0x80
+	}
+	if z.Extra == nil {
+		zb0001Len--
+		zb0001Mask |= 0x100
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -861,6 +985,26 @@ func (z *sessionExtensions) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendString(o, string(z.LargeBlob))
 		}
 		if (zb0001Mask & 0x10) == 0 { // if not omitted
+			// string "lbRead"
+			o = append(o, 0xa6, 0x6c, 0x62, 0x52, 0x65, 0x61, 0x64)
+			o = msgp.AppendBool(o, z.LargeBlobRead)
+		}
+		if (zb0001Mask & 0x20) == 0 { // if not omitted
+			// string "lbWrite"
+			o = append(o, 0xa7, 0x6c, 0x62, 0x57, 0x72, 0x69, 0x74, 0x65)
+			o = msgp.AppendBool(o, z.LargeBlobWrite)
+		}
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
+			// string "credProtect"
+			o = append(o, 0xab, 0x63, 0x72, 0x65, 0x64, 0x50, 0x72, 0x6f, 0x74, 0x65, 0x63, 0x74)
+			o = msgp.AppendString(o, string(z.CredentialProtectionPolicy))
+		}
+		if (zb0001Mask & 0x80) == 0 { // if not omitted
+			// string "cpEnforce"
+			o = append(o, 0xa9, 0x63, 0x70, 0x45, 0x6e, 0x66, 0x6f, 0x72, 0x63, 0x65)
+			o = msgp.AppendBool(o, z.EnforceCredentialProtectionPolicy)
+		}
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// string "extra"
 			o = append(o, 0xa5, 0x65, 0x78, 0x74, 0x72, 0x61)
 			o = msgp.AppendMapHeader(o, uint32(len(z.Extra)))
@@ -887,7 +1031,7 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 5 bits */
+	var zb0001Mask uint16 /* 9 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -942,21 +1086,53 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.LargeBlob = protocol.LargeBlobSupport(zb0003)
 			}
 			zb0001Mask |= 0x8
+		case "lbRead":
+			z.LargeBlobRead, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlobRead")
+				return
+			}
+			zb0001Mask |= 0x10
+		case "lbWrite":
+			z.LargeBlobWrite, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "LargeBlobWrite")
+				return
+			}
+			zb0001Mask |= 0x20
+		case "credProtect":
+			{
+				var zb0004 string
+				zb0004, bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "CredentialProtectionPolicy")
+					return
+				}
+				z.CredentialProtectionPolicy = protocol.CredentialProtectionPolicy(zb0004)
+			}
+			zb0001Mask |= 0x40
+		case "cpEnforce":
+			z.EnforceCredentialProtectionPolicy, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "EnforceCredentialProtectionPolicy")
+				return
+			}
+			zb0001Mask |= 0x80
 		case "extra":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Extra")
 				return
 			}
 			if z.Extra == nil {
-				z.Extra = make(map[string]interface{}, zb0004)
+				z.Extra = make(map[string]interface{}, zb0005)
 			} else if len(z.Extra) > 0 {
 				clear(z.Extra)
 			}
-			for zb0004 > 0 {
+			for zb0005 > 0 {
 				var za0003 interface{}
-				zb0004--
+				zb0005--
 				var za0002 string
 				za0002, bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
@@ -970,7 +1146,7 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Extra[za0002] = za0003
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x100
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -980,7 +1156,7 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x1f {
+	if zb0001Mask != 0x1ff {
 		if (zb0001Mask & 0x1) == 0 {
 			z.Requested = nil
 		}
@@ -994,6 +1170,18 @@ func (z *sessionExtensions) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			z.LargeBlob = ""
 		}
 		if (zb0001Mask & 0x10) == 0 {
+			z.LargeBlobRead = false
+		}
+		if (zb0001Mask & 0x20) == 0 {
+			z.LargeBlobWrite = false
+		}
+		if (zb0001Mask & 0x40) == 0 {
+			z.CredentialProtectionPolicy = ""
+		}
+		if (zb0001Mask & 0x80) == 0 {
+			z.EnforceCredentialProtectionPolicy = false
+		}
+		if (zb0001Mask & 0x100) == 0 {
 			z.Extra = nil
 		}
 	}
@@ -1007,7 +1195,7 @@ func (z *sessionExtensions) Msgsize() (s int) {
 	for za0001 := range z.Requested {
 		s += msgp.StringPrefixSize + len(z.Requested[za0001])
 	}
-	s += 6 + msgp.StringPrefixSize + len(z.AppID) + 13 + msgp.StringPrefixSize + len(z.AppIDExclude) + 10 + msgp.StringPrefixSize + len(string(z.LargeBlob)) + 6 + msgp.MapHeaderSize
+	s += 6 + msgp.StringPrefixSize + len(z.AppID) + 13 + msgp.StringPrefixSize + len(z.AppIDExclude) + 10 + msgp.StringPrefixSize + len(string(z.LargeBlob)) + 7 + msgp.BoolSize + 8 + msgp.BoolSize + 12 + msgp.StringPrefixSize + len(string(z.CredentialProtectionPolicy)) + 10 + msgp.BoolSize + 6 + msgp.MapHeaderSize
 	if z.Extra != nil {
 		for za0002, za0003 := range z.Extra {
 			_ = za0003

--- a/webauthn/types_session_gen_test.go
+++ b/webauthn/types_session_gen_test.go
@@ -121,3 +121,116 @@ func BenchmarkDecodeSessionData(b *testing.B) {
 		}
 	}
 }
+
+func TestMarshalUnmarshalsessionExtensions(t *testing.T) {
+	v := sessionExtensions{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgsessionExtensions(b *testing.B) {
+	v := sessionExtensions{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgsessionExtensions(b *testing.B) {
+	v := sessionExtensions{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalsessionExtensions(b *testing.B) {
+	v := sessionExtensions{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodesessionExtensions(t *testing.T) {
+	v := sessionExtensions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Log("WARNING: TestEncodeDecodesessionExtensions Msgsize() is inaccurate")
+	}
+
+	vn := sessionExtensions{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodesessionExtensions(b *testing.B) {
+	v := sessionExtensions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodesessionExtensions(b *testing.B) {
+	v := sessionExtensions{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/webauthn/types_session_test.go
+++ b/webauthn/types_session_test.go
@@ -266,9 +266,12 @@ func newPopulatedSessionData() SessionData {
 		Expires:          time.Date(2026, time.April, 19, 12, 34, 56, 0, time.UTC),
 		UserVerification: protocol.VerificationRequired,
 		Extensions: protocol.SessionExtensions{
-			Requested: []string{"credProps", "largeBlob"},
-			LargeBlob: protocol.LargeBlobSupportPreferred,
-			Extra:     map[string]any{"credProtect": int64(2)},
+			Requested:                         []string{"credProps", "largeBlob"},
+			LargeBlob:                         protocol.LargeBlobSupportPreferred,
+			LargeBlobRead:                     true,
+			CredentialProtectionPolicy:        protocol.CredentialProtectionPolicyUserVerificationRequired,
+			EnforceCredentialProtectionPolicy: true,
+			Extra:                             map[string]any{"vendorThing": int64(2)},
 		},
 		CredParams: []protocol.CredentialParameter{
 			{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},

--- a/webauthn/types_session_test.go
+++ b/webauthn/types_session_test.go
@@ -240,6 +240,31 @@ func TestSessionData_DecodeMsgInvalidTypes(t *testing.T) {
 	}
 }
 
+func TestSessionDataUnmarshalMsgLeavesExtensionsWhenOmitted(t *testing.T) {
+	// SessionData documents that Extensions, unlike the other members, is not reset when the encoded payload omits
+	// it, so a reused destination keeps the previous ceremony's extension state. This pins that behaviour: it is
+	// the reason the documentation tells Relying Parties to decode into a fresh SessionData, and a silent change
+	// either way would invalidate that advice.
+	payload := msgp.AppendMapHeader(nil, 1)
+	payload = msgp.AppendString(payload, "c")
+	payload = msgp.AppendString(payload, "a-new-challenge")
+
+	decoded := SessionData{
+		Extensions: protocol.SessionExtensions{
+			Requested: []string{protocol.ExtensionAppID},
+			AppID:     "https://previous.example.com",
+		},
+	}
+
+	left, err := decoded.UnmarshalMsg(payload)
+	require.NoError(t, err)
+	assert.Empty(t, left)
+
+	assert.Equal(t, "a-new-challenge", decoded.Challenge)
+	assert.Equal(t, "https://previous.example.com", decoded.Extensions.AppID,
+		"Extensions is not cleared by a payload which omits it; decode into a fresh SessionData")
+}
+
 func TestSessionExtensionsShadowMatches(t *testing.T) {
 	// A compile-time conversion in both directions proves the shadow struct the msgp generator uses stays
 	// field-for-field identical to the protocol type.

--- a/webauthn/types_session_test.go
+++ b/webauthn/types_session_test.go
@@ -2,6 +2,7 @@ package webauthn
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 	"time"
 
@@ -92,7 +93,7 @@ func TestSessionData_MsgpEmptyVariants(t *testing.T) {
 			},
 		},
 		{
-			name: "NilExtensions",
+			name: "ZeroExtensions",
 			original: SessionData{
 				Challenge:      "c",
 				RelyingPartyID: "r",
@@ -100,12 +101,15 @@ func TestSessionData_MsgpEmptyVariants(t *testing.T) {
 			},
 		},
 		{
-			name: "EmptyExtensions",
+			name: "PopulatedExtensions",
 			original: SessionData{
 				Challenge:      "c",
 				RelyingPartyID: "r",
 				UserID:         []byte{0x01},
-				Extensions:     protocol.AuthenticationExtensions{},
+				Extensions: protocol.SessionExtensions{
+					Requested: []string{"appid"},
+					AppID:     "https://example.com",
+				},
 			},
 		},
 		{
@@ -133,7 +137,7 @@ func TestSessionData_MsgpEmptyVariants(t *testing.T) {
 			assert.Equal(t, tc.original.RelyingPartyID, decoded.RelyingPartyID)
 			assert.Equal(t, tc.original.UserID, decoded.UserID)
 			assert.Len(t, decoded.AllowedCredentialIDs, len(tc.original.AllowedCredentialIDs))
-			assert.Len(t, decoded.Extensions, len(tc.original.Extensions))
+			assert.Equal(t, tc.original.Extensions, decoded.Extensions)
 			assert.Len(t, decoded.CredParams, len(tc.original.CredParams))
 		})
 	}
@@ -236,6 +240,20 @@ func TestSessionData_DecodeMsgInvalidTypes(t *testing.T) {
 	}
 }
 
+func TestSessionExtensionsShadowMatches(t *testing.T) {
+	// A compile-time conversion in both directions proves the shadow struct the msgp generator uses stays
+	// field-for-field identical to the protocol type.
+	var (
+		shadow sessionExtensions
+		actual protocol.SessionExtensions
+	)
+
+	assert.Equal(t, protocol.SessionExtensions(shadow), actual)
+	assert.Equal(t, sessionExtensions(actual), shadow)
+
+	assert.Equal(t, reflect.TypeOf(shadow).NumField(), reflect.TypeOf(actual).NumField())
+}
+
 func newPopulatedSessionData() SessionData {
 	return SessionData{
 		Challenge:      "challenge-bytes-b64url",
@@ -247,10 +265,10 @@ func newPopulatedSessionData() SessionData {
 		},
 		Expires:          time.Date(2026, time.April, 19, 12, 34, 56, 0, time.UTC),
 		UserVerification: protocol.VerificationRequired,
-		Extensions: protocol.AuthenticationExtensions{
-			"appid":       "https://example.com",
-			"credProtect": int64(2),
-			"largeBlob":   true,
+		Extensions: protocol.SessionExtensions{
+			Requested: []string{"credProps", "largeBlob"},
+			LargeBlob: protocol.LargeBlobSupportPreferred,
+			Extra:     map[string]any{"credProtect": int64(2)},
 		},
 		CredParams: []protocol.CredentialParameter{
 			{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256},

--- a/webauthn/types_session_test.go
+++ b/webauthn/types_session_test.go
@@ -271,6 +271,7 @@ func newPopulatedSessionData() SessionData {
 			LargeBlobRead:                     true,
 			CredentialProtectionPolicy:        protocol.CredentialProtectionPolicyUserVerificationRequired,
 			EnforceCredentialProtectionPolicy: true,
+			CredBlob:                          true,
 			Extra:                             map[string]any{"vendorThing": int64(2)},
 		},
 		CredParams: []protocol.CredentialParameter{

--- a/webauthn/util.go
+++ b/webauthn/util.go
@@ -1,6 +1,10 @@
 package webauthn
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/go-webauthn/webauthn/protocol"
+)
 
 func isByteArrayInSlice(needle []byte, haystack ...[]byte) (valid bool) {
 	for _, hay := range haystack {
@@ -32,6 +36,23 @@ allowed:
 func isCredentialIDInCredentials(credentialID []byte, credentials []Credential) (valid bool) {
 	for _, credential := range credentials {
 		if bytes.Equal(credential.ID, credentialID) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ptr returns a pointer to the given value.
+func ptr[T any](v T) *T {
+	return &v
+}
+
+// hasU2FCredential reports whether any of the given descriptors originated from the legacy FIDO U2F JavaScript
+// API, which is the condition under which the FIDO AppID and AppID Exclusion extensions are meaningful.
+func hasU2FCredential(credentials []protocol.CredentialDescriptor) bool {
+	for _, credential := range credentials {
+		if credential.AttestationFormat == string(protocol.AttestationFormatFIDOUniversalSecondFactor) {
 			return true
 		}
 	}


### PR DESCRIPTION
Extensions are modelled as typed Go values rather than an untyped map. Every extension with a defined client input gains a dedicated `webauthn.WithExtension<Name>` option applied via `WithExtensions` or `WithAssertionExtensions`, and its client and authenticator outputs are decoded into typed fields of `protocol.AuthenticationExtensionsClientOutputs` and `protocol.AuthenticatorExtensionOutputs`. An identifier with no dedicated option is still reachable verbatim through `webauthn.WithExtension`, and any output returned under it is preserved in the relevant `Extra` map rather than discarded.

`SessionData` now records which extensions the Relying Party requested so the finish step can reject client outputs that were never solicited, with `Config.ExtensionsUnsolicitedOutputPolicy` relaxing that for deployments whose clients are known to return outputs unprompted. The msgp encoding of the session carries a shadow type for the new extension state.

BREAKING CHANGE: `RegistrationOption` and `LoginOption` now return an error, so any option implemented outside this module must be adjusted, and `WithExtensions` and `WithAssertionExtensions` accept extension options in place of a map. `protocol.AuthenticationExtensions` and `protocol.AuthenticationExtensionsClientOutputs` are structs rather than `map[string]any`, `protocol.Extensions` is removed, and `ParsedPublicKeyCredential.GetAppID` takes a `protocol.SessionExtensions`. `SessionData.Extensions` changes both its type and its encoded representation, so a session persisted by an earlier version cannot be decoded by this one, and a client extension output the Relying Party did not request now fails the ceremony unless `Config.ExtensionsUnsolicitedOutputPolicy` says otherwise.