### PR TITLE
fix(metadata): report malformed status report urls

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -874,12 +874,15 @@ func (j StatusReportJSON) Parse() (report StatusReport, err error) {
 	var uri *url.URL
 
 	if len(j.URL) != 0 {
-		if uri, err = url.ParseRequestURI(j.URL); err != nil {
-			if !strings.HasPrefix(j.URL, "http") {
-				var e error
-				if uri, e = url.ParseRequestURI(fmt.Sprintf("https://%s", j.URL)); e != nil {
-					return report, fmt.Errorf("error occurred parsing URL value: %w", err)
-				}
+		var uerr error
+
+		if uri, uerr = url.ParseRequestURI(j.URL); uerr != nil {
+			if strings.HasPrefix(j.URL, "http://") || strings.HasPrefix(j.URL, "https://") {
+				return report, fmt.Errorf("error occurred parsing URL value: %w", uerr)
+			}
+
+			if uri, err = url.ParseRequestURI(fmt.Sprintf("https://%s", j.URL)); err != nil {
+				return report, fmt.Errorf("error occurred parsing URL value: %w", uerr)
 			}
 		}
 	}

--- a/metadata/parse_test.go
+++ b/metadata/parse_test.go
@@ -361,6 +361,25 @@ func TestStatusReportJSON_Parse(t *testing.T) {
 			err: "error occurred parsing URL value: parse \"\\x7f\": net/url: invalid control character in URL",
 		},
 		{
+			name: "ShouldFailInvalidURLWithScheme",
+			have: StatusReportJSON{
+				EffectiveDate: "2025-01-01",
+				URL:           "https://" + string([]byte{0x7f}),
+			},
+			err: "error occurred parsing URL value: parse \"https://\\x7f\": net/url: invalid control character in URL",
+		},
+		{
+			name: "ShouldSucceedHostPrefixedWithHTTP",
+			have: StatusReportJSON{
+				EffectiveDate: "2025-01-01",
+				URL:           "httpbin.example.com/update",
+			},
+			expected: StatusReport{
+				EffectiveDate: timePtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			expectedURL: "https://httpbin.example.com/update",
+		},
+		{
 			name: "ShouldSucceedMinimal",
 			have: StatusReportJSON{
 				EffectiveDate: "2025-01-01",


### PR DESCRIPTION
A status report url which failed to parse and already carried a scheme took an empty branch, so the error was assigned to the named return but never returned and the url came back nil with nothing to indicate anything had gone wrong.

The guard selecting that branch matched any value beginning with the letters http rather than one carrying an http scheme, so a scheme-less host such as httpbin.example.com was never retried as HTTPS. It now matches the scheme itself, leaving such hosts to the retry and reporting only the values which are genuinely malformed.