### PR TITLE
feat(protocol): compound sub-statement scope

### DIFF
--- a/protocol/attestation_compound.go
+++ b/protocol/attestation_compound.go
@@ -2,7 +2,9 @@ package protocol
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -26,14 +28,12 @@ func init() {
 // nonCompoundAttStmt = { $$attStmtType } .within { fmt: text .ne "compound", * any => any }
 //
 // §8.9 leaves the handling of a sub-statement which fails verification, and the number which must succeed, to Relying
-// Party policy. The policy applied here is the strictest available: every sub-statement must verify, and the first
-// failure rejects the attestation.
+// Party policy. The scope carries that decision and the zero value selects the strictest behavior available: every
+// sub-statement must verify, and the first failure rejects the attestation. See [CompoundSubStatementScope].
 //
 // Specification: §8.9. Compound Attestation Statement Forma
 //
 // See: https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation
-//
-//nolint:gocyclo
 func attestationFormatValidationHandlerCompound(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var (
 		aaguid   uuid.UUID
@@ -91,20 +91,25 @@ func attestationFormatValidationHandlerCompound(att AttestationObject, clientDat
 		}
 	}
 
+	// The trust paths are not conveyed to the caller. Each is validated against the Metadata Service by the
+	// verification below alongside the format and attestation type it belongs to, which a single chain can't describe
+	// for more than one sub-statement, and the paths of independent sub-statements joined together describe no real
+	// chain.
+	if policy.Compound.SubStatementScope.any() {
+		return compoundVerifySubStatementsAny(att, attStmts, clientDataHash, mds, policy, aaguid)
+	}
+
+	return compoundVerifySubStatementsAll(att, attStmts, clientDataHash, mds, policy, aaguid)
+}
+
+// compoundVerifySubStatementsAll verifies every sub-statement, rejecting the attestation on the first which fails.
+//
+// This is the behavior of [CompoundSubStatementScopeAll].
+func compoundVerifySubStatementsAll(att AttestationObject, attStmts []NonCompoundAttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy, aaguid uuid.UUID) (attestationType string, x5cs []any, err error) {
 	for i, attStmt := range attStmts {
-		object := AttestationObject{
-			Format:       attStmt.Format,
-			AttStatement: attStmt.AttStatement,
-			AuthData:     att.AuthData,
-			RawAuthData:  att.RawAuthData,
-		}
+		var subAttType string
 
-		var (
-			cx5cs      []any
-			subAttType string
-		)
-
-		if subAttType, cx5cs, err = attestationRegistry[AttestationFormat(object.Format)](object, clientDataHash, mds, policy); err != nil {
+		if subAttType, err = compoundVerifySubStatement(att, attStmt, clientDataHash, mds, policy, aaguid); err != nil {
 			return "", nil, err
 		}
 
@@ -113,18 +118,88 @@ func attestationFormatValidationHandlerCompound(att AttestationObject, clientDat
 		if i == 0 {
 			attestationType = subAttType
 		}
+	}
 
-		if mds == nil {
+	return attestationType, nil, nil
+}
+
+// compoundVerifySubStatementsAny verifies sub-statements until one of them succeeds, rejecting the attestation only
+// when none can be verified. The sub-statements after the first success are not verified as the scope is satisfied
+// by it, and the failures of the sub-statements before it are conveyed together so the reason the accepted one was
+// reached is not lost.
+//
+// This is the behavior of [CompoundSubStatementScopeAny].
+func compoundVerifySubStatementsAny(att AttestationObject, attStmts []NonCompoundAttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy, aaguid uuid.UUID) (attestationType string, x5cs []any, err error) {
+	var (
+		errs    = make([]error, 0, len(attStmts))
+		reasons = make([]string, 0, len(attStmts))
+	)
+
+	for _, attStmt := range attStmts {
+		var subAttType string
+
+		if subAttType, err = compoundVerifySubStatement(att, attStmt, clientDataHash, mds, policy, aaguid); err != nil {
+			errs = append(errs, err)
+			reasons = append(reasons, fmt.Sprintf("%s: %s", attStmt.Format, compoundSubStatementFailureReason(err)))
+
 			continue
 		}
 
-		if e := ValidateMetadata(context.Background(), mds, aaguid, subAttType, object.Format, cx5cs); e != nil {
-			return "", nil, ErrInvalidAttestation.WithInfo(fmt.Sprintf("Error occurred validating metadata during attestation validation: %+v", e)).WithDetails(e.DevInfo).WithError(e)
-		}
+		// The sub-statement which was verified is the one which describes an attestation which was obtained, so its
+		// type is the value recorded against the credential rather than that of a sub-statement which failed.
+		return subAttType, nil, nil
 	}
 
-	// The trust paths are not conveyed to the caller. Each is validated against the Metadata Service above alongside
-	// the format and attestation type it belongs to, which a single chain can't describe for more than one
-	// sub-statement, and the paths of independent sub-statements joined together describe no real chain.
-	return attestationType, nil, nil
+	return "", nil, ErrInvalidAttestation.
+		WithDetails(fmt.Sprintf("Compound statement does not contain any sub-statement which could be verified (%s)", strings.Join(reasons, "; "))).
+		WithError(errors.Join(errs...))
+}
+
+// compoundSubStatementFailureReason describes the failure of a sub-statement for the aggregate error of the any
+// scope. The details of an [Error] are preferred as they name the specific failure, falling back to the debug
+// information and then the type so that a failed sub-statement is never described by an empty string.
+func compoundSubStatementFailureReason(err error) string {
+	var e *Error
+
+	if !errors.As(err, &e) {
+		return err.Error()
+	}
+
+	switch {
+	case e.Details != "":
+		return e.Details
+	case e.DevInfo != "":
+		return e.DevInfo
+	default:
+		return e.Type
+	}
+}
+
+// compoundVerifySubStatement performs the verification procedure of a single sub-statement and validates the trust
+// path it produces against the Metadata Service. A sub-statement is verified in full or not at all, so a scope which
+// tolerates a failure treats a sub-statement whose trust path the Metadata Service rejects the same as one whose
+// verification procedure fails.
+func compoundVerifySubStatement(att AttestationObject, attStmt NonCompoundAttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy, aaguid uuid.UUID) (attestationType string, err error) {
+	object := AttestationObject{
+		Format:       attStmt.Format,
+		AttStatement: attStmt.AttStatement,
+		AuthData:     att.AuthData,
+		RawAuthData:  att.RawAuthData,
+	}
+
+	var cx5cs []any
+
+	if attestationType, cx5cs, err = attestationRegistry[AttestationFormat(object.Format)](object, clientDataHash, mds, policy); err != nil {
+		return "", err
+	}
+
+	if mds == nil {
+		return attestationType, nil
+	}
+
+	if e := ValidateMetadata(context.Background(), mds, aaguid, attestationType, object.Format, cx5cs); e != nil {
+		return "", ErrInvalidAttestation.WithInfo(fmt.Sprintf("Error occurred validating metadata during attestation validation: %+v", e)).WithDetails(e.DevInfo).WithError(e)
+	}
+
+	return attestationType, nil
 }

--- a/protocol/attestation_compound_test.go
+++ b/protocol/attestation_compound_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/go-webauthn/webauthn/testing/mocks"
 )
 
+const (
+	typePacked      = "packed-type"
+	typeApple       = "apple-type"
+	fmtUnregistered = "definitely-not-registered"
+)
+
 func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 	t.Run("ShouldReturnValidationErrors", func(t *testing.T) {
 		withFreshAttestationRegistry(t)
@@ -155,7 +161,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 				name: "ShouldRejectUnsupportedSubStatementFmt",
 				mutate: func(a AttestationObject) AttestationObject {
 					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: "definitely-not-registered", stmtAttStmt: map[string]any{}},
+						map[string]any{stmtFmt: fmtUnregistered, stmtAttStmt: map[string]any{}},
 						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
 					}
 
@@ -208,7 +214,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 				rawAuth: att.RawAuthData,
 			})
 
-			return "packed-type", []any{[]byte("cert1")}, nil
+			return typePacked, []any{[]byte("cert1")}, nil
 		}
 
 		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
@@ -219,7 +225,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 				rawAuth: att.RawAuthData,
 			})
 
