### PR TITLE
fix(metadata): honour status report order and effective dates

### DIFF
--- a/metadata/providers/memory/provider_test.go
+++ b/metadata/providers/memory/provider_test.go
@@ -207,7 +207,19 @@ func TestProvider_ValidateStatusReports(t *testing.T) {
 				WithStatusUndesired(nil),
 			},
 			reports: []metadata.StatusReport{{Status: metadata.NotFidoCertified}},
-			err:     "The following desired status reports were absent: FIDO_CERTIFIED",
+			err:     "the current status report 'NOT_FIDO_CERTIFIED' was not one of the desired statuses: FIDO_CERTIFIED",
+		},
+		{
+			// The desired status must be the current one rather than merely present in the history.
+			name: "ShouldFailWithDesiredStatusSuperseded",
+			opts: []Option{
+				WithMetadata(map[uuid.UUID]*metadata.Entry{}),
+				WithValidateStatus(true),
+				WithStatusDesired([]metadata.AuthenticatorStatus{metadata.FidoCertifiedL2}),
+				WithStatusUndesired(nil),
+			},
+			reports: []metadata.StatusReport{{Status: metadata.FidoCertifiedL2}, {Status: metadata.Revoked}},
+			err:     "the current status report 'REVOKED' was not one of the desired statuses: FIDO_CERTIFIED_L2",
 		},
 	}
 

--- a/metadata/status.go
+++ b/metadata/status.go
@@ -3,62 +3,175 @@ package metadata
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
-// ValidateStatusReports checks a list of [StatusReport] structs against a list of desired and undesired [AuthenticatorStatus]
-// values. If the reports contain all of the desired and none of the undesired status reports then no error is returned
-// otherwise an error describing the issue is returned.
+// InEffectAt returns true if this [StatusReport] is in effect at the given time.
 //
