### PR TITLE
feat(protocol): relying party attestation policy

### DIFF
--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -99,7 +99,7 @@ type NonCompoundAttestationObject struct {
 	AttStatement map[string]any `json:"attStmt,omitempty"`
 }
 
-type attestationFormatValidationHandler func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (attestationType string, x5cs []any, err error)
+type attestationFormatValidationHandler func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error)
 
 var attestationRegistry = make(map[AttestationFormat]attestationFormatValidationHandler)
 
@@ -149,7 +149,7 @@ func (ccr *AuthenticatorAttestationResponse) Parse() (p *ParsedAttestationRespon
 //
 // Steps 13 through 15 are verified against the auth data. These steps are identical to 15 through 18 for assertion so we
 // handle them with AuthData.
-func (a *AttestationObject) Verify(relyingPartyID string, clientDataHash []byte, userVerificationRequired bool, userPresenceRequired bool, mds metadata.Provider, credParams []CredentialParameter) (err error) {
+func (a *AttestationObject) Verify(relyingPartyID string, clientDataHash []byte, userVerificationRequired bool, userPresenceRequired bool, mds metadata.Provider, credParams []CredentialParameter, policy AttestationPolicy) (err error) {
 	rpIDHash := sha256.Sum256([]byte(relyingPartyID))
 
 	// Begin Step 13 through 15. Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID expected by the RP.
@@ -177,12 +177,15 @@ func (a *AttestationObject) Verify(relyingPartyID string, clientDataHash []byte,
 		return ErrAttestationFormat.WithInfo("Credential public key algorithm not supported")
 	}
 
-	return a.VerifyAttestation(clientDataHash, mds)
+	return a.VerifyAttestation(clientDataHash, mds, policy)
 }
 
 // VerifyAttestation only verifies the attestation object excluding the AuthData values. If you wish to also verify the
 // AuthData values you should use [Verify].
-func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadata.Provider) (err error) {
+//
+// The policy carries the Relying Party decisions which §8 leaves to the Relying Party. Its zero value selects the
+// most restrictive behavior available. See [AttestationPolicy].
+func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (err error) {
 	// Step 18. Determine the attestation statement format by performing a
 	// USASCII case-sensitive match on fmt against the set of supported
 	// WebAuthn Attestation Statement Format Identifier values. The up-to-date
@@ -223,7 +226,7 @@ func (a *AttestationObject) VerifyAttestation(clientDataHash []byte, mds metadat
 	// Step 19. Verify that attStmt is a correct attestation statement, conveying a valid attestation signature, by using
 	// the attestation statement format fmt’s verification procedure given attStmt, authData and the hash of the serialized
 	// client data computed in step 7.
-	if attestationType, x5cs, err = handler(*a, clientDataHash, mds); err != nil {
+	if attestationType, x5cs, err = handler(*a, clientDataHash, mds, policy); err != nil {
 		var e *Error
 
 		if errors.As(err, &e) {

--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -37,7 +37,7 @@ import (
 // See: https://www.w3.org/TR/webauthn/#sctn-android-key-attestation
 //
 //nolint:gocyclo
-func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientDataHash []byte, _ metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientDataHash []byte, _ metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var (
 		alg int64
 		sig []byte
@@ -145,22 +145,30 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 		return "", nil, ErrAttestationFormat.WithDetails("Attestation challenge not equal to clientDataHash")
 	}
 
-	if protoErr := androidKeyValidateAuthorizationLists(&decoded); protoErr != nil {
+	if protoErr := androidKeyValidateAuthorizationLists(&decoded, policy.AndroidKey.AuthorizationScope); protoErr != nil {
 		return "", nil, protoErr
 	}
 
 	return string(metadata.BasicFull), x5c, err
 }
 
-// androidKeyValidateAuthorizationLists performs the §8.4 verification steps which apply to the authorization lists of
-// the Android key attestation certificate extension.
-func androidKeyValidateAuthorizationLists(decoded *androidkeyDescription) *Error {
+// androidKeyValidateAuthorizationLists performs the §8.4 verification steps which apply to the authorization lists
+// of the Android key attestation certificate extension.
+//
+// The scope selects the lists the origin and purpose requirements are evaluated against, which §8.4 leaves to the
+// Relying Party. See [AndroidKeyAuthorizationScope].
+func androidKeyValidateAuthorizationLists(decoded *androidkeyDescription, scope AndroidKeyAuthorizationScope) *Error {
 	// The AuthorizationList.allApplications field is not present on either authorization list (softwareEnforced nor teeEnforced), since PublicKeyCredential MUST be scoped to the RP ID.
+	//
+	// This requirement precedes the sentence which introduces the Relying Party's choice of scope, so it applies to
+	// both lists regardless of the scope in effect.
 	if len(decoded.SoftwareEnforced.AllApplications.FullBytes) != 0 || len(decoded.TeeEnforced.AllApplications.FullBytes) != 0 {
 		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains all applications field")
 	}
 
 	// For the following, use only the teeEnforced authorization list if the RP wants to accept only keys from a trusted execution environment, otherwise use the union of teeEnforced and softwareEnforced.
+	union := scope.union()
+
 	// The value in the AuthorizationList.origin field is equal to KM_ORIGIN_GENERATED (which == 0).
 	var (
 		originTee, originSoftware   int
@@ -172,24 +180,49 @@ func androidKeyValidateAuthorizationLists(decoded *androidkeyDescription) *Error
 		return ErrAttestationFormat.WithDetails("Unable to parse the origin of the teeEnforced authorization list").WithError(err)
 	}
 
-	if originSoftware, presentSoftware, err = authorizationListOrigin(&decoded.SoftwareEnforced); err != nil {
-		return ErrAttestationFormat.WithDetails("Unable to parse the origin of the softwareEnforced authorization list").WithError(err)
+	// The softwareEnforced list is only parsed when the scope consults it, so a malformed origin there cannot fail
+	// an attestation the teeEnforced scope would otherwise accept on the teeEnforced list alone.
+	if union {
+		if originSoftware, presentSoftware, err = authorizationListOrigin(&decoded.SoftwareEnforced); err != nil {
+			return ErrAttestationFormat.WithDetails("Unable to parse the origin of the softwareEnforced authorization list").WithError(err)
+		}
 	}
 
-	// The union is satisfied when either list carries an origin equal to KM_ORIGIN_GENERATED. An absent origin
-	// satisfies nothing as there is no value to compare against, which mirrors the purpose check below.
-	generated := (presentTee && originTee == KM_ORIGIN_GENERATED) || (presentSoftware && originSoftware == KM_ORIGIN_GENERATED)
+	// An absent origin satisfies nothing as there is no value to compare against, which mirrors the purpose check
+	// below.
+	generated := presentTee && originTee == KM_ORIGIN_GENERATED
+
+	if union && !generated {
+		generated = presentSoftware && originSoftware == KM_ORIGIN_GENERATED
+	}
 
 	if !generated {
-		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED")
+		return ErrAttestationFormat.WithDetails(fmt.Sprintf("Attestation certificate extensions contains %s with origin not equal KM_ORIGIN_GENERATED", androidKeyScopeDescription(union)))
 	}
 
 	// The value in the AuthorizationList.purpose field is equal to KM_PURPOSE_SIGN (which == 2).
-	if !contains(decoded.SoftwareEnforced.Purpose, KM_PURPOSE_SIGN) && !contains(decoded.TeeEnforced.Purpose, KM_PURPOSE_SIGN) {
-		return ErrAttestationFormat.WithDetails("Attestation certificate extensions contains authorization list with purpose not equal KM_PURPOSE_SIGN")
+	sign := contains(decoded.TeeEnforced.Purpose, KM_PURPOSE_SIGN)
+
+	if union && !sign {
+		sign = contains(decoded.SoftwareEnforced.Purpose, KM_PURPOSE_SIGN)
+	}
+
+	if !sign {
+		return ErrAttestationFormat.WithDetails(fmt.Sprintf("Attestation certificate extensions contains %s with purpose not equal KM_PURPOSE_SIGN", androidKeyScopeDescription(union)))
 	}
 
 	return nil
+}
+
+// androidKeyScopeDescription names the authorization lists the §8.4 origin and purpose requirements were evaluated
+// against so that a failure identifies the scope in effect. The union wording is unqualified as it matches the
+// specification's own phrasing and preserves the error text of the union scope.
+func androidKeyScopeDescription(union bool) string {
+	if union {
+		return "authorization list"
+	}
+
+	return "teeEnforced authorization list"
 }
 
 // authorizationListOrigin returns the origin of an authorization list and reports whether the field was present. The
@@ -264,8 +297,10 @@ var authorizationListValidatedTags = []int{
 // [authorizationList] can't model and which precedes a field the verification procedure depends on.
 //
 // An unmodelled tag otherwise defeats the §8.4 requirement that allApplications is absent, as the element is dropped
-// along with every field declared after it while the union permits the other list to supply the origin and purpose. A
-// list which can't be modelled in full is rejected explicitly rather than silently truncated.
+// along with every field declared after it. That requirement is checked against both lists in every scope, not only
+// when the union scope draws on softwareEnforced for the origin and purpose checks, so an unmodelled tag in either
+// list needs the same protection regardless of which scope the Relying Party has selected. A list which can't be
+// modelled in full is rejected explicitly rather than silently truncated.
 func androidKeyVerifyAuthorizationListTags(raw *androidkeyDescriptionRaw) *Error {
 	for _, list := range []struct {
 		name string

--- a/protocol/attestation_androidkey_scope_wiring_test.go
+++ b/protocol/attestation_androidkey_scope_wiring_test.go
@@ -1,0 +1,131 @@
+package protocol_test
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
+	"github.com/go-webauthn/webauthn/webauthn"
+)
+
+func TestCreateCredential_AndroidKeyAuthorizationScope(t *testing.T) {
+	const (
+		errTEEEnforced = "Attestation certificate extensions contains teeEnforced authorization list with origin not equal KM_ORIGIN_GENERATED"
+		errUnion       = "Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED"
+	)
+
+	testCases := []struct {
+		name        string
+		attestation protocol.AttestationPolicy
+		err         string
+	}{
+		{
+			name:        "ShouldRejectSoftwareBackedKeyUnderDefaultScope",
+			attestation: protocol.AttestationPolicy{},
+			err:         errTEEEnforced,
+		},
+		{
+			name: "ShouldRejectSoftwareBackedKeyUnderTEEEnforcedScope",
+			attestation: protocol.AttestationPolicy{
+				AndroidKey: protocol.AndroidKeyPolicy{AuthorizationScope: protocol.AndroidKeyAuthorizationScopeTEEEnforced},
+			},
+			err: errTEEEnforced,
+		},
+		{
+			name: "ShouldRejectSoftwareBackedKeyUnderUnionScopeWithUnionWording",
+			attestation: protocol.AttestationPolicy{
+				AndroidKey: protocol.AndroidKeyPolicy{AuthorizationScope: protocol.AndroidKeyAuthorizationScopeUnion},
+			},
+			err: errUnion,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, challenge := androidKeyScopeWiringSpecVector(t)
+
+			parsedResponse, err := protocol.ParseCredentialCreationResponseBytes(body)
+			require.NoError(t, err)
+
+			userID := []byte("test-user-id")
+
+			w := &webauthn.WebAuthn{
+				Config: &webauthn.Config{
+					RPID:        "example.org",
+					RPOrigins:   []string{"https://example.org"},
+					Attestation: tc.attestation,
+				},
+			}
+
+			session := webauthn.SessionData{
+				Challenge:  challenge,
+				UserID:     userID,
+				CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+			}
+
+			credential, err := w.CreateCredential(androidKeyScopeWiringTestUser{id: userID}, session, parsedResponse)
+
+			assert.Nil(t, credential)
+			assert.EqualError(t, err, tc.err)
+		})
+	}
+}
+
+type androidKeyScopeWiringTestUser struct {
+	id []byte
+}
+
+func (u androidKeyScopeWiringTestUser) WebAuthnID() []byte                         { return u.id }
+func (u androidKeyScopeWiringTestUser) WebAuthnName() string                       { return "test-user" }
+func (u androidKeyScopeWiringTestUser) WebAuthnDisplayName() string                { return "Test User" }
+func (u androidKeyScopeWiringTestUser) WebAuthnCredentials() []webauthn.Credential { return nil }
+
+func androidKeyScopeWiringSpecVector(t *testing.T) (body []byte, challenge string) {
+	t.Helper()
+
+	const (
+		attestationObjectHex = "a363666d746b616e64726f69642d6b65796761747453746d74a363616c67266373696758483046022100e95512982aa3f216cff2e87c8ec57057b8529f674eaabeccaa27fd03d8779f19022100afb6bf459da4a826f00d01fc6b60712ff31dc4eb331619c8f874bb17e4314e94637835638159026e3082026a30820210a00302010202101ff91f76b63f44812f998b250b0286bf300a06082a8648ce3d0403023062311e301c06035504030c15576562417574686e207465737420766563746f7273310c300a060355040a0c0357334331253023060355040b0c1c41757468656e74696361746f72204174746573746174696f6e204341310b30090603550406130241413020170d3234303130313030303030305a180f33303234303130313030303030305a305f311e301c06035504030c15576562417574686e207465737420766563746f7273310c300a060355040a0c0357334331223020060355040b0c1941757468656e74696361746f72204174746573746174696f6e310b30090603550406130241413059301306072a8648ce3d020106082a8648ce3d0301070342000499169657036d089a2a9821a7d0063d341f1a4613389359636efab5f3cbf1accfdd91c55543176ea99b644406dd1dd63774b6af65ac759e06ff40b1c8ab02df6ba381a83081a5300c0603551d130101ff04023000300e0603551d0f0101ff040403020780301d0603551d0e041604141ac81e50641e8d1339ab9f7eb25f0cd5aac054b0301f0603551d2304183016801445aff715b0dd786741fee996ebc16547a3931b1e3045060a2b06010401d679020111043730350202012c0a01000201000a01000420b435028d7b6a8f83bb461d41c19b053a9d3cdb30351a4f374cd4cde8dbefb606040030003000300a06082a8648ce3d040302034800304502202d27f0ca39d2f519fc8f49c6d96dfc793059e211ff80516a50398cf1eac2a322022100d482a88c740f64cf6a98ccc6c8b9f5e1e533fa5e509f0a7b4c3a02f964a8eba768617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b55d00000000ade9705e1ce7085b899a540d02199bf800200a4729519788b6ed8a2d772b494e186244d8c798c052960dbc8c10c915176795a501020326200121582099169657036d089a2a9821a7d0063d341f1a4613389359636efab5f3cbf1accf225820dd91c55543176ea99b644406dd1dd63774b6af65ac759e06ff40b1c8ab02df6b"
+		clientDataJSONHex    = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a2250654877747a5a647a4e345f384d76795869625f7037725f682d385162494438686c334541746d57414641222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a205656316351755232714c4d5f616d50666f487a4c3067227d"
+		credentialIDHex      = "0a4729519788b6ed8a2d772b494e186244d8c798c052960dbc8c10c915176795" //nolint:gosec
+		challengeHex         = "3de1f0b7365dccde3ff0cbf25e26ffa7baff87ef106c80fc865dc402d9960050"
+	)
+
+	credentialID, err := hex.DecodeString(credentialIDHex)
+	require.NoError(t, err)
+
+	challengeBytes, err := hex.DecodeString(challengeHex)
+	require.NoError(t, err)
+
+	challenge = base64.RawURLEncoding.EncodeToString(challengeBytes)
+
+	attestationObjectBytes, err := hex.DecodeString(attestationObjectHex)
+	require.NoError(t, err)
+
+	clientDataJSONBytes, err := hex.DecodeString(clientDataJSONHex)
+	require.NoError(t, err)
+
+	id := base64.RawURLEncoding.EncodeToString(credentialID)
+	attObj := base64.RawURLEncoding.EncodeToString(attestationObjectBytes)
+	cdj := base64.RawURLEncoding.EncodeToString(clientDataJSONBytes)
+
+	response := map[string]any{
+		"id":    id,
+		"rawId": id,
+		"type":  "public-key",
+		"response": map[string]any{
+			"attestationObject": attObj,
+			"clientDataJSON":    cdj,
+		},
+	}
+
+	body, err = json.Marshal(response)
+	require.NoError(t, err)
+
+	return body, challenge
+}

--- a/protocol/attestation_androidkey_test.go
+++ b/protocol/attestation_androidkey_test.go
@@ -100,13 +100,13 @@ func TestVerifyAndroidKeyFormat(t *testing.T) {
 					tc.setup(t, mds)
 				}
 
-				attestationType, x5cs, err = attestationFormatValidationHandlerAndroidKey(tc.args.att, tc.args.clientDataHash, mds)
+				attestationType, x5cs, err = attestationFormatValidationHandlerAndroidKey(tc.args.att, tc.args.clientDataHash, mds, AttestationPolicy{})
 			} else {
 				if tc.setup != nil {
 					tc.setup(t, nil)
 				}
 
-				attestationType, x5cs, err = attestationFormatValidationHandlerAndroidKey(tc.args.att, tc.args.clientDataHash, nil)
+				attestationType, x5cs, err = attestationFormatValidationHandlerAndroidKey(tc.args.att, tc.args.clientDataHash, nil, AttestationPolicy{})
 			}
 
 			if tc.err != "" {
@@ -283,7 +283,7 @@ func TestAndroidKeyFormat_HandlerErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := attestationFormatValidationHandlerAndroidKey(tc.att, tc.clientDataHash, nil)
+			_, _, err := attestationFormatValidationHandlerAndroidKey(tc.att, tc.clientDataHash, nil, AttestationPolicy{})
 
 			assert.EqualError(t, err, tc.err)
 		})
@@ -372,9 +372,9 @@ func TestAndroidKeyAuthorizationListDecoding(t *testing.T) {
 	assert.Empty(t, decoded.SoftwareEnforced.AllApplications.FullBytes)
 }
 
-// TestAndroidKeyAuthorizationListOrigin asserts the §8.4 origin requirement is evaluated against the union of the two
-// authorization lists, matching the adjacent purpose requirement, and that an absent origin does not satisfy it. An
-// optional integer decodes to zero when absent, which is the value of KM_ORIGIN_GENERATED.
+// TestAndroidKeyAuthorizationListOrigin asserts the §8.4 origin requirement is evaluated against the authorization
+// lists the Relying Party's scope selects, and that an absent origin does not satisfy it. An optional integer
+// decodes to zero when absent, which is the value of KM_ORIGIN_GENERATED.
 func TestAndroidKeyAuthorizationListOrigin(t *testing.T) {
 	// SEQUENCE { [1] EXPLICIT SET { INTEGER 2 } [, [702] EXPLICIT INTEGER n] } where the purpose is KM_PURPOSE_SIGN.
 	list := func(t *testing.T, origin string) androidkeyAuthorizationList {
@@ -402,59 +402,187 @@ func TestAndroidKeyAuthorizationListOrigin(t *testing.T) {
 	imported := list(t, "02")  // KM_ORIGIN_IMPORTED.
 	missing := list(t, "")
 
+	const (
+		errTEE   = "Attestation certificate extensions contains teeEnforced authorization list with origin not equal KM_ORIGIN_GENERATED"
+		errUnion = "Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED"
+	)
+
 	testCases := []struct {
 		name     string
 		tee      androidkeyAuthorizationList
 		software androidkeyAuthorizationList
-		err      string
+		errTEE   string
+		errUnion string
 	}{
 		{
 			name: "ShouldAcceptWhenGeneratedInTeeAndAbsentFromSoftware",
 			tee:  generated, software: missing,
 		},
 		{
-			name: "ShouldAcceptWhenGeneratedInSoftwareAndAbsentFromTee",
+			// The union is satisfied by the softwareEnforced list, but a key the trusted execution environment
+			// does not vouch for is precisely what the teeEnforced scope exists to exclude.
+			name: "ShouldAcceptOnlyUnderUnionWhenGeneratedInSoftwareAndAbsentFromTee",
 			tee:  missing, software: generated,
+			errTEE: errTEE,
 		},
 		{
 			name: "ShouldAcceptWhenGeneratedInBoth",
 			tee:  generated, software: generated,
 		},
 		{
-			// The union is satisfied by the teeEnforced list. The previous implementation required both lists to
-			// agree, which rejected this.
+			// The teeEnforced list satisfies both scopes. The softwareEnforced list is not consulted at all under
+			// the teeEnforced scope, so an imported origin there cannot detract from a generated one in the
+			// teeEnforced list.
 			name: "ShouldAcceptWhenGeneratedInTeeAndImportedInSoftware",
 			tee:  generated, software: imported,
 		},
 		{
 			name: "ShouldRejectWhenImportedInBoth",
 			tee:  imported, software: imported,
-			err: "Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED",
+			errTEE: errTEE, errUnion: errUnion,
 		},
 		{
 			// Neither list states an origin, so there is no value equal to KM_ORIGIN_GENERATED to verify.
 			name: "ShouldRejectWhenAbsentFromBothLists",
 			tee:  missing, software: missing,
-			err: "Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED",
+			errTEE: errTEE, errUnion: errUnion,
 		},
 		{
 			name: "ShouldRejectWhenImportedInTeeAndAbsentFromSoftware",
 			tee:  imported, software: missing,
-			err: "Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED",
+			errTEE: errTEE, errUnion: errUnion,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			decoded := androidkeyDescription{TeeEnforced: tc.tee, SoftwareEnforced: tc.software}
+			for _, sc := range []struct {
+				name  string
+				scope AndroidKeyAuthorizationScope
+				err   string
+			}{
+				{"Default", AndroidKeyAuthorizationScopeDefault, tc.errTEE},
+				{"TEEEnforced", AndroidKeyAuthorizationScopeTEEEnforced, tc.errTEE},
+				{"Union", AndroidKeyAuthorizationScopeUnion, tc.errUnion},
+			} {
+				t.Run(sc.name, func(t *testing.T) {
+					decoded := androidkeyDescription{TeeEnforced: tc.tee, SoftwareEnforced: tc.software}
 
-			protoErr := androidKeyValidateAuthorizationLists(&decoded)
+					protoErr := androidKeyValidateAuthorizationLists(&decoded, sc.scope)
 
-			if tc.err != "" {
-				require.NotNil(t, protoErr)
-				assert.EqualError(t, protoErr, tc.err)
-			} else {
-				assert.Nil(t, protoErr)
+					if sc.err != "" {
+						require.NotNil(t, protoErr)
+						assert.EqualError(t, protoErr, sc.err)
+					} else {
+						assert.Nil(t, protoErr)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestAndroidKeyAuthorizationListPurpose asserts the §8.4 purpose requirement is evaluated against the
+// authorization lists the Relying Party's scope selects, matching the adjacent origin requirement.
+func TestAndroidKeyAuthorizationListPurpose(t *testing.T) {
+	// SEQUENCE { [ [1] EXPLICIT SET { INTEGER n }, ] [702] EXPLICIT INTEGER 0 } where the origin is always
+	// KM_ORIGIN_GENERATED so a failure below is attributable to the purpose alone.
+	list := func(t *testing.T, purpose string) androidkeyAuthorizationList {
+		t.Helper()
+
+		body := ""
+
+		if purpose != "" {
+			body += "a105310302010" + purpose
+		}
+
+		body += androidKeyDEROrigin
+
+		der, err := hex.DecodeString(fmt.Sprintf("30%02x", len(body)/2) + body)
+		require.NoError(t, err)
+
+		var decoded androidkeyAuthorizationList
+
+		rest, err := asn1.Unmarshal(der, &decoded)
+		require.NoError(t, err)
+		require.Empty(t, rest)
+
+		return decoded
+	}
+
+	sign := list(t, "2")   // KM_PURPOSE_SIGN, which is 2 in protocol/attestation_androidkey_types.go:133.
+	verify := list(t, "3") // KM_PURPOSE_VERIFY, which is 3 and does not satisfy the requirement.
+	missing := list(t, "")
+
+	require.Equal(t, []int{KM_PURPOSE_SIGN}, sign.Purpose)
+	require.NotContains(t, verify.Purpose, KM_PURPOSE_SIGN)
+	require.Empty(t, missing.Purpose)
+
+	const (
+		errTEE   = "Attestation certificate extensions contains teeEnforced authorization list with purpose not equal KM_PURPOSE_SIGN"
+		errUnion = "Attestation certificate extensions contains authorization list with purpose not equal KM_PURPOSE_SIGN"
+	)
+
+	testCases := []struct {
+		name     string
+		tee      androidkeyAuthorizationList
+		software androidkeyAuthorizationList
+		errTEE   string
+		errUnion string
+	}{
+		{
+			name: "ShouldAcceptWhenSignInTeeAndAbsentFromSoftware",
+			tee:  sign, software: missing,
+		},
+		{
+			name: "ShouldAcceptOnlyUnderUnionWhenSignInSoftwareAndAbsentFromTee",
+			tee:  missing, software: sign,
+			errTEE: errTEE,
+		},
+		{
+			name: "ShouldAcceptOnlyUnderUnionWhenVerifyInTeeAndSignInSoftware",
+			tee:  verify, software: sign,
+			errTEE: errTEE,
+		},
+		{
+			name: "ShouldAcceptWhenSignInBoth",
+			tee:  sign, software: sign,
+		},
+		{
+			name: "ShouldRejectWhenVerifyInBoth",
+			tee:  verify, software: verify,
+			errTEE: errTEE, errUnion: errUnion,
+		},
+		{
+			name: "ShouldRejectWhenAbsentFromBothLists",
+			tee:  missing, software: missing,
+			errTEE: errTEE, errUnion: errUnion,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, sc := range []struct {
+				name  string
+				scope AndroidKeyAuthorizationScope
+				err   string
+			}{
+				{"Default", AndroidKeyAuthorizationScopeDefault, tc.errTEE},
+				{"TEEEnforced", AndroidKeyAuthorizationScopeTEEEnforced, tc.errTEE},
+				{"Union", AndroidKeyAuthorizationScopeUnion, tc.errUnion},
+			} {
+				t.Run(sc.name, func(t *testing.T) {
+					decoded := androidkeyDescription{TeeEnforced: tc.tee, SoftwareEnforced: tc.software}
+
+					protoErr := androidKeyValidateAuthorizationLists(&decoded, sc.scope)
+
+					if sc.err != "" {
+						require.NotNil(t, protoErr)
+						assert.EqualError(t, protoErr, sc.err)
+					} else {
+						assert.Nil(t, protoErr)
+					}
+				})
 			}
 		})
 	}
@@ -606,13 +734,27 @@ func TestAndroidKeyAuthorizationListAllApplicationsDER(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			protoErr := androidKeyValidateAuthorizationLists(&tc.decoded)
+			// §8.4 requires allApplications is absent from both lists in the sentence preceding the one which
+			// introduces the Relying Party's choice of scope, so the choice does not reach it.
+			for _, sc := range []struct {
+				name  string
+				scope AndroidKeyAuthorizationScope
+			}{
+				{"TEEEnforced", AndroidKeyAuthorizationScopeTEEEnforced},
+				{"Union", AndroidKeyAuthorizationScopeUnion},
+			} {
+				t.Run(sc.name, func(t *testing.T) {
+					decoded := tc.decoded
 
-			if tc.err != "" {
-				require.NotNil(t, protoErr)
-				assert.EqualError(t, protoErr, tc.err)
-			} else {
-				assert.Nil(t, protoErr)
+					protoErr := androidKeyValidateAuthorizationLists(&decoded, sc.scope)
+
+					if tc.err != "" {
+						require.NotNil(t, protoErr)
+						assert.EqualError(t, protoErr, tc.err)
+					} else {
+						assert.Nil(t, protoErr)
+					}
+				})
 			}
 		})
 	}
@@ -659,8 +801,12 @@ func TestAndroidKeyAuthorizationListUnsupportedTagBypass(t *testing.T) {
 
 	// The decode reports no error yet allApplications, which is present in the encoding, is absent from the result.
 	// The §8.4 checks alone therefore accept the attestation.
+	//
+	// The union scope is required to demonstrate this. The unmodelled tag also drops the teeEnforced origin, so
+	// under the teeEnforced scope the attestation is rejected for that unrelated reason, which would mask the
+	// bypass rather than exhibit it.
 	require.Empty(t, decoded.TeeEnforced.AllApplications.FullBytes)
-	require.Nil(t, androidKeyValidateAuthorizationLists(&decoded))
+	require.Nil(t, androidKeyValidateAuthorizationLists(&decoded, AndroidKeyAuthorizationScopeUnion))
 
 	// Verifying the tags actually present against the raw extension is what rejects it.
 	var raw androidkeyDescriptionRaw

--- a/protocol/attestation_apple.go
+++ b/protocol/attestation_apple.go
@@ -27,7 +27,7 @@ import (
 // Specification: §8.8. Apple Anonymous Attestation Statement Format
 //
 // See : https://www.w3.org/TR/webauthn/#sctn-apple-anonymous-attestation
-func attestationFormatValidationHandlerAppleAnonymous(att AttestationObject, clientDataHash []byte, _ metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerAppleAnonymous(att AttestationObject, clientDataHash []byte, _ metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	// Step 1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it
 	// to extract the contained fields.
 	var (

--- a/protocol/attestation_apple_test.go
+++ b/protocol/attestation_apple_test.go
@@ -41,7 +41,7 @@ func Test_VerifyAppleFormat(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attestationType, x5cs, err := attestationFormatValidationHandlerAppleAnonymous(tc.args.att, tc.args.clientDataHash, nil)
+			attestationType, x5cs, err := attestationFormatValidationHandlerAppleAnonymous(tc.args.att, tc.args.clientDataHash, nil, AttestationPolicy{})
 
 			assert.Equal(t, tc.attestationType, attestationType)
 			assert.Equal(t, tc.x5cs, x5cs)

--- a/protocol/attestation_compound.go
+++ b/protocol/attestation_compound.go
@@ -34,7 +34,7 @@ func init() {
 // See: https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation
 //
 //nolint:gocyclo
-func attestationFormatValidationHandlerCompound(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerCompound(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var (
 		aaguid   uuid.UUID
 		raw      any
@@ -104,7 +104,7 @@ func attestationFormatValidationHandlerCompound(att AttestationObject, clientDat
 			subAttType string
 		)
 
-		if subAttType, cx5cs, err = attestationRegistry[AttestationFormat(object.Format)](object, clientDataHash, mds); err != nil {
+		if subAttType, cx5cs, err = attestationRegistry[AttestationFormat(object.Format)](object, clientDataHash, mds, policy); err != nil {
 			return "", nil, err
 		}
 

--- a/protocol/attestation_compound_test.go
+++ b/protocol/attestation_compound_test.go
@@ -19,7 +19,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 	t.Run("ShouldReturnValidationErrors", func(t *testing.T) {
 		withFreshAttestationRegistry(t)
 
-		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			return "ok", nil, nil
 		}
 
@@ -170,7 +170,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				att := tc.mutate(base)
 
-				attestationType, x5cs, err := attestationFormatValidationHandlerCompound(att, []byte("clientDataHash"), nil)
+				attestationType, x5cs, err := attestationFormatValidationHandlerCompound(att, []byte("clientDataHash"), nil, AttestationPolicy{})
 				require.Error(t, err)
 				assert.Empty(t, attestationType)
 				assert.Nil(t, x5cs)
@@ -200,7 +200,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 
 		var calls []call
 
-		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			calls = append(calls, call{
 				format:  att.Format,
 				attStmt: att.AttStatement,
@@ -211,7 +211,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			return "packed-type", []any{[]byte("cert1")}, nil
 		}
 
-		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			calls = append(calls, call{
 				format:  att.Format,
 				attStmt: att.AttStatement,
@@ -246,7 +246,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			},
 		}
 
-		gotType, gotX5Cs, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil)
+		gotType, gotX5Cs, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, AttestationPolicy{})
 		require.NoError(t, err)
 
 		// §8.9 returns any combination of the outputs of the successful verification procedures. The type of the
@@ -265,12 +265,59 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			"expected raw auth data to be passed through unchanged, got: %#v", calls)
 	})
 
+	t.Run("ShouldForwardPolicyToSubHandlersUnchanged", func(t *testing.T) {
+		withFreshAttestationRegistry(t)
+
+		type call struct {
+			format string
+			policy AttestationPolicy
+		}
+
+		var calls []call
+
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (string, []any, error) {
+			calls = append(calls, call{format: att.Format, policy: policy})
+
+			return "packed-type", nil, nil
+		}
+
+		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (string, []any, error) {
+			calls = append(calls, call{format: att.Format, policy: policy})
+
+			return "apple-type", nil, nil
+		}
+
+		att := AttestationObject{
+			Format: string(AttestationFormatCompound),
+			AuthData: AuthenticatorData{
+				AttData: AttestedCredentialData{AAGUID: make([]byte, 0)},
+			},
+			AttStatement: map[string]any{
+				stmtAttStmt: []any{
+					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					map[string]any{stmtFmt: string(AttestationFormatApple), stmtAttStmt: map[string]any{}},
+				},
+			},
+		}
+
+		// A non-zero policy is deliberate: asserting against the zero value would still pass if the forwarding were
+		// replaced by AttestationPolicy{}, which is the exact regression this test exists to catch.
+		policy := AttestationPolicy{AndroidKey: AndroidKeyPolicy{AuthorizationScope: AndroidKeyAuthorizationScopeUnion}}
+
+		_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, policy)
+		require.NoError(t, err)
+
+		require.Len(t, calls, 2)
+		assert.Equal(t, policy, calls[0].policy)
+		assert.Equal(t, policy, calls[1].policy)
+	})
+
 	t.Run("ShouldPropagateSubHandlerError", func(t *testing.T) {
 		withFreshAttestationRegistry(t)
 
 		subErr := ErrInvalidAttestation.WithDetails("sub-handler failed")
 
-		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			return "", nil, subErr
 		}
 
@@ -287,7 +334,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			},
 		}
 
-		_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil)
+		_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, AttestationPolicy{})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, subErr))
 	})
@@ -297,7 +344,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 
 		var handlerCalls int
 
-		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			handlerCalls++
 
 			return testAttTypeSome, []any{[]byte("cert")}, nil
@@ -327,7 +374,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			},
 		}
 
-		_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), mds)
+		_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), mds, AttestationPolicy{})
 		require.Error(t, err)
 
 		protoErr, ok := err.(*Error)
@@ -344,7 +391,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 
 		var handlerCalls int
 
-		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			handlerCalls++
 			return testAttTypeSome, []any{[]byte("cert")}, nil
 		}
@@ -364,7 +411,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			},
 		}
 
-		gotType, gotX5Cs, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil)
+		gotType, gotX5Cs, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, AttestationPolicy{})
 		require.NoError(t, err)
 
 		assert.Equal(t, testAttTypeSome, gotType)
@@ -377,7 +424,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 	t.Run("ShouldValidateMetadataAgainstTheConveyedAttestationType", func(t *testing.T) {
 		withFreshAttestationRegistry(t)
 
-		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 			return string(metadata.BasicFull), nil, nil
 		}
 
@@ -394,7 +441,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			},
 		}
 
-		gotType, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil)
+		gotType, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, AttestationPolicy{})
 		require.NoError(t, err)
 		require.NotEqual(t, stmtTypNone, gotType)
 

--- a/protocol/attestation_fido_u2f.go
+++ b/protocol/attestation_fido_u2f.go
@@ -30,7 +30,7 @@ import (
 // Specification: §8.6. FIDO U2F Attestation Statement Format
 //
 // See: https://www.w3.org/TR/webauthn/#sctn-fido-u2f-attestation
-func attestationFormatValidationHandlerFIDOU2F(att AttestationObject, clientDataHash []byte, _ metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerFIDOU2F(att AttestationObject, clientDataHash []byte, _ metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	// Signing procedure. Non-normative verification procedure of expected requirement.
 	// If the credential public key of the attested credential is not of algorithm -7 ("ES256"), stop and return an error.
 	var key webauthncose.EC2PublicKeyData

--- a/protocol/attestation_fido_u2f_test.go
+++ b/protocol/attestation_fido_u2f_test.go
@@ -39,7 +39,7 @@ func TestVerifyU2FFormat(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attestationType, _, err := attestationFormatValidationHandlerFIDOU2F(tc.att, tc.clientDataHash, nil)
+			attestationType, _, err := attestationFormatValidationHandlerFIDOU2F(tc.att, tc.clientDataHash, nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
@@ -176,7 +176,7 @@ func TestVerifyU2FFormat_Errors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := attestationFormatValidationHandlerFIDOU2F(tc.att, []byte("hash"), nil)
+			_, _, err := attestationFormatValidationHandlerFIDOU2F(tc.att, []byte("hash"), nil, AttestationPolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -264,7 +264,7 @@ func TestVerifyU2FFormat_CertificateErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := attestationFormatValidationHandlerFIDOU2F(tc.att, []byte("hash"), nil)
+			_, _, err := attestationFormatValidationHandlerFIDOU2F(tc.att, []byte("hash"), nil, AttestationPolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -38,7 +38,7 @@ func init() {
 // Specification: §8.2. Packed Attestation Statement Format
 //
 // See: https://www.w3.org/TR/webauthn/#sctn-packed-attestation
-func attestationFormatValidationHandlerPacked(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerPacked(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var (
 		alg int64
 		sig []byte

--- a/protocol/attestation_packed_test.go
+++ b/protocol/attestation_packed_test.go
@@ -55,7 +55,7 @@ func Test_VerifyPackedFormat(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attestationType, _, err := attestationFormatValidationHandlerPacked(tc.att, tc.clientDataHash, nil)
+			attestationType, _, err := attestationFormatValidationHandlerPacked(tc.att, tc.clientDataHash, nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)
@@ -108,7 +108,7 @@ func TestPackedFormat_HandlerErrors(t *testing.T) {
 				AttStatement: tc.attStatement,
 			}
 
-			_, _, err := attestationFormatValidationHandlerPacked(att, []byte("hash"), nil)
+			_, _, err := attestationFormatValidationHandlerPacked(att, []byte("hash"), nil, AttestationPolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}

--- a/protocol/attestation_policy.go
+++ b/protocol/attestation_policy.go
@@ -1,0 +1,51 @@
+package protocol
+
+// AttestationPolicy carries the Relying Party policy decisions which §8 of the specification delegates to the
+// Relying Party rather than fixing. The zero value selects the most restrictive behavior available for each
+// policy it carries.
+type AttestationPolicy struct {
+	// AndroidKey configures the Android Key Attestation Statement Format verification procedure.
+	AndroidKey AndroidKeyPolicy
+}
+
+// AndroidKeyPolicy configures the Android Key Attestation Statement Format verification procedure.
+//
+// Specification: §8.4. Android Key Attestation Statement Format (https://www.w3.org/TR/webauthn/#sctn-android-key-attestation)
+type AndroidKeyPolicy struct {
+	// AuthorizationScope selects the authorization lists of the attestation certificate extension which the origin
+	// and purpose requirements are evaluated against.
+	AuthorizationScope AndroidKeyAuthorizationScope
+}
+
+// AndroidKeyAuthorizationScope selects the authorization lists of the Android key attestation certificate
+// extension which the §8.4 origin and purpose requirements are evaluated against.
+//
+// §8.4 assigns this choice to the Relying Party: "For the following, use only the teeEnforced authorization list
+// if the RP wants to accept only keys from a trusted execution environment, otherwise use the union of
+// teeEnforced and softwareEnforced."
+//
+// Specification: §8.4. Android Key Attestation Statement Format (https://www.w3.org/TR/webauthn/#sctn-android-key-attestation)
+type AndroidKeyAuthorizationScope int
+
+const (
+	// AndroidKeyAuthorizationScopeDefault is the zero value of [AndroidKeyAuthorizationScope] and has no matching
+	// rule in §8.4. It evaluates as [AndroidKeyAuthorizationScopeTEEEnforced] wherever it is used. webauthn.Config
+	// rewrites it to that explicit constant during validation, so a Relying Party can tell an unset field apart
+	// from a deliberate choice of the same scope.
+	AndroidKeyAuthorizationScopeDefault AndroidKeyAuthorizationScope = iota
+
+	// AndroidKeyAuthorizationScopeTEEEnforced evaluates the origin and purpose requirements against the teeEnforced
+	// authorization list alone, accepting only keys generated within a trusted execution environment.
+	AndroidKeyAuthorizationScopeTEEEnforced
+
+	// AndroidKeyAuthorizationScopeUnion evaluates the origin and purpose requirements against the union of the
+	// teeEnforced and softwareEnforced authorization lists, which additionally accepts software backed keys.
+	AndroidKeyAuthorizationScopeUnion
+)
+
+// union returns true when the scope evaluates the origin and purpose requirements against both authorization
+// lists. Every other value, including the zero value and any value outside the defined set, evaluates them
+// against teeEnforced alone so that an unset or malformed policy is the restrictive one.
+func (s AndroidKeyAuthorizationScope) union() bool {
+	return s == AndroidKeyAuthorizationScopeUnion
+}

--- a/protocol/attestation_policy_test.go
+++ b/protocol/attestation_policy_test.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAndroidKeyAuthorizationScopeUnion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		scope    AndroidKeyAuthorizationScope
+		expected bool
+	}{
+		{
+			// The zero value must resolve to the restrictive branch so a policy which was never passed through
+			// config validation is still safe.
+			name:     "ShouldTreatDefaultAsTEEEnforced",
+			scope:    AndroidKeyAuthorizationScopeDefault,
+			expected: false,
+		},
+		{
+			name:     "ShouldTreatTEEEnforcedAsTEEEnforced",
+			scope:    AndroidKeyAuthorizationScopeTEEEnforced,
+			expected: false,
+		},
+		{
+			name:     "ShouldTreatUnionAsUnion",
+			scope:    AndroidKeyAuthorizationScopeUnion,
+			expected: true,
+		},
+		{
+			// A value outside the defined set resolves to the restrictive branch rather than the permissive one.
+			name:     "ShouldTreatUnknownAsTEEEnforced",
+			scope:    AndroidKeyAuthorizationScope(99),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.scope.union())
+		})
+	}
+}
+
+func TestAttestationPolicyZeroValue(t *testing.T) {
+	var policy AttestationPolicy
+
+	assert.Equal(t, AndroidKeyAuthorizationScopeDefault, policy.AndroidKey.AuthorizationScope)
+	assert.False(t, policy.AndroidKey.AuthorizationScope.union())
+}

--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -39,7 +39,7 @@ import (
 // Specification: §8.5. Android SafetyNet Attestation Statement Format
 //
 // See: https://www.w3.org/TR/webauthn/#sctn-android-safetynet-attestation
-func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	// The syntax of an Android Attestation statement is defined as follows:
 	//     $$attStmtType //= (
 	//                           fmt: "android-safetynet",

--- a/protocol/attestation_safetynet_test.go
+++ b/protocol/attestation_safetynet_test.go
@@ -64,7 +64,7 @@ func TestSafetyNetFormat_AttStatementErrors(t *testing.T) {
 				AttStatement: tc.attStatement,
 			}
 
-			_, _, err := attestationFormatValidationHandlerAndroidSafetyNet(att, []byte("hash"), nil)
+			_, _, err := attestationFormatValidationHandlerAndroidSafetyNet(att, []byte("hash"), nil, AttestationPolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -255,7 +255,7 @@ func TestSafetyNetFormat_JWTValidation(t *testing.T) {
 				},
 			}
 
-			attestationType, _, err := attestationFormatValidationHandlerAndroidSafetyNet(att, tc.clientDataHash, tc.mds)
+			attestationType, _, err := attestationFormatValidationHandlerAndroidSafetyNet(att, tc.clientDataHash, tc.mds, AttestationPolicy{})
 
 			if tc.err != "" {
 				require.EqualError(t, err, tc.err)

--- a/protocol/attestation_spec_test.go
+++ b/protocol/attestation_spec_test.go
@@ -59,7 +59,7 @@ func TestSpecVectors_PackedSelfES256(t *testing.T) {
 	rawClientDataJSON := specTestDecodeHex(t, clientDataJSONHex)
 	clientDataHash := sha256.Sum256(rawClientDataJSON)
 
-	attestationType, _, err := attestationFormatValidationHandlerPacked(att, clientDataHash[:], nil)
+	attestationType, _, err := attestationFormatValidationHandlerPacked(att, clientDataHash[:], nil, AttestationPolicy{})
 	require.NoError(t, err)
 	assert.Equal(t, string(metadata.BasicSurrogate), attestationType)
 }
@@ -80,7 +80,7 @@ func TestSpecVectors_PackedES256(t *testing.T) {
 	rawClientDataJSON := specTestDecodeHex(t, clientDataJSONHex)
 	clientDataHash := sha256.Sum256(rawClientDataJSON)
 
-	attestationType, x5cs, err := attestationFormatValidationHandlerPacked(att, clientDataHash[:], nil)
+	attestationType, x5cs, err := attestationFormatValidationHandlerPacked(att, clientDataHash[:], nil, AttestationPolicy{})
 	require.NoError(t, err)
 	assert.Equal(t, string(metadata.BasicFull), attestationType)
 	assert.NotEmpty(t, x5cs)
@@ -105,7 +105,7 @@ func TestSpecVectors_TPMES256(t *testing.T) {
 
 	clientDataHash := sha256.Sum256(specTestDecodeHex(t, clientDataJSONHex))
 
-	_, _, err := attestationFormatValidationHandlerTPM(att, clientDataHash[:], nil)
+	_, _, err := attestationFormatValidationHandlerTPM(att, clientDataHash[:], nil, AttestationPolicy{})
 	assert.NoError(t, err)
 }
 
@@ -148,7 +148,7 @@ func TestSpecVectors_AppleES256(t *testing.T) {
 
 	clientDataHash := sha256.Sum256(specTestDecodeHex(t, clientDataJSONHex))
 
-	_, _, err := attestationFormatValidationHandlerAppleAnonymous(att, clientDataHash[:], nil)
+	_, _, err := attestationFormatValidationHandlerAppleAnonymous(att, clientDataHash[:], nil, AttestationPolicy{})
 	assert.NoError(t, err)
 }
 
@@ -178,7 +178,7 @@ func TestSpecVectors_FIDOU2FES256(t *testing.T) {
 
 	clientDataHash := sha256.Sum256(specTestDecodeHex(t, clientDataJSONHex))
 
-	_, _, err := attestationFormatValidationHandlerFIDOU2F(att, clientDataHash[:], nil)
+	_, _, err := attestationFormatValidationHandlerFIDOU2F(att, clientDataHash[:], nil, AttestationPolicy{})
 	assert.NoError(t, err)
 }
 
@@ -213,7 +213,7 @@ func specTestParseAndVerify(t *testing.T, attObjHex, clientDataJSONHex string, c
 
 	clientDataHash := sha256.Sum256(rawClientDataJSON)
 
-	require.NoError(t, att.Verify(specTestRPID, clientDataHash[:], false, true, nil, credParams))
+	require.NoError(t, att.Verify(specTestRPID, clientDataHash[:], false, true, nil, credParams, AttestationPolicy{}))
 
 	return att
 }

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -60,7 +60,7 @@ func TestAttestationVerify(t *testing.T) {
 
 			pcc.Response = *parsedAttestationResponse
 
-			_, err = pcc.Verify(options.Response.Challenge.String(), options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginExplicitVerificationMode, false, false, false, nil, options.Response.Parameters)
+			_, err = pcc.Verify(options.Response.Challenge.String(), options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginExplicitVerificationMode, false, false, false, nil, options.Response.Parameters, AttestationPolicy{})
 
 			require.NoError(t, err)
 		})
@@ -72,7 +72,7 @@ func TestPackedAttestationVerification(t *testing.T) {
 
 	clientDataHash := sha256.Sum256(pcc.Raw.AttestationResponse.ClientDataJSON)
 
-	_, _, err := attestationFormatValidationHandlerPacked(pcc.Response.AttestationObject, clientDataHash[:], nil)
+	_, _, err := attestationFormatValidationHandlerPacked(pcc.Response.AttestationObject, clientDataHash[:], nil, AttestationPolicy{})
 	require.NoError(t, err)
 }
 
@@ -138,7 +138,7 @@ func TestAttestationObject_VerifyAttestation_Errors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.att.VerifyAttestation([]byte("hash"), nil)
+			err := tc.att.VerifyAttestation([]byte("hash"), nil, AttestationPolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -151,7 +151,7 @@ func TestAttestationObject_Verify_AlgorithmMismatch(t *testing.T) {
 
 	wrongParams := []CredentialParameter{{Type: PublicKeyCredentialType, Algorithm: -257}}
 
-	err := att.Verify("localhost", clientDataHash[:], false, false, nil, wrongParams)
+	err := att.Verify("localhost", clientDataHash[:], false, false, nil, wrongParams, AttestationPolicy{})
 	require.EqualError(t, err, "Invalid attestation format")
 }
 
@@ -170,7 +170,7 @@ func TestAttestationObject_VerifyAttestation_HandlerErrors(t *testing.T) {
 		{
 			name:   "ShouldWrapProtocolError",
 			format: "test-format",
-			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 				return string(metadata.BasicFull), nil, ErrInvalidAttestation.WithDetails("handler failed")
 			},
 			err:     "handler failed",
@@ -179,7 +179,7 @@ func TestAttestationObject_VerifyAttestation_HandlerErrors(t *testing.T) {
 		{
 			name:   "ShouldWrapNonProtocolError",
 			format: "test-format",
-			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 				return string(metadata.BasicFull), nil, fmt.Errorf("stdlib error")
 			},
 			err:     "stdlib error",
@@ -188,14 +188,14 @@ func TestAttestationObject_VerifyAttestation_HandlerErrors(t *testing.T) {
 		{
 			name:   "ShouldReturnNilForCompoundAttestationType",
 			format: "test-format",
-			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 				return string(AttestationFormatCompound), nil, nil
 			},
 		},
 		{
 			name:   "ShouldFailWithInvalidAAGUIDLength",
 			format: "test-format",
-			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider) (string, []any, error) {
+			handler: func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
 				return string(metadata.BasicFull), nil, nil
 			},
 			authData: AuthenticatorData{
@@ -218,7 +218,7 @@ func TestAttestationObject_VerifyAttestation_HandlerErrors(t *testing.T) {
 				AuthData:     tc.authData,
 			}
 
-			err := att.VerifyAttestation([]byte("hash"), nil)
+			err := att.VerifyAttestation([]byte("hash"), nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				require.Error(t, err)

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -43,7 +43,7 @@ import (
 // See: https://www.w3.org/TR/webauthn/#sctn-tpm-attestation
 //
 //nolint:gocyclo
-func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash []byte, _ metadata.Provider) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash []byte, _ metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var statement *tpm2AttStatement
 
 	if statement, err = newTPM2AttStatement(att.AttStatement); err != nil {

--- a/protocol/attestation_tpm_test.go
+++ b/protocol/attestation_tpm_test.go
@@ -502,7 +502,7 @@ func TestTPMAttestationVerificationBasicConstraints(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(makeTPMAttestation(t, tc.opts), nil, nil)
+			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(makeTPMAttestation(t, tc.opts), nil, nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
@@ -555,7 +555,7 @@ func TestTPMAttestationVerificationAAGUID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(makeTPMAttestation(t, tc.opts), nil, nil)
+			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(makeTPMAttestation(t, tc.opts), nil, nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
@@ -632,7 +632,7 @@ func TestTPMAttestationVerificationSuccess(t *testing.T) {
 			pcc := attestationTestUnpackResponse(t, testAttestationTPMResponses[i])
 			clientDataHash := sha256.Sum256(pcc.Raw.AttestationResponse.ClientDataJSON)
 
-			attestationType, _, err := attestationFormatValidationHandlerTPM(pcc.Response.AttestationObject, clientDataHash[:], nil)
+			attestationType, _, err := attestationFormatValidationHandlerTPM(pcc.Response.AttestationObject, clientDataHash[:], nil, AttestationPolicy{})
 			require.NoError(t, err)
 
 			assert.Equal(t, "attca", attestationType)
@@ -721,7 +721,7 @@ func TestTPMAttestationVerificationFailAttStatement(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(tc.att, nil, nil)
+			attestationType, x5cs, err := attestationFormatValidationHandlerTPM(tc.att, nil, nil, AttestationPolicy{})
 
 			assert.Equal(t, tc.attestationType, attestationType)
 			assert.Equal(t, tc.x5cs, x5cs)
@@ -832,7 +832,7 @@ func TestTPMAttestationVerificationFailPubArea(t *testing.T) {
 				},
 			}
 
-			attestationType, _, err := attestationFormatValidationHandlerTPM(att, nil, nil)
+			attestationType, _, err := attestationFormatValidationHandlerTPM(att, nil, nil, AttestationPolicy{})
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
 			} else {
@@ -919,7 +919,7 @@ func TestTPMAttestationVerificationRSAExponent(t *testing.T) {
 			}
 
 			require.NotPanics(t, func() {
-				attestationType, x5cs, aerr := attestationFormatValidationHandlerTPM(att, nil, nil)
+				attestationType, x5cs, aerr := attestationFormatValidationHandlerTPM(att, nil, nil, AttestationPolicy{})
 
 				assert.Empty(t, attestationType)
 				assert.Nil(t, x5cs)
@@ -1003,7 +1003,7 @@ func TestTPMAttestationVerificationFailCertInfo(t *testing.T) {
 			}
 
 			att.AttStatement[stmtCertInfo] = tpm2.Marshal(tc.certInfo)
-			attestationType, _, err := attestationFormatValidationHandlerTPM(att, nil, nil)
+			attestationType, _, err := attestationFormatValidationHandlerTPM(att, nil, nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
@@ -1107,7 +1107,7 @@ func TestTPMAttestationVerificationFailX5c(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			att.AttStatement[stmtX5C] = tc.x5c
-			attestationType, _, err := attestationFormatValidationHandlerTPM(att, nil, nil)
+			attestationType, _, err := attestationFormatValidationHandlerTPM(att, nil, nil, AttestationPolicy{})
 
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -169,7 +169,7 @@ func (ccr CredentialCreationResponse) Parse() (pcc *ParsedCredentialCreationData
 // Verify the Client and Attestation data.
 //
 // Specification: §7.1. Registering a New Credential (https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential)
-func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, mds metadata.Provider, credParams []CredentialParameter) (clientDataHash []byte, err error) {
+func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, mds metadata.Provider, credParams []CredentialParameter, policy AttestationPolicy) (clientDataHash []byte, err error) {
 	// Handles steps 3 through 6 - Verifying the Client Data against the Relying Party's stored data.
 	if err = pcc.Response.CollectedClientData.Verify(storedChallenge, CreateCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin); err != nil {
 		return nil, err
@@ -185,7 +185,7 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingP
 
 	// We do the above step while parsing and decoding the CredentialCreationResponse
 	// Handle steps 9 through 14 - This verifies the attestation object.
-	if err = pcc.Response.AttestationObject.Verify(relyingPartyID, clientDataHash, verifyUser, verifyUserPresence, mds, credParams); err != nil {
+	if err = pcc.Response.AttestationObject.Verify(relyingPartyID, clientDataHash, verifyUser, verifyUserPresence, mds, credParams, policy); err != nil {
 		return clientDataHash, err
 	}
 

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -270,7 +270,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				Raw:                       tc.fields.Raw,
 			}
 
-			actual, err := pcc.Verify(tc.args.storedChallenge.String(), tc.args.relyingPartyID, tc.args.relyingPartyOrigin, nil, TopOriginExplicitVerificationMode, false, tc.args.verifyUser, false, nil, tc.args.credParams)
+			actual, err := pcc.Verify(tc.args.storedChallenge.String(), tc.args.relyingPartyID, tc.args.relyingPartyOrigin, nil, TopOriginExplicitVerificationMode, false, tc.args.verifyUser, false, nil, tc.args.credParams, AttestationPolicy{})
 
 			assert.Equal(t, tc.expected, actual)
 

--- a/protocol/specification_vectors_e2e_test.go
+++ b/protocol/specification_vectors_e2e_test.go
@@ -236,8 +236,9 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 			credParams:                  []CredentialParameter{{Type: PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
 			rpTopOriginVerificationMode: TopOriginExplicitVerificationMode,
 			// Both authorization lists of this vector are empty sequences, so it satisfies neither the origin nor the
-			// purpose requirement of §8.4. The origin is reported as it is the first of the two in the specification.
-			err: "Attestation certificate extensions contains authorization list with origin not equal KM_ORIGIN_GENERATED",
+			// purpose requirement of §8.4 under either scope. The origin is reported as it is the first of the two in
+			// the specification, and the teeEnforced list is named as the zero policy selects that scope.
+			err: "Attestation certificate extensions contains teeEnforced authorization list with origin not equal KM_ORIGIN_GENERATED",
 		},
 		{
 			// §16.15 Apple Anonymous Attestation - ES256 - Top Origin
@@ -275,7 +276,7 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 
 			challenge := base64.RawURLEncoding.EncodeToString(specTestDecodeHex(t, tc.challenge))
 
-			_, err = pcc.Verify(challenge, specTestRPID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, tc.mds, tc.credParams)
+			_, err = pcc.Verify(challenge, specTestRPID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, tc.mds, tc.credParams, AttestationPolicy{})
 
 			if tc.err == "" {
 				assert.NoError(t, err)

--- a/webauthn/credential.go
+++ b/webauthn/credential.go
@@ -172,7 +172,11 @@ func (c *Credential) Descriptor() (descriptor protocol.CredentialDescriptor) {
 // pointer receiver.
 //
 // See [CredentialAttestation] for guidance on persisting these raw values securely.
-func (c *Credential) Verify(mds metadata.Provider) (err error) {
+//
+// The policy carries the Relying Party decisions which §8 leaves to the Relying Party; pass
+// [Config.Attestation] to apply the same policy the registration ceremony applied. Its zero value selects the
+// most restrictive behavior available. See [protocol.AttestationPolicy].
+func (c *Credential) Verify(mds metadata.Provider, policy protocol.AttestationPolicy) (err error) {
 	if mds == nil {
 		return fmt.Errorf("error verifying credential: the metadata provider must be provided but it's nil")
 	}
@@ -197,7 +201,7 @@ func (c *Credential) Verify(mds metadata.Provider) (err error) {
 		clientDataHash = sum[:]
 	}
 
-	if err = attestation.AttestationObject.VerifyAttestation(clientDataHash, mds); err != nil {
+	if err = attestation.AttestationObject.VerifyAttestation(clientDataHash, mds, policy); err != nil {
 		return fmt.Errorf("error verifying credential: error verifying attestation: %w", err)
 	}
 
@@ -210,7 +214,11 @@ func (c *Credential) Verify(mds metadata.Provider) (err error) {
 
 // VerifyAttestationType is a cutdown version of Verify which only does the minimal verification to update the
 // AttestationType if it's unset. For full verification use Verify.
-func (c *Credential) VerifyAttestationType() (err error) {
+//
+// The policy carries the Relying Party decisions which §8 leaves to the Relying Party; pass
+// [Config.Attestation] to apply the same policy the registration ceremony applied. Its zero value selects the
+// most restrictive behavior available. See [protocol.AttestationPolicy].
+func (c *Credential) VerifyAttestationType(policy protocol.AttestationPolicy) (err error) {
 	if c.AttestationType != "" {
 		return nil
 	}
@@ -235,7 +243,7 @@ func (c *Credential) VerifyAttestationType() (err error) {
 		clientDataHash = sum[:]
 	}
 
-	if err = attestation.AttestationObject.VerifyAttestation(clientDataHash, nil); err != nil {
+	if err = attestation.AttestationObject.VerifyAttestation(clientDataHash, nil, policy); err != nil {
 		return fmt.Errorf("error verifying credential: error verifying attestation: %w", err)
 	}
 

--- a/webauthn/credential_test.go
+++ b/webauthn/credential_test.go
@@ -76,7 +76,7 @@ func TestNewCredentialFlags(t *testing.T) {
 }
 
 func TestCredential_Verify(t *testing.T) {
-	assert.EqualError(t, (&Credential{}).Verify(nil), "error verifying credential: the metadata provider must be provided but it's nil")
+	assert.EqualError(t, (&Credential{}).Verify(nil, protocol.AttestationPolicy{}), "error verifying credential: the metadata provider must be provided but it's nil")
 
 	testCases := []struct {
 		name       string
@@ -265,7 +265,7 @@ func TestCredential_Verify(t *testing.T) {
 
 			credential := tc.credential(t)
 
-			err := credential.Verify(provider)
+			err := credential.Verify(provider, protocol.AttestationPolicy{})
 
 			if tc.err == "" {
 				assert.NoError(t, err)
@@ -284,7 +284,7 @@ func TestCredential_Verify_RestoresAttestationType(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := mocks.NewMockMetadataProvider(ctrl)
 
-	require.NoError(t, credential.Verify(provider))
+	require.NoError(t, credential.Verify(provider, protocol.AttestationPolicy{}))
 	assert.Equal(t, "none", credential.AttestationType)
 	assert.Equal(t, "none", credential.AttestationFormat)
 }
@@ -298,7 +298,7 @@ func TestCredential_Verify_LeavesExistingAttestationTypeAlone(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := mocks.NewMockMetadataProvider(ctrl)
 
-	require.NoError(t, credential.Verify(provider))
+	require.NoError(t, credential.Verify(provider, protocol.AttestationPolicy{}))
 	assert.Equal(t, "caller-set-value", credential.AttestationType)
 }
 
@@ -314,7 +314,7 @@ func TestCredential_Verify_RejectsTamperedPublicKey(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		provider := mocks.NewMockMetadataProvider(ctrl)
 
-		err := credential.Verify(provider)
+		err := credential.Verify(provider, protocol.AttestationPolicy{})
 		assert.EqualError(t, err, "error verifying credential: stored public key does not match the credential public key embedded in the attestation object")
 	})
 
@@ -325,7 +325,7 @@ func TestCredential_Verify_RejectsTamperedPublicKey(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		provider := mocks.NewMockMetadataProvider(ctrl)
 
-		err := credential.Verify(provider)
+		err := credential.Verify(provider, protocol.AttestationPolicy{})
 		assert.EqualError(t, err, "error verifying credential: stored public key does not match the credential public key embedded in the attestation object")
 	})
 }
@@ -437,7 +437,7 @@ func TestCredential_VerifyAttestationType(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			credential := tc.credential(t)
 
-			err := credential.VerifyAttestationType()
+			err := credential.VerifyAttestationType(protocol.AttestationPolicy{})
 
 			if tc.err == "" {
 				require.NoError(t, err)

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -151,7 +151,7 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 	var clientDataHash []byte
 
-	if clientDataHash, err = parsedResponse.Verify(session.Challenge, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams); err != nil {
+	if clientDataHash, err = parsedResponse.Verify(session.Challenge, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -88,6 +88,11 @@ type Config struct {
 	// or [github.com/go-webauthn/webauthn/metadata/providers/cached] to create a provider instance.
 	MDS metadata.Provider
 
+	// Attestation configures Relying Party policy for the verification of attestation statements. These are the
+	// decisions §8 of the specification delegates to the Relying Party rather than fixing. The zero value selects
+	// the most restrictive behavior available for each policy it carries.
+	Attestation protocol.AttestationPolicy
+
 	// Filtering configures the filtering of authenticators based on their AAGUIDs. This is useful for enforcing
 	// policy on the authenticators that are available to be registered with the Relying Party.
 	Filtering *FilteringConfig
@@ -171,6 +176,10 @@ func (config *Config) validate() (err error) {
 		config.RPTopOriginVerificationMode = protocol.TopOriginExplicitVerificationMode
 	}
 
+	if config.Attestation.AndroidKey.AuthorizationScope == protocol.AndroidKeyAuthorizationScopeDefault {
+		config.Attestation.AndroidKey.AuthorizationScope = protocol.AndroidKeyAuthorizationScopeTEEEnforced
+	}
+
 	if config.Filtering != nil {
 		if len(config.Filtering.PermittedAAGUIDs) > 0 && len(config.Filtering.ProhibitedAAGUIDs) > 0 {
 			return fmt.Errorf("cannot set both 'PermittedAAGUIDs' and 'ProhibitedAAGUIDs' in the filtering config")
@@ -207,6 +216,11 @@ func (c *Config) GetMetaDataProvider() metadata.Provider {
 	return c.MDS
 }
 
+// GetAttestationPolicy returns the configured attestation verification policy.
+func (c *Config) GetAttestationPolicy() protocol.AttestationPolicy {
+	return c.Attestation
+}
+
 // ConfigProvider is an interface that provides access to the WebAuthn [Config] values. This is useful for
 // implementations that wish to provide configuration from alternative sources.
 type ConfigProvider interface {
@@ -215,6 +229,7 @@ type ConfigProvider interface {
 	GetTopOrigins() []string
 	GetTopOriginVerificationMode() protocol.TopOriginVerificationMode
 	GetMetaDataProvider() metadata.Provider
+	GetAttestationPolicy() protocol.AttestationPolicy
 }
 
 // User is an interface with the Relying Party's User entry and provides the fields and methods needed for WebAuthn

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -19,6 +19,7 @@ func TestConfig_Getters(t *testing.T) {
 		expectedTopOrigins            []string
 		expectedTopOriginVerification protocol.TopOriginVerificationMode
 		expectedMetaDataProviderIsNil bool
+		expectedAttestationPolicy     protocol.AttestationPolicy
 	}{
 		{
 			name: "ShouldReturnAllValues",
@@ -27,12 +28,18 @@ func TestConfig_Getters(t *testing.T) {
 				RPOrigins:                   []string{"https://example.com"},
 				RPTopOrigins:                []string{"https://top.example.com"},
 				RPTopOriginVerificationMode: protocol.TopOriginExplicitVerificationMode,
+				Attestation: protocol.AttestationPolicy{
+					AndroidKey: protocol.AndroidKeyPolicy{AuthorizationScope: protocol.AndroidKeyAuthorizationScopeUnion},
+				},
 			},
 			expectedRPID:                  "example.com",
 			expectedOrigins:               []string{"https://example.com"},
 			expectedTopOrigins:            []string{"https://top.example.com"},
 			expectedTopOriginVerification: protocol.TopOriginExplicitVerificationMode,
 			expectedMetaDataProviderIsNil: true,
+			expectedAttestationPolicy: protocol.AttestationPolicy{
+				AndroidKey: protocol.AndroidKeyPolicy{AuthorizationScope: protocol.AndroidKeyAuthorizationScopeUnion},
+			},
 		},
 		{
 			name: "ShouldReturnDefaults",
@@ -44,6 +51,7 @@ func TestConfig_Getters(t *testing.T) {
 			expectedTopOrigins:            nil,
 			expectedTopOriginVerification: protocol.TopOriginDefaultVerificationMode,
 			expectedMetaDataProviderIsNil: true,
+			expectedAttestationPolicy:     protocol.AttestationPolicy{},
 		},
 	}
 
@@ -53,6 +61,7 @@ func TestConfig_Getters(t *testing.T) {
 			assert.Equal(t, tc.expectedOrigins, tc.config.GetOrigins())
 			assert.Equal(t, tc.expectedTopOrigins, tc.config.GetTopOrigins())
 			assert.Equal(t, tc.expectedTopOriginVerification, tc.config.GetTopOriginVerificationMode())
+			assert.Equal(t, tc.expectedAttestationPolicy, tc.config.GetAttestationPolicy())
 
 			if tc.expectedMetaDataProviderIsNil {
 				assert.Nil(t, tc.config.GetMetaDataProvider())
@@ -178,6 +187,46 @@ func TestConfig_Validate_DefaultsRPTopOriginVerificationModeToExplicit(t *testin
 		require.NoError(t, config.validate())
 		assert.Equal(t, protocol.TopOriginExplicitVerificationMode, config.RPTopOriginVerificationMode)
 	})
+}
+
+func TestConfig_Validate_DefaultsAndroidKeyAuthorizationScopeToTEEEnforced(t *testing.T) {
+	testCases := []struct {
+		name     string
+		scope    protocol.AndroidKeyAuthorizationScope
+		expected protocol.AndroidKeyAuthorizationScope
+	}{
+		{
+			name:     "ShouldCoerceDefaultToTEEEnforced",
+			scope:    protocol.AndroidKeyAuthorizationScopeDefault,
+			expected: protocol.AndroidKeyAuthorizationScopeTEEEnforced,
+		},
+		{
+			name:     "ShouldPreserveExplicitTEEEnforced",
+			scope:    protocol.AndroidKeyAuthorizationScopeTEEEnforced,
+			expected: protocol.AndroidKeyAuthorizationScopeTEEEnforced,
+		},
+		{
+			name:     "ShouldPreserveExplicitUnion",
+			scope:    protocol.AndroidKeyAuthorizationScopeUnion,
+			expected: protocol.AndroidKeyAuthorizationScopeUnion,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &Config{
+				RPID:      "example.com",
+				RPOrigins: []string{"https://example.com"},
+				Attestation: protocol.AttestationPolicy{
+					AndroidKey: protocol.AndroidKeyPolicy{AuthorizationScope: tc.scope},
+				},
+			}
+
+			require.NoError(t, config.validate())
+			assert.Equal(t, tc.expected, config.Attestation.AndroidKey.AuthorizationScope)
+			assert.Equal(t, config.Attestation, config.GetAttestationPolicy())
+		})
+	}
 }
 
 func TestConfig_Validate_FilteringMutuallyExclusive(t *testing.T) {


### PR DESCRIPTION
Introduces AttestationPolicy to carry the attestation verification decisions §8 delegates to the Relying Party, configured on webauthn.Config and threaded through to the format handlers. Its first member selects the Android Key authorization lists the origin and purpose requirements are evaluated against, defaulting to teeEnforced alone so an unset policy accepts only keys generated within a trusted execution environment.

BREAKING CHANGE: AttestationObject.Verify and AttestationObject.VerifyAttestation take an AttestationPolicy, and ConfigProvider requires GetAttestationPolicy.