-			return "apple-type", []any{[]byte("cert2")}, nil
+			return typeApple, []any{[]byte("cert2")}, nil
 		}
 
 		auth := AuthenticatorData{
@@ -251,7 +257,7 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 
 		// §8.9 returns any combination of the outputs of the successful verification procedures. The type of the
 		// first sub-statement is conveyed so the credential isn't recorded as carrying no attestation.
-		assert.Equal(t, "packed-type", gotType)
+		assert.Equal(t, typePacked, gotType)
 		assert.Nil(t, gotX5Cs)
 
 		require.Len(t, calls, 2)
@@ -278,13 +284,13 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (string, []any, error) {
 			calls = append(calls, call{format: att.Format, policy: policy})
 
-			return "packed-type", nil, nil
+			return typePacked, nil, nil
 		}
 
 		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (string, []any, error) {
 			calls = append(calls, call{format: att.Format, policy: policy})
 
-			return "apple-type", nil, nil
+			return typeApple, nil, nil
 		}
 
 		att := AttestationObject{
@@ -463,7 +469,267 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 	})
 }
 
+func TestAttestationFormatValidationHandlerCompoundSubStatementScope(t *testing.T) {
+	var (
+		policyAll = AttestationPolicy{Compound: CompoundPolicy{SubStatementScope: CompoundSubStatementScopeAll}}
+		policyAny = AttestationPolicy{Compound: CompoundPolicy{SubStatementScope: CompoundSubStatementScopeAny}}
+	)
+
+	t.Run("ShouldAcceptWhenALaterSubStatementVerifies", func(t *testing.T) {
+		errPacked := ErrInvalidAttestation.WithDetails("packed sub-statement failed")
+
+		register := func(t *testing.T) {
+			t.Helper()
+
+			withFreshAttestationRegistry(t)
+
+			attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+				return "", nil, errPacked
+			}
+
+			attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+				return typeApple, nil, nil
+			}
+		}
+
+		t.Run("Any", func(t *testing.T) {
+			register(t)
+
+			// The type recorded against the credential is that of the sub-statement which was verified, not that of
+			// the first sub-statement which the all scope conveys.
+			attestationType, x5cs, err := attestationFormatValidationHandlerCompound(compoundScopeTestAttestation(nil), []byte("hash"), nil, policyAny)
+			require.NoError(t, err)
+			assert.Equal(t, typeApple, attestationType)
+			assert.Nil(t, x5cs)
+		})
+
+		t.Run("All", func(t *testing.T) {
+			register(t)
+
+			_, _, err := attestationFormatValidationHandlerCompound(compoundScopeTestAttestation(nil), []byte("hash"), nil, policyAll)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, errPacked))
+		})
+	})
+
+	t.Run("ShouldNotVerifySubStatementsAfterTheFirstSuccess", func(t *testing.T) {
+		withFreshAttestationRegistry(t)
+
+		var packedCalls, appleCalls int
+
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+			packedCalls++
+
+			return typePacked, nil, nil
+		}
+
+		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+			appleCalls++
+
+			return "", nil, ErrInvalidAttestation.WithDetails("apple sub-statement failed")
+		}
+
+		attestationType, _, err := attestationFormatValidationHandlerCompound(compoundScopeTestAttestation(nil), []byte("hash"), nil, policyAny)
+		require.NoError(t, err)
+
+		assert.Equal(t, typePacked, attestationType)
+		assert.Equal(t, 1, packedCalls)
+		assert.Equal(t, 0, appleCalls)
+	})
+
+	// A sub-statement which verifies but whose trust path the Metadata Service rejects hasn't been verified in full,
+	// so the any scope must move on to the next sub-statement rather than accept it or reject the attestation.
+	t.Run("ShouldTreatAMetadataFailureAsASubStatementFailure", func(t *testing.T) {
+		u := uuid.New()
+
+		newProvider := func(t *testing.T) metadata.Provider {
+			t.Helper()
+
+			ctrl := gomock.NewController(t)
+
+			mds := mocks.NewMockMetadataProvider(ctrl)
+
+			entry := &metadata.Entry{
+				MetadataStatement: metadata.Statement{
+					AttestationTypes: metadata.AuthenticatorAttestationTypes{metadata.BasicFull},
+				},
+			}
+
+			mds.EXPECT().GetEntry(gomock.Any(), gomock.Any()).Return(entry, nil).AnyTimes()
+			mds.EXPECT().GetValidateAttestationTypes(gomock.Any()).Return(true).AnyTimes()
+			mds.EXPECT().GetValidateStatus(gomock.Any()).Return(false).AnyTimes()
+			mds.EXPECT().GetValidateTrustAnchor(gomock.Any()).Return(false).AnyTimes()
+
+			return mds
+		}
+
+		register := func(t *testing.T) {
+			t.Helper()
+
+			withFreshAttestationRegistry(t)
+
+			// The surrogate type isn't one the metadata entry above declares, so this sub-statement verifies but is
+			// rejected by ValidateMetadata.
+			attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+				return string(metadata.BasicSurrogate), nil, nil
+			}
+
+			attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+				return string(metadata.BasicFull), nil, nil
+			}
+		}
+
+		t.Run("Any", func(t *testing.T) {
+			register(t)
+
+			attestationType, _, err := attestationFormatValidationHandlerCompound(compoundScopeTestAttestation(u[:]), []byte("hash"), newProvider(t), policyAny)
+			require.NoError(t, err)
+			assert.Equal(t, string(metadata.BasicFull), attestationType)
+		})
+
+		t.Run("All", func(t *testing.T) {
+			register(t)
+
+			_, _, err := attestationFormatValidationHandlerCompound(compoundScopeTestAttestation(u[:]), []byte("hash"), newProvider(t), policyAll)
+			require.Error(t, err)
+
+			protoErr, ok := err.(*Error)
+			require.True(t, ok)
+
+			assert.Equal(t, ErrInvalidAttestation.Type, protoErr.Type)
+			assert.Contains(t, protoErr.DevInfo, "Error occurred validating metadata")
+		})
+	})
+
+	t.Run("ShouldJoinTheFailuresWhenNoSubStatementVerifies", func(t *testing.T) {
+		withFreshAttestationRegistry(t)
+
+		var (
+			errPacked = ErrInvalidAttestation.WithDetails("packed sub-statement failed")
+			errApple  = ErrInvalidAttestation.WithDetails("apple sub-statement failed")
+		)
+
+		attestationRegistry[AttestationFormatPacked] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+			return "", nil, errPacked
+		}
+
+		attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+			return "", nil, errApple
+		}
+
+		attestationType, x5cs, err := attestationFormatValidationHandlerCompound(compoundScopeTestAttestation(nil), []byte("hash"), nil, policyAny)
+		require.Error(t, err)
+
+		assert.Empty(t, attestationType)
+		assert.Nil(t, x5cs)
+
+		protoErr, ok := err.(*Error)
+		require.True(t, ok)
+
+		assert.Equal(t, ErrInvalidAttestation.Type, protoErr.Type)
+
+		// Every sub-statement is named alongside its reason so the failure of the set can be diagnosed without
+		// re-running the verification of each one.
+		assert.Contains(t, protoErr.Details, "packed: packed sub-statement failed")
+		assert.Contains(t, protoErr.Details, "apple: apple sub-statement failed")
+
+		assert.True(t, errors.Is(err, errPacked))
+		assert.True(t, errors.Is(err, errApple))
+	})
+
+	// The scope applies to the outcome of the verification procedures and not to the syntax of the statement, so a
+	// sub-statement which can't be verified at all is rejected regardless of the scope in effect.
+	t.Run("ShouldRejectUnsupportedSubStatementFormatUnderEveryScope", func(t *testing.T) {
+		for _, tc := range []struct {
+			name   string
+			policy AttestationPolicy
+		}{
+			{name: "All", policy: policyAll},
+			{name: "Any", policy: policyAny},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				withFreshAttestationRegistry(t)
+
+				attestationRegistry[AttestationFormatApple] = func(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (string, []any, error) {
+					return typeApple, nil, nil
+				}
+
+				att := compoundScopeTestAttestation(nil)
+				att.AttStatement[stmtAttStmt] = []any{
+					map[string]any{stmtFmt: fmtUnregistered, stmtAttStmt: map[string]any{}},
+					map[string]any{stmtFmt: string(AttestationFormatApple), stmtAttStmt: map[string]any{}},
+				}
+
+				_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, tc.policy)
+				require.Error(t, err)
+
+				protoErr, ok := err.(*Error)
+				require.True(t, ok)
+
+				assert.Equal(t, ErrAttestationFormat.Type, protoErr.Type)
+				assert.Contains(t, protoErr.DevInfo, "unsupported")
+			})
+		}
+	})
+}
+
+func TestCompoundSubStatementFailureReason(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "ShouldUseTheDetails",
+			err:      ErrInvalidAttestation.WithDetails("the details").WithInfo("the info"),
+			expected: "the details",
+		},
+		{
+			name:     "ShouldFallbackToTheDevInfo",
+			err:      ErrInvalidAttestation.WithDetails("").WithInfo("the info"),
+			expected: "the info",
+		},
+		{
+			name:     "ShouldFallbackToTheType",
+			err:      ErrInvalidAttestation.WithDetails("").WithInfo(""),
+			expected: ErrInvalidAttestation.Type,
+		},
+		{
+			name:     "ShouldUseTheErrorOfANonProtocolError",
+			err:      errors.New("some other error"),
+			expected: "some other error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, compoundSubStatementFailureReason(tc.err))
+		})
+	}
+}
+
 // Supporting functions.