-//nolint:gocyclo
+// A report which has an effective date in the future has not come into effect yet, and a report which has reached its
+// sunset date has expired. An absent effective date means the report is in effect while present, and an absent sunset
+// date means it has no scheduled expiry.
+//
+// See: https://fidoalliance.org/specs/mds/fido-metadata-service-v3.1.1-rd-20251016.html#sctn-stat-rep
+func (r StatusReport) InEffectAt(at time.Time) bool {
+	if r.EffectiveDate != nil && r.EffectiveDate.After(at) {
+		return false
+	}
+
+	if r.SunsetDate != nil && !r.SunsetDate.After(at) {
+		return false
+	}
+
+	return true
+}
+
+// EffectiveStatusReports returns the subset of the given [StatusReport] values which are in effect at the given time,
+// preserving their original order. See [StatusReport.InEffectAt] for the rules applied.
+func EffectiveStatusReports(reports []StatusReport, at time.Time) (effective []StatusReport) {
+	for _, report := range reports {
+		if report.InEffectAt(at) {
+			effective = append(effective, report)
+		}
+	}
+
+	return effective
+}
+
+// CurrentStatusReportAt returns the [StatusReport] which reflects the current status of the authenticator at the given
+// time, or nil if no report is in effect. See [currentStatusReport] for how the current report is selected.
+func CurrentStatusReportAt(reports []StatusReport, at time.Time) (current *StatusReport) {
+	return currentStatusReport(EffectiveStatusReports(reports, at))
+}
+
+// currentStatusReport returns the report reflecting the current status from a set of reports already known to be in
+// effect, or nil if there are none.
+//
+// MDS3 requires that the latest entry reflects the current status, so the last element wins by default. Where both
+// candidates carry an effective date that date is preferred over the document order, which keeps the selection correct
+// for a blob whose reports are not listed oldest first. Ties resolve to the later element.
+func currentStatusReport(effective []StatusReport) (current *StatusReport) {
+	for i := range effective {
+		report := &effective[i]
+
+		if current == nil || current.EffectiveDate == nil || report.EffectiveDate == nil {
+			current = report
+
+			continue
+		}
+
+		if !report.EffectiveDate.Before(*current.EffectiveDate) {
+			current = report
+		}
+	}
+
+	return current
+}
+
+// ValidateStatusReports checks a list of [StatusReport] structs against a list of desired and undesired
+// [AuthenticatorStatus] values as at the current time. See [ValidateStatusReportsAt] for the validation performed.
 func ValidateStatusReports(reports []StatusReport, desired, undesired []AuthenticatorStatus) (err error) {
-	if len(desired) == 0 && (len(undesired) == 0 || len(reports) == 0) {
+	return ValidateStatusReportsAt(reports, desired, undesired, time.Now())
+}
+
+// ValidateStatusReportsAt checks a list of [StatusReport] structs against a list of desired and undesired
+// [AuthenticatorStatus] values as at the given time. If the reports satisfy the desired statuses and contain none of
+// the undesired statuses then no error is returned, otherwise an error describing the issue is returned.
+//
+// Reports which are not in effect at the given time are excluded from consideration entirely, i.e. those with an
+// effective date in the future and those which have reached their sunset date.
+//
+// The desired statuses are matched against the current status only, and are treated as a set of acceptable statuses of
+// which one must match. MDS3 requires that the latest report reflects the current status, so an authenticator formerly
+// certified at some level but since revoked does not satisfy a desired status naming that certification level.
+//
+// The undesired statuses are matched against every report in effect rather than the current one alone. Statuses such as
+// [AttestationKeyCompromise] and [UserKeyPhysicalCompromise] describe a weakness discovered in the authenticator model
+// which a later report does not retract; the sunset date honored above is the mechanism by which such a report stops
+// applying.
+//
+// Note that a compromise reported against a specific attestation certificate, i.e. where [StatusReport.Certificate] or
+// [StatusReport.BatchCertificate] is set, applies only to that batch of authenticators. This function has no visibility
+// of the attestation statement being validated, so it conservatively treats such a report as applying to every
+// authenticator of the model.
+func ValidateStatusReportsAt(reports []StatusReport, desired, undesired []AuthenticatorStatus, at time.Time) (err error) {
+	if len(desired) == 0 && len(undesired) == 0 {
 		return nil
 	}
 
-	var present, absent []string
+	effective := EffectiveStatusReports(reports, at)
+
+	var present []string
 
 	if len(undesired) != 0 {
-		for _, report := range reports {
-			for _, status := range undesired {
-				if report.Status == status {
-					present = append(present, string(status))
+		seen := make(map[AuthenticatorStatus]struct{}, len(undesired))
 
-					continue
-				}
+		for _, report := range effective {
+			if _, ok := seen[report.Status]; ok {
+				continue
+			}
+
+			if hasStatus(report.Status, undesired) {
+				seen[report.Status] = struct{}{}
+
+				present = append(present, string(report.Status))
 			}
 		}
 	}
 
-	if len(desired) != 0 {
-	desired:
-		for _, status := range desired {
-			for _, report := range reports {
-				if report.Status == status {
-					continue desired
-				}
-			}
+	var (
+		current     *StatusReport
+		unsatisfied bool
+	)
 
-			absent = append(absent, string(status))
-		}
+	if len(desired) != 0 {
+		current = currentStatusReport(effective)
+
+		unsatisfied = current == nil || !hasStatus(current.Status, desired)
 	}
 
 	switch {
-	case len(present) == 0 && len(absent) == 0:
+	case len(present) == 0 && !unsatisfied:
 		return nil
-	case len(present) != 0 && len(absent) == 0:
+	case len(present) != 0 && !unsatisfied:
 		return &Error{
 			Type:    "invalid_status",
 			Details: fmt.Sprintf("The following undesired status reports were present: %s", strings.Join(present, ", ")),
 		}
-	case len(present) == 0 && len(absent) != 0:
+	case len(present) == 0:
 		return &Error{
 			Type:    "invalid_status",
-			Details: fmt.Sprintf("The following desired status reports were absent: %s", strings.Join(absent, ", ")),
+			Details: describeDesiredUnsatisfied(current, desired),
 		}
 	default:
 		return &Error{
 			Type:    "invalid_status",
-			Details: fmt.Sprintf("The following undesired status reports were present: %s; the following desired status reports were absent: %s", strings.Join(present, ", "), strings.Join(absent, ", ")),
+			Details: fmt.Sprintf("The following undesired status reports were present: %s; %s", strings.Join(present, ", "), describeDesiredUnsatisfied(current, desired)),
 		}
 	}
+}
+
+// hasStatus returns true if the given status is a member of the given values.
+func hasStatus(status AuthenticatorStatus, values []AuthenticatorStatus) bool {
+	for _, value := range values {
+		if value == status {
+			return true
+		}
+	}
+
+	return false
+}
+
+// describeDesiredUnsatisfied renders the reason the desired statuses were not satisfied by the current status report.
+func describeDesiredUnsatisfied(current *StatusReport, desired []AuthenticatorStatus) string {
+	statuses := make([]string, len(desired))
+
+	for i, status := range desired {
+		statuses[i] = string(status)
+	}
+
+	if current == nil {
+		return fmt.Sprintf("no status report was in effect so none of the desired statuses could be satisfied: %s", strings.Join(statuses, ", "))
+	}
+
+	return fmt.Sprintf("the current status report '%s' was not one of the desired statuses: %s", current.Status, strings.Join(statuses, ", "))
 }

--- a/metadata/status_test.go
+++ b/metadata/status_test.go
@@ -2,12 +2,23 @@ package metadata
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateStatusReports(t *testing.T) {
+// now is the reference point used by the status report tests. Reports are placed relative to it so that the effective
+// and sunset date handling is exercised deterministically.
+var now = time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+func date(y int, m time.Month, d int) *time.Time {
+	v := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+
+	return &v
+}
+
+func TestValidateStatusReportsAt(t *testing.T) {
 	testCases := []struct {
 		name      string
 		reports   []StatusReport
@@ -28,11 +39,6 @@ func TestValidateStatusReports(t *testing.T) {
 			undesired: []AuthenticatorStatus{Revoked},
 		},
 		{
-			name:    "ShouldReturnNilWhenAllDesiredPresent",
-			reports: []StatusReport{{Status: FidoCertified}, {Status: FidoCertifiedL1}},
-			desired: []AuthenticatorStatus{FidoCertified},
-		},
-		{
 			name:      "ShouldReturnNilWhenNoUndesiredPresent",
 			reports:   []StatusReport{{Status: FidoCertified}},
 			desired:   []AuthenticatorStatus{FidoCertified},
@@ -46,36 +52,107 @@ func TestValidateStatusReports(t *testing.T) {
 			err:       "The following undesired status reports were present: REVOKED",
 		},
 		{
-			name:    "ShouldFailWhenDesiredAbsent",
-			reports: []StatusReport{{Status: NotFidoCertified}},
-			desired: []AuthenticatorStatus{FidoCertified},
-			err:     "The following desired status reports were absent: FIDO_CERTIFIED",
-		},
-		{
-			name:      "ShouldFailWhenBothUndesiredPresentAndDesiredAbsent",
-			reports:   []StatusReport{{Status: Revoked}},
-			desired:   []AuthenticatorStatus{FidoCertified},
-			undesired: []AuthenticatorStatus{Revoked},
-			err:       "The following undesired status reports were present: REVOKED; the following desired status reports were absent: FIDO_CERTIFIED",
-		},
-		{
-			name:      "ShouldReturnNilWithMultipleDesiredAllPresent",
-			reports:   []StatusReport{{Status: FidoCertified}, {Status: FidoCertifiedL1}},
-			desired:   []AuthenticatorStatus{FidoCertified, FidoCertifiedL1},
-			undesired: []AuthenticatorStatus{Revoked},
-		},
-		{
 			name:      "ShouldFailWithMultipleUndesiredPresent",
 			reports:   []StatusReport{{Status: Revoked}, {Status: AttestationKeyCompromise}},
 			desired:   nil,
 			undesired: []AuthenticatorStatus{Revoked, AttestationKeyCompromise},
 			err:       "The following undesired status reports were present: REVOKED, ATTESTATION_KEY_COMPROMISE",
 		},
+		{
+			name:      "ShouldNotRepeatDuplicateUndesiredStatuses",
+			reports:   []StatusReport{{Status: Revoked}, {Status: Revoked}},
+			undesired: []AuthenticatorStatus{Revoked},
+			err:       "The following undesired status reports were present: REVOKED",
+		},
+
+		// The desired statuses are a set of acceptable current statuses.
+		{
+			name:    "ShouldAcceptCurrentStatusAmongDesired",
+			reports: []StatusReport{{Status: FidoCertified}, {Status: FidoCertifiedL1}},
+			desired: []AuthenticatorStatus{FidoCertified, FidoCertifiedL1},
+		},
+		{
+			// The authenticator held FIDO_CERTIFIED historically but the current status is FIDO_CERTIFIED_L1.
+			name:    "ShouldRejectSupersededDesiredStatus",
+			reports: []StatusReport{{Status: FidoCertified}, {Status: FidoCertifiedL1}},
+			desired: []AuthenticatorStatus{FidoCertified},
+			err:     "the current status report 'FIDO_CERTIFIED_L1' was not one of the desired statuses: FIDO_CERTIFIED",
+		},
+		{
+			// A revoked authenticator must not satisfy a desired status naming a certification it formerly held.
+			name:    "ShouldRejectRevokedDespiteFormerCertification",
+			reports: []StatusReport{{Status: FidoCertifiedL2}, {Status: Revoked}},
+			desired: []AuthenticatorStatus{FidoCertifiedL2},
+			err:     "the current status report 'REVOKED' was not one of the desired statuses: FIDO_CERTIFIED_L2",
+		},
+		{
+			name:    "ShouldFailWhenDesiredAbsent",
+			reports: []StatusReport{{Status: NotFidoCertified}},
+			desired: []AuthenticatorStatus{FidoCertified},
+			err:     "the current status report 'NOT_FIDO_CERTIFIED' was not one of the desired statuses: FIDO_CERTIFIED",
+		},
+		{
+			name:      "ShouldFailWhenBothUndesiredPresentAndDesiredUnsatisfied",
+			reports:   []StatusReport{{Status: Revoked}},
+			desired:   []AuthenticatorStatus{FidoCertified},
+			undesired: []AuthenticatorStatus{Revoked},
+			err:       "The following undesired status reports were present: REVOKED; the current status report 'REVOKED' was not one of the desired statuses: FIDO_CERTIFIED",
+		},
+		{
+			name:    "ShouldFailWhenNoReportsAtAll",
+			reports: nil,
+			desired: []AuthenticatorStatus{FidoCertifiedL1},
+			err:     "no status report was in effect so none of the desired statuses could be satisfied: FIDO_CERTIFIED_L1",
+		},
+
+		// Reports which are not in effect are excluded entirely.
+		{
+			name:      "ShouldIgnoreUndesiredReportPastItsSunsetDate",
+			reports:   []StatusReport{{Status: UserVerificationBypass, SunsetDate: date(2025, 1, 1)}, {Status: FidoCertifiedL2}},
+			undesired: []AuthenticatorStatus{UserVerificationBypass},
+		},
+		{
+			name:      "ShouldHonourUndesiredReportBeforeItsSunsetDate",
+			reports:   []StatusReport{{Status: UserVerificationBypass, SunsetDate: date(2025, 12, 1)}},
+			undesired: []AuthenticatorStatus{UserVerificationBypass},
+			err:       "The following undesired status reports were present: USER_VERIFICATION_BYPASS",
+		},
+		{
+			name:      "ShouldIgnoreUndesiredReportNotYetEffective",
+			reports:   []StatusReport{{Status: FidoCertifiedL2}, {Status: Revoked, EffectiveDate: date(2025, 12, 1)}},
+			undesired: []AuthenticatorStatus{Revoked},
+		},
+		{
+			name:      "ShouldHonourUndesiredReportAlreadyEffective",
+			reports:   []StatusReport{{Status: FidoCertifiedL2}, {Status: Revoked, EffectiveDate: date(2025, 1, 1)}},
+			undesired: []AuthenticatorStatus{Revoked},
+			err:       "The following undesired status reports were present: REVOKED",
+		},
+		{
+			// The pending revocation is not in effect so the certification remains current.
+			name:    "ShouldUseLatestEffectiveReportAsCurrent",
+			reports: []StatusReport{{Status: FidoCertifiedL2}, {Status: Revoked, EffectiveDate: date(2025, 12, 1)}},
+			desired: []AuthenticatorStatus{FidoCertifiedL2},
+		},
+		{
+			name:    "ShouldFailWhenEveryReportHasSunset",
+			reports: []StatusReport{{Status: FidoCertifiedL2, SunsetDate: date(2025, 1, 1)}},
+			desired: []AuthenticatorStatus{FidoCertifiedL2},
+			err:     "no status report was in effect so none of the desired statuses could be satisfied: FIDO_CERTIFIED_L2",
+		},
+		{
+			// Effective dates take precedence over document order so a blob which does not list reports oldest first
+			// still resolves the correct current status.
+			name:    "ShouldPreferEffectiveDateOverDocumentOrder",
+			reports: []StatusReport{{Status: Revoked, EffectiveDate: date(2025, 3, 1)}, {Status: FidoCertifiedL2, EffectiveDate: date(2020, 1, 1)}},
+			desired: []AuthenticatorStatus{FidoCertifiedL2},
+			err:     "the current status report 'REVOKED' was not one of the desired statuses: FIDO_CERTIFIED_L2",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateStatusReports(tc.reports, tc.desired, tc.undesired)
+			err := ValidateStatusReportsAt(tc.reports, tc.desired, tc.undesired, now)
 
 			if tc.err != "" {
 				require.Error(t, err)
@@ -85,4 +162,147 @@ func TestValidateStatusReports(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateStatusReportsUsesCurrentTime(t *testing.T) {
+	// The exported wrapper must apply the same effective and sunset date handling relative to the current time.
+	reports := []StatusReport{
+		{Status: Revoked, SunsetDate: date(2020, 1, 1)},
+		{Status: FidoCertifiedL2},
+	}
+
+	assert.NoError(t, ValidateStatusReports(reports, []AuthenticatorStatus{FidoCertifiedL2}, DefaultUndesiredAuthenticatorStatuses()))
+
+	pending := []StatusReport{
+		{Status: FidoCertifiedL2},
+		{Status: Revoked, EffectiveDate: date(2999, 1, 1)},
+	}
+
+	assert.NoError(t, ValidateStatusReports(pending, nil, DefaultUndesiredAuthenticatorStatuses()))
+}
+
+func TestStatusReportInEffectAt(t *testing.T) {
+	testCases := []struct {
+		name     string
+		report   StatusReport
+		expected bool
+	}{
+		{
+			name:     "ShouldBeInEffectWithoutDates",
+			report:   StatusReport{Status: FidoCertifiedL1},
+			expected: true,
+		},
+		{
+			name:     "ShouldBeInEffectAfterEffectiveDate",
+			report:   StatusReport{EffectiveDate: date(2025, 1, 1)},
+			expected: true,
+		},
+		{
+			name:     "ShouldBeInEffectOnEffectiveDate",
+			report:   StatusReport{EffectiveDate: date(2025, 6, 1)},
+			expected: true,
+		},
+		{
+			name:     "ShouldNotBeInEffectBeforeEffectiveDate",
+			report:   StatusReport{EffectiveDate: date(2025, 6, 2)},
+			expected: false,
+		},
+		{
+			name:     "ShouldNotBeInEffectOnSunsetDate",
+			report:   StatusReport{SunsetDate: date(2025, 6, 1)},
+			expected: false,
+		},
+		{
+			name:     "ShouldNotBeInEffectAfterSunsetDate",
+			report:   StatusReport{SunsetDate: date(2025, 5, 1)},
+			expected: false,
+		},
+		{
+			name:     "ShouldBeInEffectBeforeSunsetDate",
+			report:   StatusReport{SunsetDate: date(2025, 6, 2)},
+			expected: true,
+		},
+		{
+			name:     "ShouldBeInEffectWithinWindow",
+			report:   StatusReport{EffectiveDate: date(2025, 1, 1), SunsetDate: date(2025, 12, 1)},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.report.InEffectAt(now))
+		})
+	}
+}
+
+func TestCurrentStatusReportAt(t *testing.T) {
+	testCases := []struct {
+		name     string
+		reports  []StatusReport
+		expected *AuthenticatorStatus
+	}{
+		{
+			name:     "ShouldReturnNilForNoReports",
+			reports:  nil,
+			expected: nil,
+		},
+		{
+			name:     "ShouldReturnNilWhenAllReportsExcluded",
+			reports:  []StatusReport{{Status: FidoCertifiedL1, SunsetDate: date(2025, 1, 1)}},
+			expected: nil,
+		},
+		{
+			name:     "ShouldReturnLastReportInDocumentOrder",
+			reports:  []StatusReport{{Status: NotFidoCertified}, {Status: FidoCertifiedL1}},
+			expected: statusPtr(FidoCertifiedL1),
+		},
+		{
+			name:     "ShouldPreferGreatestEffectiveDate",
+			reports:  []StatusReport{{Status: FidoCertifiedL2, EffectiveDate: date(2025, 3, 1)}, {Status: NotFidoCertified, EffectiveDate: date(2019, 1, 1)}},
+			expected: statusPtr(FidoCertifiedL2),
+		},
+		{
+			name:     "ShouldResolveTiesToTheLaterReport",
+			reports:  []StatusReport{{Status: NotFidoCertified, EffectiveDate: date(2025, 3, 1)}, {Status: FidoCertifiedL2, EffectiveDate: date(2025, 3, 1)}},
+			expected: statusPtr(FidoCertifiedL2),
+		},
+		{
+			name:     "ShouldSkipReportsNotYetEffective",
+			reports:  []StatusReport{{Status: FidoCertifiedL2}, {Status: Revoked, EffectiveDate: date(2025, 12, 1)}},
+			expected: statusPtr(FidoCertifiedL2),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			current := CurrentStatusReportAt(tc.reports, now)
+
+			if tc.expected == nil {
+				assert.Nil(t, current)
+			} else {
+				require.NotNil(t, current)
+				assert.Equal(t, *tc.expected, current.Status)
+			}
+		})
+	}
+}
+
+func TestEffectiveStatusReports(t *testing.T) {
+	reports := []StatusReport{
+		{Status: NotFidoCertified},
+		{Status: UserVerificationBypass, SunsetDate: date(2025, 1, 1)},
+		{Status: FidoCertifiedL1, EffectiveDate: date(2025, 1, 1)},
+		{Status: Revoked, EffectiveDate: date(2025, 12, 1)},
+	}
+
+	effective := EffectiveStatusReports(reports, now)
+
+	require.Len(t, effective, 2)
+	assert.Equal(t, NotFidoCertified, effective[0].Status)
+	assert.Equal(t, FidoCertifiedL1, effective[1].Status)
+}
+
+func statusPtr(status AuthenticatorStatus) *AuthenticatorStatus {
+	return &status
 }

--- a/metadata/types.go
+++ b/metadata/types.go
@@ -219,24 +219,12 @@ var defaultUndesiredAuthenticatorStatus = [...]AuthenticatorStatus{
 
 // IsUndesiredAuthenticatorStatus returns whether the supplied authenticator status is desirable or not.
 func IsUndesiredAuthenticatorStatus(status AuthenticatorStatus) bool {
-	for _, s := range defaultUndesiredAuthenticatorStatus {
-		if s == status {
-			return true
-		}
-	}
-
-	return false
+	return hasStatus(status, defaultUndesiredAuthenticatorStatus[:])
 }
 
 // IsUndesiredAuthenticatorStatusSlice returns whether the supplied authenticator status is desirable or not.
 func IsUndesiredAuthenticatorStatusSlice(status AuthenticatorStatus, values []AuthenticatorStatus) bool {
-	for _, s := range values {
-		if s == status {
-			return true
-		}
-	}
-
-	return false
+	return hasStatus(status, values)
 }
 
 // IsUndesiredAuthenticatorStatusMap returns whether the supplied authenticator status is desirable or not.


### PR DESCRIPTION
Status reports are a history rather than a set. Desired statuses are now matched against the current status only, so an authenticator which is presently revoked no longer satisfies a certification level it held previously. Undesired statuses remain matched against every report in effect as a compromise is not retracted by a later report.

The effectiveDate and sunsetDate values are now honoured, excluding reports which have not come into effect and those which have expired.

BREAKING CHANGE: the desired statuses given to ValidateStatusReports are now a set of acceptable current statuses rather than a set which must all appear somewhere in the report history.