### PR TITLE
fix(metadata): mds3 parsing conformance and cache integrity

### DIFF
--- a/metadata/decode.go
+++ b/metadata/decode.go
@@ -98,7 +98,7 @@ func (d *Decoder) DecodeBytes(bytes []byte) (payload *PayloadJSON, err error) {
 
 	if token, err = d.parser.Parse(string(bytes), func(token *jwt.Token) (any, error) {
 		// 2. If the x5u attribute is present in the JWT Header.
-		if _, ok := token.Header[HeaderX509URI].([]any); ok {
+		if _, ok := token.Header[HeaderX509URI]; ok {
 			// Never seen an x5u here, although it is in the spec.
 			return nil, errors.New("x5u encountered in header of metadata TOC payload")
 		}

--- a/metadata/decode_test.go
+++ b/metadata/decode_test.go
@@ -1,9 +1,12 @@
 package metadata
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateChainMalformed(t *testing.T) {
@@ -39,6 +42,27 @@ func TestValidateChainMalformed(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestDecodeBytesRejectsX509URIHeader(t *testing.T) {
+	decoder, err := NewDecoder()
+	require.NoError(t, err)
+
+	encode := func(v string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(v))
+	}
+
+	token := strings.Join([]string{
+		encode(`{"alg":"ES256","typ":"JWT","x5u":"https://mds.example.com/signing.pem"}`),
+		encode(`{"no":1,"nextUpdate":"2025-01-01","entries":[]}`),
+		encode("signature"),
+	}, ".")
+
+	payload, err := decoder.DecodeBytes([]byte(token))
+
+	assert.Nil(t, payload)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "x5u encountered in header of metadata TOC payload")
 }
 
 func TestValidateChainFallbackRoot(t *testing.T) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -327,8 +327,8 @@ type Statement struct {
 	// UserVerificationDetails is a list of alternative VerificationMethodANDCombinations.
 	UserVerificationDetails [][]VerificationMethodDescriptor
 
-	// KeyProtection is a 16-bit number representing the bit fields defined by the KEY_PROTECTION constants in the FIDO
-	// Registry of Predefined Values.
+	// KeyProtection is a list of KEY_PROTECTION short form case-sensitive string name constants from the FIDO Registry
+	// of Predefined Values describing the method used by the authenticator to protect the FIDO private key material.
 	KeyProtection []string
 
 	// IsKeyRestricted is set to true or it is omitted, if the Uauth private key is restricted by the authenticator to
@@ -342,20 +342,23 @@ type Statement struct {
 	// caching time ago.
 	IsFreshUserVerificationRequired bool
 
-	// MatcherProtection is a 16-bit number representing the bit fields defined by the MATCHER_PROTECTION constants in
-	// the FIDO Registry of Predefined Values.
+	// MatcherProtection is a list of MATCHER_PROTECTION short form case-sensitive string name constants from the FIDO
+	// Registry of Predefined Values describing the method used by the authenticator to protect the matcher that
+	// performs user verification.
 	MatcherProtection []string
 
 	// CryptoStrength is the authenticator's overall claimed cryptographic strength in bits (sometimes also called
 	// security strength or security level).
 	CryptoStrength uint16
 
-	// AttachmentHint is a 32-bit number representing the bit fields defined by the ATTACHMENT_HINT constants in the
-	// FIDO Registry of Predefined Values.
+	// AttachmentHint is a list of ATTACHMENT_HINT short form case-sensitive string name constants from the FIDO
+	// Registry of Predefined Values describing the method(s) by which the authenticator communicates with the FIDO
+	// user device. These values are hints and MUST NOT be relied upon for security purposes.
 	AttachmentHint []string
 
-	// TcDisplay is a 16-bit number representing a combination of the bit flags defined by the
-	// TRANSACTION_CONFIRMATION_DISPLAY constants in the FIDO Registry of Predefined Values.
+	// TcDisplay is a list of TRANSACTION_CONFIRMATION_DISPLAY short form case-sensitive string name constants from the
+	// FIDO Registry of Predefined Values describing the availability and implementation of the transaction
+	// confirmation display. This list MUST be empty if transaction confirmation is not supported.
 	TcDisplay []string
 
 	// TcDisplayContentType is the supported MIME content type [RFC2049] for the transaction confirmation display, such
@@ -490,7 +493,7 @@ type StatementJSON struct {
 	// UserVerificationDetails is a list of alternative VerificationMethodANDCombinations.
 	UserVerificationDetails [][]VerificationMethodDescriptor `json:"userVerificationDetails"`
 
-	// KeyProtection is the key protection type(s).
+	// KeyProtection is a list of KEY_PROTECTION short form case-sensitive string name constants.
 	KeyProtection []string `json:"keyProtection"`
 
 	// IsKeyRestricted indicates if the Uauth private key is restricted to only sign valid FIDO signature assertions.
@@ -499,16 +502,16 @@ type StatementJSON struct {
 	// IsFreshUserVerificationRequired indicates if Uauth key usage always requires a fresh user verification.
 	IsFreshUserVerificationRequired bool `json:"isFreshUserVerificationRequired"`
 
-	// MatcherProtection is the matcher protection type(s).
+	// MatcherProtection is a list of MATCHER_PROTECTION short form case-sensitive string name constants.
 	MatcherProtection []string `json:"matcherProtection"`
 
 	// CryptoStrength is the authenticator's overall claimed cryptographic strength in bits.
 	CryptoStrength uint16 `json:"cryptoStrength"`
 
-	// AttachmentHint is the attachment hint(s).
+	// AttachmentHint is a list of ATTACHMENT_HINT short form case-sensitive string name constants.
 	AttachmentHint []string `json:"attachmentHint"`
 
-	// TcDisplay is the transaction confirmation display type(s).
+	// TcDisplay is a list of TRANSACTION_CONFIRMATION_DISPLAY short form case-sensitive string name constants.
 	TcDisplay []string `json:"tcDisplay"`
 
 	// TcDisplayContentType is the supported MIME content type for the transaction confirmation display.
@@ -668,8 +671,8 @@ type BiometricStatusReport struct {
 	Modality string
 
 	// EffectiveDate is an ISO-8601 formatted date since when the certLevel achieved, if applicable. If no date is
-	// given, the status is assumed to be effective while present.
-	EffectiveDate time.Time
+	// given, i.e. this value is nil, the status is assumed to be effective while present.
+	EffectiveDate *time.Time
 
 	// CertificationDescriptor describes the externally visible aspects of the Biometric Certification evaluation.
 	CertificationDescriptor string
@@ -696,7 +699,8 @@ type BiometricStatusReportJSON struct {
 	// Modality is a single USER_VERIFY short form string constant representing the biometric modality.
 	Modality string `json:"modality"`
 
-	// EffectiveDate is an ISO-8601 formatted date since when the certLevel was achieved.
+	// EffectiveDate is an ISO-8601 formatted date since when the certLevel was achieved. This value is optional and
+	// when it is omitted the parsed [BiometricStatusReport.EffectiveDate] is nil.
 	EffectiveDate string `json:"effectiveDate"`
 
 	// CertificationDescriptor describes the externally visible aspects of the Biometric Certification evaluation.
@@ -713,9 +717,9 @@ type BiometricStatusReportJSON struct {
 }
 
 func (j BiometricStatusReportJSON) Parse() (report BiometricStatusReport, err error) {
-	var effective time.Time
+	var effective *time.Time
 
-	if effective, err = time.Parse(time.DateOnly, j.EffectiveDate); err != nil {
+	if effective, err = mdsParseTimePointer(time.DateOnly, j.EffectiveDate); err != nil {
 		return report, fmt.Errorf("error occurred parsing effective date value: %w", err)
 	}
 
@@ -739,8 +743,8 @@ type StatusReport struct {
 	Status AuthenticatorStatus
 
 	// EffectiveDate is an ISO-8601 formatted date since when the status code was set, if applicable. If no date is
-	// given, the status is assumed to be effective while present.
-	EffectiveDate time.Time
+	// given, i.e. this value is nil, the status is assumed to be effective while present.
+	EffectiveDate *time.Time
 
 	// AuthenticatorVersion is the authenticator version (firmware version) that this status report relates to. In the
 	// case of FIDO_CERTIFIED* status values, the status applies to higher authenticatorVersions until there is a new
@@ -797,7 +801,8 @@ type StatusReportJSON struct {
 	// Status of the authenticator. Additional fields MAY be set depending on this value.
 	Status AuthenticatorStatus `json:"status"`
 
-	// EffectiveDate is an ISO-8601 formatted date since when the status code was set.
+	// EffectiveDate is an ISO-8601 formatted date since when the status code was set. This value is optional and when
+	// it is omitted the parsed [StatusReport.EffectiveDate] is nil.
 	EffectiveDate string `json:"effectiveDate"`
 
 	// AuthenticatorVersion is the authenticator version (firmware version) that this status report relates to.
@@ -855,11 +860,10 @@ func (j StatusReportJSON) Parse() (report StatusReport, err error) {
 	}
 
 	var (
-		effective time.Time
-		sunset    *time.Time
+		effective, sunset *time.Time
 	)
 
-	if effective, err = time.Parse(time.DateOnly, j.EffectiveDate); err != nil {
+	if effective, err = mdsParseTimePointer(time.DateOnly, j.EffectiveDate); err != nil {
 		return report, fmt.Errorf("error occurred parsing effective date value: %w", err)
 	}
 

--- a/metadata/parse_test.go
+++ b/metadata/parse_test.go
@@ -130,16 +130,43 @@ func TestEntryJSON_Parse(t *testing.T) {
 				TimeOfLastStatusChange: "2025-01-01",
 			},
 		},
+		{
+			name: "ShouldSucceedWithStatusReportsWithoutEffectiveDate",
+			have: EntryJSON{
+				AaGUID:                 "0132d110-bf4e-4208-a403-ab4f5f12efe5",
+				TimeOfLastStatusChange: "2025-01-01",
+				StatusReports: []StatusReportJSON{
+					{Status: FidoCertifiedL1},
+				},
+				BiometricStatusReports: []BiometricStatusReportJSON{
+					{CertLevel: 1, Modality: "fingerprint"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.have.Parse()
+			entry, err := tc.have.Parse()
 
-			if tc.err == "" {
-				assert.NoError(t, err)
-			} else {
+			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			assert.NoError(t, err)
+
+			for i := range entry.StatusReports {
+				if len(tc.have.StatusReports[i].EffectiveDate) == 0 {
+					assert.Nil(t, entry.StatusReports[i].EffectiveDate, "status report %d", i)
+				}
+			}
+
+			for i := range entry.BiometricStatusReports {
+				if len(tc.have.BiometricStatusReports[i].EffectiveDate) == 0 {
+					assert.Nil(t, entry.BiometricStatusReports[i].EffectiveDate, "biometric status report %d", i)
+				}
 			}
 		})
 	}
@@ -240,9 +267,10 @@ func TestStatementJSON_Parse(t *testing.T) {
 
 func TestBiometricStatusReportJSON_Parse(t *testing.T) {
 	testCases := []struct {
-		name string
-		have BiometricStatusReportJSON
-		err  string
+		name     string
+		have     BiometricStatusReportJSON
+		expected *time.Time
+		err      string
 	}{
 		{
 			name: "ShouldFailInvalidEffectiveDate",
@@ -257,18 +285,30 @@ func TestBiometricStatusReportJSON_Parse(t *testing.T) {
 				EffectiveDate: "2025-01-01",
 				CertLevel:     1,
 			},
+			expected: timePtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			name: "ShouldSucceedWithoutEffectiveDate",
+			have: BiometricStatusReportJSON{
+				CertLevel: 1,
+				Modality:  "fingerprint",
+			},
+			expected: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.have.Parse()
+			report, err := tc.have.Parse()
 
-			if tc.err == "" {
-				assert.NoError(t, err)
-			} else {
+			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
+
+				return
 			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, report.EffectiveDate)
 		})
 	}
 }
@@ -327,7 +367,17 @@ func TestStatusReportJSON_Parse(t *testing.T) {
 			},
 			expected: StatusReport{
 				Status:        "",
-				EffectiveDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				EffectiveDate: timePtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+		},
+		{
+			name: "ShouldSucceedWithoutEffectiveDate",
+			have: StatusReportJSON{
+				Status: FidoCertifiedL1,
+			},
+			expected: StatusReport{
+				Status:        FidoCertifiedL1,
+				EffectiveDate: nil,
 			},
 		},
 		{
@@ -337,7 +387,7 @@ func TestStatusReportJSON_Parse(t *testing.T) {
 				SunsetDate:    "2026-06-01",
 			},
 			expected: StatusReport{
-				EffectiveDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				EffectiveDate: timePtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
 				SunsetDate:    timePtr(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
 			},
 		},
@@ -359,7 +409,7 @@ func TestStatusReportJSON_Parse(t *testing.T) {
 			},
 			expected: StatusReport{
 				Status:                           FidoCertifiedL1,
-				EffectiveDate:                    time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC),
+				EffectiveDate:                    timePtr(time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)),
 				AuthenticatorVersion:             42,
 				CertificationDescriptor:          "SecurityKey based on CC EAL 5 certified chip",
 				CertificateNumber:                "FIDO2-CERT-001",
@@ -379,7 +429,7 @@ func TestStatusReportJSON_Parse(t *testing.T) {
 				URL:           "example.com/update",
 			},
 			expected: StatusReport{
-				EffectiveDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				EffectiveDate: timePtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
 			},
 			expectedURL: "https://example.com/update",
 		},

--- a/metadata/providers/cached/provider.go
+++ b/metadata/providers/cached/provider.go
@@ -63,45 +63,54 @@ type Provider struct {
 }
 
 func (p *Provider) init() (err error) {
-	var (
-		f       *os.File
-		rc      io.ReadCloser
-		created bool
-		mds     *metadata.Metadata
-	)
+	var mds *metadata.Metadata
 
-	if f, created, err = doOpenOrCreate(p.name); err != nil {
+	if !p.force {
+		if mds, err = p.cached(); err != nil {
+			return err
+		}
+
+		if mds != nil && !p.outdated(mds) {
+			return p.setup(mds)
+		}
+	}
+
+	var data []byte
+
+	if data, err = p.get(); err != nil {
 		return err
 	}
 
-	defer f.Close()
-
-	if created || p.force {
-		if rc, err = p.get(); err != nil {
-			return err
-		}
-	} else {
-		if mds, err = p.parse(f); err != nil {
-			return err
-		}
-
-		if p.outdated(mds) {
-			if rc, err = p.get(); err != nil {
-				return err
-			}
-		}
+	if mds, err = p.parseBytes(data); err != nil {
+		return err
 	}
 
-	if rc != nil {
-		if err = doTruncateCopyAndSeekStart(f, rc); err != nil {
-			return err
-		}
-
-		if mds, err = p.parse(f); err != nil {
-			return err
-		}
+	if err = doAtomicReplace(p.name, data); err != nil {
+		return err
 	}
 
+	return p.setup(mds)
+}
+
+func (p *Provider) cached() (mds *metadata.Metadata, err error) {
+	var f *os.File
+
+	if f, err = os.Open(p.name); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	return p.parse(f)
+}
+
+func (p *Provider) setup(mds *metadata.Metadata) (err error) {
 	var provider metadata.Provider
 
 	if provider, err = p.newup(mds); err != nil {
@@ -113,10 +122,10 @@ func (p *Provider) init() (err error) {
 	return nil
 }
 
-func (p *Provider) parse(rc io.ReadCloser) (data *metadata.Metadata, err error) {
+func (p *Provider) parse(r io.Reader) (data *metadata.Metadata, err error) {
 	var payload *metadata.PayloadJSON
 
-	if payload, err = p.decoder.Decode(rc); err != nil {
+	if payload, err = p.decoder.Decode(r); err != nil {
 		return nil, err
 	}
 
@@ -127,11 +136,25 @@ func (p *Provider) parse(rc io.ReadCloser) (data *metadata.Metadata, err error) 
 	return data, nil
 }
 
+func (p *Provider) parseBytes(data []byte) (mds *metadata.Metadata, err error) {
+	var payload *metadata.PayloadJSON
+
+	if payload, err = p.decoder.DecodeBytes(data); err != nil {
+		return nil, err
+	}
+
+	if mds, err = p.decoder.Parse(payload); err != nil {
+		return nil, err
+	}
+
+	return mds, nil
+}
+
 func (p *Provider) outdated(mds *metadata.Metadata) bool {
 	return p.update && p.clock.Now().After(mds.Parsed.NextUpdate)
 }
 
-func (p *Provider) get() (f io.ReadCloser, err error) {
+func (p *Provider) get() (data []byte, err error) {
 	if p.client == nil {
 		p.client = &http.Client{}
 	}
@@ -142,5 +165,17 @@ func (p *Provider) get() (f io.ReadCloser, err error) {
 		return nil, err
 	}
 
-	return res.Body, nil
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error occurred requesting metadata from '%s': unexpected status code %d", p.uri, res.StatusCode)
+	}
+
+	if data, err = io.ReadAll(res.Body); err != nil {
+		return nil, fmt.Errorf("error occurred reading metadata response body from '%s': %w", p.uri, err)
+	}
+
+	return data, nil
 }

--- a/metadata/providers/cached/provider_test.go
+++ b/metadata/providers/cached/provider_test.go
@@ -2,6 +2,9 @@ package cached
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -161,4 +164,70 @@ func TestWithNew(t *testing.T) {
 	_, _ = p.newup(nil)
 
 	assert.True(t, called)
+}
+
+func TestProviderDoesNotPoisonCache(t *testing.T) {
+	const sentinel = "cached blob that must survive a failed refresh"
+
+	testCases := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "ShouldRejectServerError",
+			status:  http.StatusServiceUnavailable,
+			body:    "<html>503 Service Unavailable</html>",
+			wantErr: "unexpected status code 503",
+		},
+		{
+			name:    "ShouldRejectNotFound",
+			status:  http.StatusNotFound,
+			body:    "not found",
+			wantErr: "unexpected status code 404",
+		},
+		{
+			// A 200 response is not enough: the body must decode and parse before it is allowed to replace the cache.
+			name:    "ShouldRejectUnparseableBody",
+			status:  http.StatusOK,
+			body:    "this is not a jwt",
+			wantErr: "token is malformed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			t.Run("ShouldPreserveExistingCache", func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "mds.jwt")
+				require.NoError(t, os.WriteFile(path, []byte(sentinel), 0600))
+
+				// Force skips reading the existing cache and goes straight to the download.
+				_, err := New(WithPath(path), WithMetadataURL(srv.URL), WithForceUpdate(true))
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErr)
+
+				content, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Equal(t, sentinel, string(content), "a failed refresh must not overwrite the cached blob")
+			})
+
+			t.Run("ShouldNotLeaveCacheFileBehind", func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "mds.jwt")
+
+				_, err := New(WithPath(path), WithMetadataURL(srv.URL))
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErr)
+
+				_, err = os.Stat(path)
+				assert.True(t, os.IsNotExist(err), "a cache file we created but never populated must be removed, otherwise it fails to parse on every subsequent run")
+			})
+		})
+	}
 }

--- a/metadata/providers/cached/util.go
+++ b/metadata/providers/cached/util.go
@@ -1,43 +1,49 @@
 package cached
 
 import (
-	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/go-webauthn/webauthn/metadata"
 	"github.com/go-webauthn/webauthn/metadata/providers/memory"
 )
 
-func doTruncateCopyAndSeekStart(f *os.File, rc io.ReadCloser) (err error) {
-	if err = f.Truncate(0); err != nil {
+// doAtomicReplace writes the data to a temporary file in the same directory as the cache before atomically replacing
+// it. The existing cache is never truncated or otherwise modified until the replacement has been written and synced in
+// full, so neither a partial write nor a failure part way through can leave a corrupt blob behind. The temporary file
+// is removed if any step fails.
+func doAtomicReplace(name string, data []byte) (err error) {
+	var f *os.File
+
+	if f, err = os.CreateTemp(filepath.Dir(name), filepath.Base(name)+".tmp*"); err != nil {
 		return err
 	}
 
-	if _, err = io.Copy(f, rc); err != nil {
-		return err
-	}
+	tmp := f.Name()
 
-	if _, err = f.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
-
-	return rc.Close()
-}
-
-func doOpenOrCreate(name string) (f *os.File, created bool, err error) {
-	if f, err = os.OpenFile(name, os.O_RDWR, 0); err == nil {
-		return f, false, nil
-	}
-
-	if os.IsNotExist(err) {
-		if f, err = os.Create(name); err != nil {
-			return nil, false, err
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp)
 		}
+	}()
 
-		return f, true, nil
+	if _, err = f.Write(data); err != nil {
+		_ = f.Close()
+
+		return err
 	}
 
-	return nil, false, err
+	if err = f.Sync(); err != nil {
+		_ = f.Close()
+
+		return err
+	}
+
+	if err = f.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp, name)
 }
 
 func defaultNew(mds *metadata.Metadata) (provider metadata.Provider, err error) {

--- a/metadata/providers/cached/util_test.go
+++ b/metadata/providers/cached/util_test.go
@@ -1,8 +1,6 @@
 package cached
 
 import (
-	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,121 +13,59 @@ import (
 	"github.com/go-webauthn/webauthn/metadata"
 )
 
-func TestDoOpenOrCreate(t *testing.T) {
-	testCases := []struct {
-		name            string
-		setup           func(t *testing.T) string
-		expectedCreated bool
-		err             string
-	}{
-		{
-			name: "ShouldCreateNewFile",
-			setup: func(t *testing.T) string {
-				t.Helper()
+func TestDoAtomicReplace(t *testing.T) {
+	const original = "the cached blob that was already in place"
 
-				return filepath.Join(t.TempDir(), "new-file.json")
-			},
-			expectedCreated: true,
-		},
-		{
-			name: "ShouldOpenExistingFile",
-			setup: func(t *testing.T) string {
-				t.Helper()
+	t.Run("ShouldReplaceExistingCache", func(t *testing.T) {
+		dir := t.TempDir()
+		name := filepath.Join(dir, "mds.jwt")
 
-				path := filepath.Join(t.TempDir(), "existing-file.json")
+		require.NoError(t, os.WriteFile(name, []byte(original), 0600))
+		require.NoError(t, doAtomicReplace(name, []byte("the replacement blob")))
 
-				f, err := os.Create(path)
-				require.NoError(t, err)
-				require.NoError(t, f.Close())
+		content, err := os.ReadFile(name)
+		require.NoError(t, err)
+		assert.Equal(t, "the replacement blob", string(content))
 
-				return path
-			},
-			expectedCreated: false,
-		},
-		{
-			name: "ShouldFailInvalidPath",
-			setup: func(t *testing.T) string {
-				t.Helper()
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1, "the temporary file must not be left behind")
+	})
 
-				return filepath.Join(t.TempDir(), "nonexistent-dir", "subdir", "file.json")
-			},
-			err: "no such file or directory",
-		},
-	}
+	t.Run("ShouldCreateCacheWhenAbsent", func(t *testing.T) {
+		dir := t.TempDir()
+		name := filepath.Join(dir, "mds.jwt")
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			path := tc.setup(t)
+		require.NoError(t, doAtomicReplace(name, []byte("the first blob")))
 
-			f, created, err := doOpenOrCreate(path)
+		content, err := os.ReadFile(name)
+		require.NoError(t, err)
+		assert.Equal(t, "the first blob", string(content))
+	})
 
-			if tc.err != "" {
-				assert.Nil(t, f)
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.err)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, f)
-				assert.Equal(t, tc.expectedCreated, created)
+	t.Run("ShouldLeaveOriginalIntactWhenReplacementFails", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("the read only directory used to force the failure is not enforced for the root user")
+		}
 
-				require.NoError(t, f.Close())
-			}
+		dir := t.TempDir()
+		name := filepath.Join(dir, "mds.jwt")
+
+		require.NoError(t, os.WriteFile(name, []byte(original), 0600))
+
+		// Deny creation of the temporary file so the replacement cannot be written.
+		require.NoError(t, os.Chmod(dir, 0500))
+
+		t.Cleanup(func() {
+			_ = os.Chmod(dir, 0700)
 		})
-	}
-}
 
-func TestDoTruncateCopyAndSeekStart(t *testing.T) {
-	testCases := []struct {
-		name            string
-		initialContent  string
-		copyContent     string
-		expectedContent string
-		err             string
-	}{
-		{
-			name:            "ShouldTruncateAndCopy",
-			initialContent:  "old content that should be replaced",
-			copyContent:     "new data",
-			expectedContent: "new data",
-		},
-		{
-			name:            "ShouldHandleEmptyInitialContent",
-			initialContent:  "",
-			copyContent:     "fresh content",
-			expectedContent: "fresh content",
-		},
-	}
+		require.Error(t, doAtomicReplace(name, []byte("the replacement blob")))
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "test-file.json")
-
-			f, err := os.Create(path)
-			require.NoError(t, err)
-
-			_, err = f.WriteString(tc.initialContent)
-			require.NoError(t, err)
-
-			_, err = f.Seek(0, io.SeekStart)
-			require.NoError(t, err)
-
-			rc := io.NopCloser(bytes.NewReader([]byte(tc.copyContent)))
-
-			err = doTruncateCopyAndSeekStart(f, rc)
-
-			if tc.err != "" {
-				assert.EqualError(t, err, tc.err)
-			} else {
-				require.NoError(t, err)
-
-				content, err := io.ReadAll(f)
-				require.NoError(t, err)
-				assert.Equal(t, tc.expectedContent, string(content))
-			}
-
-			require.NoError(t, f.Close())
-		})
-	}
+		content, err := os.ReadFile(name)
+		require.NoError(t, err)
+		assert.Equal(t, original, string(content), "a failed replacement must not modify the cached blob")
+	})
 }
 
 func TestDefaultNew(t *testing.T) {


### PR DESCRIPTION
The effectiveDate of a status or biometric status report is optional, but it was parsed as required, which discarded the whole entry it belonged to. It is now a nillable value, matching sunsetDate.

The cached provider treated any HTTP response as a blob and wrote it to the cache before checking it, so an outage could replace a working blob with an error page. It also wrote at a file offset left at EOF by the preceding read, which corrupted every refresh. Responses are now validated before the cache is touched at all, and are put in place by an atomic rename, so the existing blob survives anything short of a complete replacement.

The x5u header is a string URI rather than an array per RFC7515 Section 4.1.5, so the check for it never matched. Several metadata statement comments also still described the MDS2 bit fields rather than the MDS3 string constants.

BREAKING CHANGE: StatusReport.EffectiveDate and BiometricStatusReport.EffectiveDate are now *time.Time so an absent date is distinguishable from a zero value.