### PR TITLE
fix(metadata): handle certificate chains of any depth

### DIFF
--- a/metadata/decode.go
+++ b/metadata/decode.go
@@ -206,24 +206,21 @@ func validateChain(root string, chain []any) (bool, error) {
 		return true, nil
 	}
 
-	leaf, ok := chain[0].(string)
-	if !ok {
-		return false, errInvalidCertificateChain
+	// The chain is the signing certificate followed by every intermediate between it and the trust anchor. Each entry
+	// is type checked before any of them are decoded so that a malformed chain is reported as such rather than as a
+	// decoding failure of whichever entry happened to be handled first.
+	encoded := make([]string, len(chain))
+
+	for i, entry := range chain {
+		value, ok := entry.(string)
+		if !ok {
+			return false, errInvalidCertificateChain
+		}
+
+		encoded[i] = value
 	}
 
-	intermediate, ok := chain[1].(string)
-	if !ok {
-		return false, errInvalidCertificateChain
-	}
-
-	oRoot := make([]byte, base64.StdEncoding.DecodedLen(len(root)))
-
-	nRoot, err := base64.StdEncoding.Decode(oRoot, []byte(root))
-	if err != nil {
-		return false, err
-	}
-
-	rootcert, err := x509.ParseCertificate(oRoot[:nRoot])
+	rootcert, err := mdsParseX509Certificate(root)
 	if err != nil {
 		return false, err
 	}
@@ -232,39 +229,29 @@ func validateChain(root string, chain []any) (bool, error) {
 
 	roots.AddCert(rootcert)
 
-	o := make([]byte, base64.StdEncoding.DecodedLen(len(intermediate)))
-
-	n, err := base64.StdEncoding.Decode(o, []byte(intermediate))
-	if err != nil {
-		return false, err
-	}
-
-	intcert, err := x509.ParseCertificate(o[:n])
-	if err != nil {
-		return false, err
-	}
-
-	if revoked, ok := revoke.VerifyCertificate(intcert); !ok {
-		issuer := intcert.IssuingCertificateURL
-
-		if issuer != nil {
-			return false, errCRLUnavailable
-		}
-	} else if revoked {
-		return false, errIntermediateCertRevoked
-	}
-
 	ints := x509.NewCertPool()
-	ints.AddCert(intcert)
 
-	l := make([]byte, base64.StdEncoding.DecodedLen(len(leaf)))
+	for _, value := range encoded[1:] {
+		var intcert *x509.Certificate
 
-	n, err = base64.StdEncoding.Decode(l, []byte(leaf))
-	if err != nil {
-		return false, err
+		if intcert, err = mdsParseX509Certificate(value); err != nil {
+			return false, err
+		}
+
+		if revoked, ok := revoke.VerifyCertificate(intcert); !ok {
+			issuer := intcert.IssuingCertificateURL
+
+			if issuer != nil {
+				return false, errCRLUnavailable
+			}
+		} else if revoked {
+			return false, errIntermediateCertRevoked
+		}
+
+		ints.AddCert(intcert)
 	}
 
-	leafcert, err := x509.ParseCertificate(l[:n])
+	leafcert, err := mdsParseX509Certificate(encoded[0])
 	if err != nil {
 		return false, err
 	}

--- a/metadata/decode_test.go
+++ b/metadata/decode_test.go
@@ -1,9 +1,16 @@
 package metadata
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,4 +79,86 @@ func TestValidateChainFallbackRoot(t *testing.T) {
 
 	assert.True(t, valid)
 	assert.NoError(t, err)
+}
+
+func TestValidateChainDepth(t *testing.T) {
+	root, rootKey, rootEncoded := newTestCertificate(t, 1, "root", nil, nil, true)
+	first, firstKey, firstEncoded := newTestCertificate(t, 2, "intermediate one", root, rootKey, true)
+	second, secondKey, secondEncoded := newTestCertificate(t, 3, "intermediate two", first, firstKey, true)
+
+	_, _, shallowEncoded := newTestCertificate(t, 4, "shallow leaf", first, firstKey, false)
+	_, _, deepEncoded := newTestCertificate(t, 5, "deep leaf", second, secondKey, false)
+
+	testCases := []struct {
+		name  string
+		chain []any
+		valid bool
+	}{
+		{
+			name:  "ShouldValidateSingleIntermediate",
+			chain: []any{shallowEncoded, firstEncoded},
+			valid: true,
+		},
+		{
+			name:  "ShouldValidateTwoIntermediates",
+			chain: []any{deepEncoded, secondEncoded, firstEncoded},
+			valid: true,
+		},
+		{
+			name: "ShouldRejectIncompleteChain",
+			chain: []any{deepEncoded, secondEncoded},
+			valid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			valid, err := validateChain(rootEncoded, tc.chain)
+
+			assert.Equal(t, tc.valid, valid)
+
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func newTestCertificate(t *testing.T, serial int64, name string, parent *x509.Certificate, parentKey *ecdsa.PrivateKey, ca bool) (cert *x509.Certificate, key *ecdsa.PrivateKey, encoded string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: name},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour * 24),
+		BasicConstraintsValid: true,
+		IsCA:                  ca,
+	}
+
+	if ca {
+		template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	} else {
+		template.KeyUsage = x509.KeyUsageDigitalSignature
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
+	}
+
+	signer, signerKey := template, key
+
+	if parent != nil {
+		signer, signerKey = parent, parentKey
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, signer, &key.PublicKey, signerKey)
+	require.NoError(t, err)
+
+	cert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return cert, key, base64.StdEncoding.EncodeToString(der)
 }


### PR DESCRIPTION
The x5c header carries the signing certificate followed by every intermediate up to the trust anchor, but only the first intermediate was added to the pool used to build the path. Anything beyond it was dropped, so a blob signed through more than one intermediate could never be verified. Every entry after the signing certificate is now decoded, checked for revocation and added to the pool.

Entries are type checked before any of them are decoded so that a malformed chain is still reported as such rather than as a decoding failure of whichever entry happened to be handled first. Decoding now reuses the existing certificate helper rather than repeating it per entry.