+
+// compoundScopeTestAttestation returns a compound attestation with a packed and an apple sub-statement, in that
+// order, which the scope tests register handlers for individually.
+func compoundScopeTestAttestation(aaguid []byte) AttestationObject {
+	if aaguid == nil {
+		aaguid = make([]byte, 0)
+	}
+
+	return AttestationObject{
+		Format: string(AttestationFormatCompound),
+		AuthData: AuthenticatorData{
+			AttData: AttestedCredentialData{AAGUID: aaguid},
+		},
+		AttStatement: map[string]any{
+			stmtAttStmt: []any{
+				map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+				map[string]any{stmtFmt: string(AttestationFormatApple), stmtAttStmt: map[string]any{}},
+			},
+		},
+	}
+}
 
 func withFreshAttestationRegistry(t *testing.T) {
 	t.Helper()

--- a/protocol/attestation_policy.go
+++ b/protocol/attestation_policy.go
@@ -6,6 +6,9 @@ package protocol
 type AttestationPolicy struct {
 	// AndroidKey configures the Android Key Attestation Statement Format verification procedure.
 	AndroidKey AndroidKeyPolicy
+
+	// Compound configures the Compound Attestation Statement Format verification procedure.
+	Compound CompoundPolicy
 }
 
 // AndroidKeyPolicy configures the Android Key Attestation Statement Format verification procedure.
@@ -48,4 +51,51 @@ const (
 // against teeEnforced alone so that an unset or malformed policy is the restrictive one.
 func (s AndroidKeyAuthorizationScope) union() bool {
 	return s == AndroidKeyAuthorizationScopeUnion
+}
+
+// CompoundPolicy configures the Compound Attestation Statement Format verification procedure.
+//
+// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+type CompoundPolicy struct {
+	// SubStatementScope selects the sub-statements of the compound attestation which must be verified for the
+	// attestation to be accepted.
+	SubStatementScope CompoundSubStatementScope
+}
+
+// CompoundSubStatementScope selects the sub-statements of a compound attestation which must be verified for the
+// attestation to be accepted.
+//
+// §8.9 assigns this choice to the Relying Party: the handling of a sub-statement which fails verification, and the
+// number of sub-statements which must succeed, are matters of Relying Party policy.
+//
+// The scope applies only to the outcome of the verification procedures. The syntax of the compound statement itself
+// is not a matter of policy, so a statement which doesn't satisfy the §8.9 CDDL, nests a compound sub-statement, or
+// names a format this library doesn't implement is rejected under every scope.
+//
+// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+type CompoundSubStatementScope int
+
+const (
+	// CompoundSubStatementScopeDefault is the zero value of [CompoundSubStatementScope] and has no matching rule in
+	// §8.9. It evaluates as [CompoundSubStatementScopeAll] wherever it is used. webauthn.Config rewrites it to that
+	// explicit constant during validation, so a Relying Party can tell an unset field apart from a deliberate choice
+	// of the same scope.
+	CompoundSubStatementScopeDefault CompoundSubStatementScope = iota
+
+	// CompoundSubStatementScopeAll requires every sub-statement to be verified, and rejects the attestation on the
+	// first sub-statement which fails.
+	CompoundSubStatementScopeAll
+
+	// CompoundSubStatementScopeAny requires a single sub-statement to be verified, and rejects the attestation only
+	// when none of them can be. A sub-statement is verified when its format's verification procedure succeeds and
+	// the trust path it produces is accepted by the Metadata Service, so a failure of either is tolerated provided
+	// another sub-statement satisfies both.
+	CompoundSubStatementScopeAny
+)
+
+// any returns true when the scope accepts the attestation on a single verified sub-statement. Every other value,
+// including the zero value and any value outside the defined set, requires all of them so that an unset or malformed
+// policy is the restrictive one.
+func (s CompoundSubStatementScope) any() bool {
+	return s == CompoundSubStatementScopeAny
 }

--- a/protocol/attestation_policy_test.go
+++ b/protocol/attestation_policy_test.go
@@ -44,9 +44,50 @@ func TestAndroidKeyAuthorizationScopeUnion(t *testing.T) {
 	}
 }
 
+func TestCompoundSubStatementScopeAny(t *testing.T) {
+	testCases := []struct {
+		name     string
+		scope    CompoundSubStatementScope
+		expected bool
+	}{
+		{
+			// The zero value must resolve to the restrictive branch so a policy which was never passed through
+			// config validation is still safe.
+			name:     "ShouldTreatDefaultAsAll",
+			scope:    CompoundSubStatementScopeDefault,
+			expected: false,
+		},
+		{
+			name:     "ShouldTreatAllAsAll",
+			scope:    CompoundSubStatementScopeAll,
+			expected: false,
+		},
+		{
+			name:     "ShouldTreatAnyAsAny",
+			scope:    CompoundSubStatementScopeAny,
+			expected: true,
+		},
+		{
+			// A value outside the defined set resolves to the restrictive branch rather than the permissive one.
+			name:     "ShouldTreatUnknownAsAll",
+			scope:    CompoundSubStatementScope(99),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.scope.any())
+		})
+	}
+}
+
 func TestAttestationPolicyZeroValue(t *testing.T) {
 	var policy AttestationPolicy
 
 	assert.Equal(t, AndroidKeyAuthorizationScopeDefault, policy.AndroidKey.AuthorizationScope)
 	assert.False(t, policy.AndroidKey.AuthorizationScope.union())
+
+	assert.Equal(t, CompoundSubStatementScopeDefault, policy.Compound.SubStatementScope)
+	assert.False(t, policy.Compound.SubStatementScope.any())
 }

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -180,6 +180,10 @@ func (config *Config) validate() (err error) {
 		config.Attestation.AndroidKey.AuthorizationScope = protocol.AndroidKeyAuthorizationScopeTEEEnforced
 	}
 
+	if config.Attestation.Compound.SubStatementScope == protocol.CompoundSubStatementScopeDefault {
+		config.Attestation.Compound.SubStatementScope = protocol.CompoundSubStatementScopeAll
+	}
+
 	if config.Filtering != nil {
 		if len(config.Filtering.PermittedAAGUIDs) > 0 && len(config.Filtering.ProhibitedAAGUIDs) > 0 {
 			return fmt.Errorf("cannot set both 'PermittedAAGUIDs' and 'ProhibitedAAGUIDs' in the filtering config")

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -229,6 +229,46 @@ func TestConfig_Validate_DefaultsAndroidKeyAuthorizationScopeToTEEEnforced(t *te
 	}
 }
 
+func TestConfig_Validate_DefaultsCompoundSubStatementScopeToAll(t *testing.T) {
+	testCases := []struct {
+		name     string
+		scope    protocol.CompoundSubStatementScope
+		expected protocol.CompoundSubStatementScope
+	}{
+		{
+			name:     "ShouldCoerceDefaultToAll",
+			scope:    protocol.CompoundSubStatementScopeDefault,
+			expected: protocol.CompoundSubStatementScopeAll,
+		},
+		{
+			name:     "ShouldPreserveExplicitAll",
+			scope:    protocol.CompoundSubStatementScopeAll,
+			expected: protocol.CompoundSubStatementScopeAll,
+		},
+		{
+			name:     "ShouldPreserveExplicitAny",
+			scope:    protocol.CompoundSubStatementScopeAny,
+			expected: protocol.CompoundSubStatementScopeAny,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &Config{
+				RPID:      "example.com",
+				RPOrigins: []string{"https://example.com"},
+				Attestation: protocol.AttestationPolicy{
+					Compound: protocol.CompoundPolicy{SubStatementScope: tc.scope},
+				},
+			}
+
+			require.NoError(t, config.validate())
+			assert.Equal(t, tc.expected, config.Attestation.Compound.SubStatementScope)
+			assert.Equal(t, config.Attestation, config.GetAttestationPolicy())
+		})
+	}
+}
+
 func TestConfig_Validate_FilteringMutuallyExclusive(t *testing.T) {
 	aaguidA := uuid.MustParse("00000000-0000-0000-0000-00000000000a")
 	aaguidB := uuid.MustParse("00000000-0000-0000-0000-00000000000b")


### PR DESCRIPTION
Adds the compound attestation policy which selects the sub-statements §8.9 requires to be verified for the attestation to be accepted, either all of them or any one of them, with the zero value evaluating as all so an unset policy remains the strictest behavior available. A sub-statement counts as verified only when its format's verification procedure succeeds and the trust path it produces is accepted by the Metadata Service, so the any scope tolerates a failure of either provided another sub-statement satisfies both, and conveys the attestation type of the sub-statement which was verified rather than that of one which failed. When no sub-statement can be verified the failures are conveyed together, each named alongside its format, and joined so the underlying errors remain reachable.

The scope applies only to the outcome of the verification procedures. A statement which does not satisfy the §8.9 CDDL, nests a compound sub-statement, or names an unsupported format is rejected under every scope.