### PR TITLE
feat(protocol): ecdsa attestation signature encoding policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.5
 require (
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-viper/mapstructure/v2 v2.5.0
-	github.com/go-webauthn/x v0.2.7
+	github.com/go-webauthn/x v0.2.8
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-tpm v0.9.8
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
-github.com/go-webauthn/x v0.2.7 h1:3JLJ0z4OpZfu7J7xe860sMl3rZwYt5xBBad0WRmAD2I=
-github.com/go-webauthn/x v0.2.7/go.mod h1:mdH0BXq0eKmAtBc7QTr37Yv+qGfsVf/ai8M3R+aXyUE=
+github.com/go-webauthn/x v0.2.8 h1:x7whGNJdgDJzJ06uItJjiqvneS0ljcvT3HGkgL+8g3M=
+github.com/go-webauthn/x v0.2.8/go.mod h1:mdH0BXq0eKmAtBc7QTr37Yv+qGfsVf/ai8M3R+aXyUE=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-tpm v0.9.8 h1:slArAR9Ft+1ybZu0lBwpSmpwhRXaa85hWtMinMyRAWo=

--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -83,7 +83,7 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 
 	if sigAlg := webauthncose.SigAlgFromCOSEAlg(webauthncose.COSEAlgorithmIdentifier(alg)); sigAlg == x509.UnknownSignatureAlgorithm {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Unsupported COSE alg: %d", alg))
-	} else if err = credCert.CheckSignature(sigAlg, signatureData, sig); err != nil {
+	} else if err = attestationCertCheckSignature(credCert, sigAlg, signatureData, sig, policy.Signature); err != nil {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err)).WithError(err)
 	}
 
@@ -99,7 +99,7 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 	// as each selects the digest from the algorithm it carries.
 	var valid bool
 
-	if valid, err = webauthncose.VerifySignature(credentialPublicKey, signatureData, sig); err != nil {
+	if valid, err = attestationKeyVerifySignature(credentialPublicKey, signatureData, sig, policy.Signature); err != nil {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Error verifying the signature with the credential public key: %+v", err)).WithError(err)
 	} else if !valid {
 		return "", nil, ErrInvalidAttestation.WithDetails("Signature is not valid for the credential public key")

--- a/protocol/attestation_fido_u2f.go
+++ b/protocol/attestation_fido_u2f.go
@@ -30,7 +30,7 @@ import (
 // Specification: §8.6. FIDO U2F Attestation Statement Format
 //
 // See: https://www.w3.org/TR/webauthn/#sctn-fido-u2f-attestation
-func attestationFormatValidationHandlerFIDOU2F(att AttestationObject, clientDataHash []byte, _ metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerFIDOU2F(att AttestationObject, clientDataHash []byte, _ metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	// Signing procedure. Non-normative verification procedure of expected requirement.
 	// If the credential public key of the attested credential is not of algorithm -7 ("ES256"), stop and return an error.
 	var key webauthncose.EC2PublicKeyData
@@ -138,7 +138,7 @@ func attestationFormatValidationHandlerFIDOU2F(att AttestationObject, clientData
 
 	// Step 6. Verify the sig using verificationData and the certificate public key per section 4.1.4 of [SEC1] with
 	// SHA-256 as the hash function used in step two.
-	if err = attCert.CheckSignature(x509.ECDSAWithSHA256, verificationData.Bytes(), sig); err != nil {
+	if err = attestationCertCheckSignature(attCert, x509.ECDSAWithSHA256, verificationData.Bytes(), sig, policy.Signature); err != nil {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err)).WithError(err)
 	}
 

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -38,7 +38,7 @@ func init() {
 // Specification: §8.2. Packed Attestation Statement Format
 //
 // See: https://www.w3.org/TR/webauthn/#sctn-packed-attestation
-func attestationFormatValidationHandlerPacked(att AttestationObject, clientDataHash []byte, mds metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerPacked(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var (
 		alg int64
 		sig []byte
@@ -62,7 +62,7 @@ func attestationFormatValidationHandlerPacked(att AttestationObject, clientDataH
 	// Step 2. If x5c is present, this indicates that the attestation type is not ECDAA.
 	if x5c, ok = att.AttStatement[stmtX5C].([]any); ok {
 		// Handle Basic Attestation steps for the x509 Certificate.
-		return handleBasicAttestation(sig, clientDataHash, att.RawAuthData, att.AuthData.AttData.AAGUID, alg, x5c, mds)
+		return handleBasicAttestation(sig, clientDataHash, att.RawAuthData, att.AuthData.AttData.AAGUID, alg, x5c, mds, policy.Signature)
 	}
 
 	// Step 3. If ecdaaKeyId is present, then the attestation type is ECDAA.
@@ -74,13 +74,13 @@ func attestationFormatValidationHandlerPacked(att AttestationObject, clientDataH
 	}
 
 	// Step 4. If neither x5c nor ecdaaKeyId is present, self attestation is in use.
-	return handleSelfAttestation(alg, att.AuthData.AttData.CredentialPublicKey, att.RawAuthData, clientDataHash, sig, mds)
+	return handleSelfAttestation(alg, att.AuthData.AttData.CredentialPublicKey, att.RawAuthData, clientDataHash, sig, mds, policy.Signature)
 }
 
 // Handle the attestation steps laid out in the basic format.
 //
 //nolint:gocyclo
-func handleBasicAttestation(sig, clientDataHash, authData, aaguid []byte, alg int64, x5c []any, _ metadata.Provider) (attestationType string, x5cs []any, err error) {
+func handleBasicAttestation(sig, clientDataHash, authData, aaguid []byte, alg int64, x5c []any, _ metadata.Provider, policy SignaturePolicy) (attestationType string, x5cs []any, err error) {
 	// Step 2.1. Verify that sig is a valid signature over the concatenation of authenticatorData
 	// and clientDataHash using the attestation public key in attestnCert with the algorithm specified in alg.
 	var attestnCert *x509.Certificate
@@ -113,7 +113,7 @@ func handleBasicAttestation(sig, clientDataHash, authData, aaguid []byte, alg in
 
 	if sigAlg := webauthncose.SigAlgFromCOSEAlg(webauthncose.COSEAlgorithmIdentifier(alg)); sigAlg == x509.UnknownSignatureAlgorithm {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Unsupported COSE alg: %d", alg))
-	} else if err = attestnCert.CheckSignature(sigAlg, signatureData, sig); err != nil {
+	} else if err = attestationCertCheckSignature(attestnCert, sigAlg, signatureData, sig, policy); err != nil {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err)).WithError(err)
 	}
 
@@ -194,7 +194,7 @@ func handleECDAAAttestation(sig, clientDataHash, ecdaaKeyID []byte, _ metadata.P
 	return "Packed (ECDAA)", nil, ErrNotSpecImplemented
 }
 
-func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, sig []byte, _ metadata.Provider) (attestationType string, x5cs []any, err error) {
+func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, sig []byte, _ metadata.Provider, policy SignaturePolicy) (attestationType string, x5cs []any, err error) {
 	verificationData := append(authData, clientDataHash...) //nolint:gocritic // This is intentional.
 
 	var (
@@ -224,7 +224,7 @@ func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, sig []by
 
 	// §4.2 Verify that sig is a valid signature over the concatenation of authenticatorData and
 	// clientDataHash using the credential public key with alg.
-	if valid, err = webauthncose.VerifySignature(key, verificationData, sig); err != nil {
+	if valid, err = attestationKeyVerifySignature(key, verificationData, sig, policy); err != nil {
 		return "", nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Error verifying the signature: %+v", err)).WithError(err)
 	} else if !valid {
 		return "", nil, ErrInvalidAttestation.WithDetails("Unable to verify signature")

--- a/protocol/attestation_packed_test.go
+++ b/protocol/attestation_packed_test.go
@@ -143,7 +143,7 @@ func TestPackedFormat_BasicAttestationErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := handleBasicAttestation([]byte("sig"), []byte("hash"), []byte("auth"), []byte("aaguid"), tc.alg, tc.x5c, nil)
+			_, _, err := handleBasicAttestation([]byte("sig"), []byte("hash"), []byte("auth"), []byte("aaguid"), tc.alg, tc.x5c, nil, SignaturePolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -238,7 +238,7 @@ func TestPackedFormat_BasicAttestationSignatureAndTimeErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := handleBasicAttestation(tc.sig, clientDataHash, authData, nil, tc.alg, tc.x5c, nil)
+			_, _, err := handleBasicAttestation(tc.sig, clientDataHash, authData, nil, tc.alg, tc.x5c, nil, SignaturePolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -270,7 +270,7 @@ func TestPackedFormat_SelfAttestationErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, err := handleSelfAttestation(tc.alg, tc.pub, []byte("auth"), []byte("hash"), []byte("sig"), nil)
+			_, _, err := handleSelfAttestation(tc.alg, tc.pub, []byte("auth"), []byte("hash"), []byte("sig"), nil, SignaturePolicy{})
 			require.EqualError(t, err, tc.err)
 		})
 	}
@@ -447,7 +447,7 @@ func TestPackedFormat_BasicAttestationCertRequirements(t *testing.T) {
 
 			x5c := []any{certDER}
 
-			_, _, err = handleBasicAttestation(sig, clientDataHash, authData, nil, int64(webauthncose.AlgES256), x5c, nil)
+			_, _, err = handleBasicAttestation(sig, clientDataHash, authData, nil, int64(webauthncose.AlgES256), x5c, nil, SignaturePolicy{})
 			require.EqualError(t, err, tc.err)
 
 			_ = cert

--- a/protocol/attestation_policy.go
+++ b/protocol/attestation_policy.go
@@ -9,6 +9,58 @@ type AttestationPolicy struct {
 
 	// Compound configures the Compound Attestation Statement Format verification procedure.
 	Compound CompoundPolicy
+
+	// Signature configures the verification of the attestation signature, which is common to the formats which
+	// convey one.
+	Signature SignaturePolicy
+}
+
+// SignaturePolicy configures the verification of the attestation signature.
+type SignaturePolicy struct {
+	// ECDSAEncoding selects the ASN.1 encodings which are accepted for an ECDSA attestation signature.
+	ECDSAEncoding ECDSASignatureEncoding
+}
+
+// ECDSASignatureEncoding selects the ASN.1 encodings which are accepted for an ECDSA attestation signature.
+//
+// §8 requires the attestation signature to be valid under the algorithm the attestation statement names, and the
+// registered ECDSA algorithms are defined over the DER encoding. Some authenticators nonetheless emit a signature
+// whose integers carry the padding BER permits and DER forbids, which a conforming verifier rejects. Tolerating
+// that encoding is a deviation from the specification rather than a choice §8 delegates, so it's offered here as a
+// Relying Party decision with the conforming behavior as the default.
+type ECDSASignatureEncoding int
+
+const (
+	// ECDSASignatureEncodingDefault is the zero value of [ECDSASignatureEncoding]. It evaluates as
+	// [ECDSASignatureEncodingDER] wherever it is used. webauthn.Config rewrites it to that explicit constant during
+	// validation, so a Relying Party can tell an unset field apart from a deliberate choice of the same encoding.
+	ECDSASignatureEncodingDefault ECDSASignatureEncoding = iota
+
+	// ECDSASignatureEncodingDER accepts only the DER encoding, which is the encoding the specification requires.
+	ECDSASignatureEncodingDER
+
+	// ECDSASignatureEncodingBER additionally accepts a signature whose integers are encoded under BER, by decoding
+	// it and re-encoding the two integers it carries as DER before verification. Verification itself is unchanged:
+	// the same signature over the same data by the same key is required, and only the encoding the verifier is
+	// handed differs.
+	//
+	// The relaxation is confined to the minimal encoding requirement DER places on an INTEGER. A signature which is
+	// not a SEQUENCE of exactly two positive integers, which carries a non-minimal or indefinite length, or which
+	// has trailing data is rejected under this encoding as it is under [ECDSASignatureEncodingDER]. A signature
+	// which cannot be decoded fails the attestation rather than being passed on to be verified unchanged.
+	//
+	// This is insecure and not recommended. Accepting a non-DER signature makes the encoding of an attestation
+	// signature malleable, in that byte sequences which are not equal verify against the same attestation, and it
+	// accepts an authenticator which does not conform to the specification. Select it only where a population of
+	// authenticators known to emit such signatures has to be supported.
+	ECDSASignatureEncodingBER
+)
+
+// ber returns true when the encoding accepts an ECDSA signature whose integers are encoded under BER. Every other
+// value, including the zero value and any value outside the defined set, accepts DER alone so that an unset or
+// malformed policy is the conforming one.
+func (e ECDSASignatureEncoding) ber() bool {
+	return e == ECDSASignatureEncodingBER
 }
 
 // AndroidKeyPolicy configures the Android Key Attestation Statement Format verification procedure.

--- a/protocol/attestation_signature.go
+++ b/protocol/attestation_signature.go
@@ -1,0 +1,70 @@
+package protocol
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/go-webauthn/x/encoding/asn1"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
+)
+
+// attestationCertCheckSignature verifies a signature over signed with the public key of cert, applying the encoding
+// the policy selects to the signature beforehand.
+//
+// This is the [x509.Certificate.CheckSignature] of the attestation statement formats which verify their signature
+// against a certificate. That method accepts only a DER encoded ECDSA signature and offers no way to relax it, so a
+// signature the policy admits under another encoding is normalized to DER before it's handed over. Verification
+// itself is left to the standard library so that the encoding is the only thing the policy alters.
+func attestationCertCheckSignature(cert *x509.Certificate, algo x509.SignatureAlgorithm, signed, sig []byte, policy SignaturePolicy) (err error) {
+	if sig, err = attestationSignatureEncode(cert.PublicKey, sig, policy); err != nil {
+		return err
+	}
+
+	return cert.CheckSignature(algo, signed, sig)
+}
+
+// attestationKeyVerifySignature verifies a signature over signed with a credential public key parsed from its COSE
+// encoding, applying the encoding the policy selects to the signature beforehand.
+//
+// This is the [webauthncose.VerifySignature] of the attestation statement formats which verify their signature
+// against the credential public key, and exists so that the two ways an attestation signature is verified accept the
+// same set of encodings under the same policy.
+func attestationKeyVerifySignature(key any, signed, sig []byte, policy SignaturePolicy) (valid bool, err error) {
+	if sig, err = attestationSignatureEncode(key, sig, policy); err != nil {
+		return false, err
+	}
+
+	return webauthncose.VerifySignature(key, signed, sig)
+}
+
+// attestationSignatureEncode returns the signature in the encoding the verifiers require, which is DER for an ECDSA
+// signature and the signature unaltered for every other key type.
+//
+// The signature is returned unaltered unless the policy admits an encoding a verifier doesn't, so the conforming
+// policy reaches the verifier with exactly the bytes the authenticator produced. The key selects whether the
+// signature is an ECDSA one, as that's what determines how the verifier will decode it.
+func attestationSignatureEncode(key any, sig []byte, policy SignaturePolicy) (encoded []byte, err error) {
+	if !policy.ECDSAEncoding.ber() || !attestationSignatureKeyIsECDSA(key) {
+		return sig, nil
+	}
+
+	if encoded, err = asn1.NormalizeECDSASignature(sig); err != nil {
+		return nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Signature validation error: %+v", err)).WithError(err)
+	}
+
+	return encoded, nil
+}
+
+// attestationSignatureKeyIsECDSA returns true when a signature made with the key is an ASN.1 encoded ECDSA
+// signature. It accepts both the standard library key of a certificate and the credential public key produced by
+// the COSE parser, as the signature of an attestation is verified against either.
+func attestationSignatureKeyIsECDSA(key any) bool {
+	switch key.(type) {
+	case *ecdsa.PublicKey, ecdsa.PublicKey, webauthncose.EC2PublicKeyData, *webauthncose.EC2PublicKeyData:
+		return true
+	default:
+		return false
+	}
+}

--- a/protocol/attestation_signature_test.go
+++ b/protocol/attestation_signature_test.go
@@ -1,0 +1,299 @@
+package protocol
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/x/encoding/asn1"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
+)
+
+func TestAttestationCertCheckSignature(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	require.NoError(t, err)
+
+	cert := testSignatureCert(t, key)
+
+	signed := []byte("authenticator data and client data hash")
+	digest := sha256.Sum256(signed)
+
+	der, err := ecdsa.SignASN1(rand.Reader, key, digest[:])
+
+	require.NoError(t, err)
+
+	ber := testSignatureBER(t, der)
+
+	require.NotEqual(t, der, ber)
+
+	testCases := []struct {
+		name     string
+		encoding ECDSASignatureEncoding
+		sig      []byte
+		err      string
+	}{
+		{
+			"ShouldAcceptDERUnderDefault",
+			ECDSASignatureEncodingDefault,
+			der,
+			"",
+		},
+		{
+			"ShouldAcceptDERUnderDER",
+			ECDSASignatureEncodingDER,
+			der,
+			"",
+		},
+		{
+			"ShouldAcceptDERUnderBER",
+			ECDSASignatureEncodingBER,
+			der,
+			"",
+		},
+		{
+			"ShouldRejectBERUnderDefault",
+			ECDSASignatureEncodingDefault,
+			ber,
+			"x509: ECDSA verification failure",
+		},
+		{
+			"ShouldRejectBERUnderDER",
+			ECDSASignatureEncodingDER,
+			ber,
+			"x509: ECDSA verification failure",
+		},
+		{
+			"ShouldAcceptBERUnderBER",
+			ECDSASignatureEncodingBER,
+			ber,
+			"",
+		},
+		{
+			// A signature the normalizer can't decode fails the attestation rather than being passed on to the
+			// verifier unchanged, so that enabling the encoding never widens what is accepted beyond BER integers.
+			"ShouldRejectUndecodableUnderBER",
+			ECDSASignatureEncodingBER,
+			[]byte{0x30, 0x03, 0x02, 0x01},
+			"Signature validation error: asn1: syntax error: data truncated",
+		},
+		{
+			// A signature of a valid encoding but the wrong value is still rejected, as only the encoding is relaxed.
+			"ShouldRejectWrongSignatureUnderBER",
+			ECDSASignatureEncodingBER,
+			testSignatureBER(t, mustSignASN1(t, key, sha256.Sum256([]byte("different data")))),
+			"x509: ECDSA verification failure",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err = attestationCertCheckSignature(cert, x509.ECDSAWithSHA256, signed, tc.sig, SignaturePolicy{ECDSAEncoding: tc.encoding})
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+		})
+	}
+}
+
+func mustSignASN1(t *testing.T, key *ecdsa.PrivateKey, digest [32]byte) []byte {
+	t.Helper()
+
+	sig, err := ecdsa.SignASN1(rand.Reader, key, digest[:])
+
+	require.NoError(t, err)
+
+	return sig
+}
+
+// TestAttestationCertCheckSignatureShouldNotAlterRSA checks that the encoding has no effect on a signature which
+// isn't an ASN.1 ECDSA signature, as the normalizer would otherwise be handed a PKCS #1 v1.5 signature.
+func TestAttestationCertCheckSignatureShouldNotAlterRSA(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+
+	require.NoError(t, err)
+
+	cert := testSignatureCert(t, key)
+
+	signed := []byte("authenticator data and client data hash")
+	digest := sha256.Sum256(signed)
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+
+	require.NoError(t, err)
+
+	for _, encoding := range []ECDSASignatureEncoding{ECDSASignatureEncodingDefault, ECDSASignatureEncodingDER, ECDSASignatureEncodingBER} {
+		assert.NoError(t, attestationCertCheckSignature(cert, x509.SHA256WithRSA, signed, sig, SignaturePolicy{ECDSAEncoding: encoding}))
+	}
+}
+
+// TestAttestationKeyVerifySignature checks that a signature verified against the credential public key accepts the
+// same encodings under the same policy as one verified against a certificate, so that the two checks an attestation
+// format may perform can't disagree.
+func TestAttestationKeyVerifySignature(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	require.NoError(t, err)
+
+	credentialPublicKey := webauthncose.EC2PublicKeyData{
+		PublicKeyData: webauthncose.PublicKeyData{
+			KeyType:   int64(webauthncose.EllipticKey),
+			Algorithm: int64(webauthncose.AlgES256),
+		},
+		Curve:  int64(webauthncose.P256),
+		XCoord: padP256Coord(key.X),
+		YCoord: padP256Coord(key.Y),
+	}
+
+	signed := []byte("authenticator data and client data hash")
+	digest := sha256.Sum256(signed)
+
+	der := mustSignASN1(t, key, digest)
+	ber := testSignatureBER(t, der)
+
+	testCases := []struct {
+		name     string
+		encoding ECDSASignatureEncoding
+		sig      []byte
+		valid    bool
+		err      string
+	}{
+		{"ShouldAcceptDERUnderDefault", ECDSASignatureEncodingDefault, der, true, ""},
+		{"ShouldAcceptDERUnderBER", ECDSASignatureEncodingBER, der, true, ""},
+		{"ShouldRejectBERUnderDefault", ECDSASignatureEncodingDefault, ber, false, "Signature invalid or not provided"},
+		{"ShouldAcceptBERUnderBER", ECDSASignatureEncodingBER, ber, true, ""},
+		{"ShouldRejectUndecodableUnderBER", ECDSASignatureEncodingBER, []byte{0x30, 0x03, 0x02, 0x01}, false, "Signature validation error: asn1: syntax error: data truncated"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			valid, err := attestationKeyVerifySignature(credentialPublicKey, signed, tc.sig, SignaturePolicy{ECDSAEncoding: tc.encoding})
+
+			assert.Equal(t, tc.valid, valid)
+
+			if tc.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err)
+			}
+		})
+	}
+}
+
+// TestAttestationSignaturePolicyGatesBasicAttestation checks the policy reaches a format handler and gates only the
+// signature step of it, by observing that a BER signature fails the signature check under the default policy and
+// gets past it to the certificate requirements under the BER encoding.
+func TestAttestationSignaturePolicyGatesBasicAttestation(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+
+	require.NoError(t, err)
+
+	var (
+		authData       = []byte("authenticator data")
+		clientDataHash = []byte("client data hash")
+	)
+
+	digest := sha256.Sum256(append(append([]byte{}, authData...), clientDataHash...))
+
+	ber := testSignatureBER(t, mustSignASN1(t, key, digest))
+
+	// Under the default policy the BER signature fails the signature check.
+	_, _, err = handleBasicAttestation(ber, clientDataHash, authData, nil, int64(webauthncose.AlgES256), []any{certDER}, nil, SignaturePolicy{})
+
+	require.EqualError(t, err, "Signature validation error: x509: ECDSA verification failure")
+
+	// Under the BER encoding the same signature passes it and the handler proceeds to the §8.2.1 certificate
+	// requirements, which this certificate does not meet.
+	_, _, err = handleBasicAttestation(ber, clientDataHash, authData, nil, int64(webauthncose.AlgES256), []any{certDER}, nil, SignaturePolicy{ECDSAEncoding: ECDSASignatureEncodingBER})
+
+	require.EqualError(t, err, "Attestation Certificate Country Code is invalid")
+}
+
+func testSignatureShortFormLen(t *testing.T, n int) byte {
+	t.Helper()
+
+	require.Less(t, n, 0x80)
+
+	return byte(n) //nolint:gosec // The length is bounds checked above.
+}
+
+func testSignatureBER(t *testing.T, der []byte) []byte {
+	t.Helper()
+
+	var signature asn1.ECDSASignature
+
+	rest, err := asn1.Unmarshal(der, &signature)
+
+	require.NoError(t, err)
+	require.Empty(t, rest)
+
+	pad := func(i *big.Int) []byte {
+		var (
+			content []byte
+			err     error
+		)
+
+		content, err = asn1.Marshal(i)
+
+		require.NoError(t, err)
+
+		// The minimal encoding of an integer of the size carried by a signature has a short form length, so its
+		// content octets follow the two octets of its tag and length.
+		octets := append([]byte{0x00}, content[2:]...)
+
+		return append([]byte{0x02, testSignatureShortFormLen(t, len(octets))}, octets...)
+	}
+
+	body := append(pad(signature.R), pad(signature.S)...)
+
+	return append([]byte{0x30, testSignatureShortFormLen(t, len(body))}, body...)
+}
+
+func testSignatureCert(t *testing.T, key crypto.Signer) *x509.Certificate {
+	t.Helper()
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+
+	require.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(der)
+
+	require.NoError(t, err)
+
+	return cert
+}

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -43,7 +43,7 @@ import (
 // See: https://www.w3.org/TR/webauthn/#sctn-tpm-attestation
 //
 //nolint:gocyclo
-func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash []byte, _ metadata.Provider, _ AttestationPolicy) (attestationType string, x5cs []any, err error) {
+func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash []byte, _ metadata.Provider, policy AttestationPolicy) (attestationType string, x5cs []any, err error) {
 	var statement *tpm2AttStatement
 
 	if statement, err = newTPM2AttStatement(att.AttStatement); err != nil {
@@ -187,7 +187,7 @@ func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash
 
 	if sigAlg := webauthncose.SigAlgFromCOSEAlg(coseAlg); sigAlg == x509.UnknownSignatureAlgorithm {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Unsupported COSE alg: %d", statement.Algorithm))
-	} else if err = aikCert.CheckSignature(sigAlg, statement.CertInfo, statement.Signature); err != nil {
+	} else if err = attestationCertCheckSignature(aikCert, sigAlg, statement.CertInfo, statement.Signature, policy.Signature); err != nil {
 		return "", nil, ErrAttestationFormat.WithDetails(fmt.Sprintf("Signature validation error: %+v", err))
 	}
 

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -176,13 +176,7 @@ func (config *Config) validate() (err error) {
 		config.RPTopOriginVerificationMode = protocol.TopOriginExplicitVerificationMode
 	}
 
-	if config.Attestation.AndroidKey.AuthorizationScope == protocol.AndroidKeyAuthorizationScopeDefault {
-		config.Attestation.AndroidKey.AuthorizationScope = protocol.AndroidKeyAuthorizationScopeTEEEnforced
-	}
-
-	if config.Attestation.Compound.SubStatementScope == protocol.CompoundSubStatementScopeDefault {
-		config.Attestation.Compound.SubStatementScope = protocol.CompoundSubStatementScopeAll
-	}
+	config.validateAttestationPolicy()
 
 	if config.Filtering != nil {
 		if len(config.Filtering.PermittedAAGUIDs) > 0 && len(config.Filtering.ProhibitedAAGUIDs) > 0 {
@@ -193,6 +187,24 @@ func (config *Config) validate() (err error) {
 	config.validated = true
 
 	return nil
+}
+
+// validateAttestationPolicy rewrites each zero value of the attestation policy to the explicit constant it evaluates
+// as, so a Relying Party can tell an unset field apart from a deliberate choice of the same behavior. Every default
+// is the most restrictive behavior the policy offers, which for the encoding of a signature is the one the
+// specification requires.
+func (config *Config) validateAttestationPolicy() {
+	if config.Attestation.AndroidKey.AuthorizationScope == protocol.AndroidKeyAuthorizationScopeDefault {
+		config.Attestation.AndroidKey.AuthorizationScope = protocol.AndroidKeyAuthorizationScopeTEEEnforced
+	}
+
+	if config.Attestation.Compound.SubStatementScope == protocol.CompoundSubStatementScopeDefault {
+		config.Attestation.Compound.SubStatementScope = protocol.CompoundSubStatementScopeAll
+	}
+
+	if config.Attestation.Signature.ECDSAEncoding == protocol.ECDSASignatureEncodingDefault {
+		config.Attestation.Signature.ECDSAEncoding = protocol.ECDSASignatureEncodingDER
+	}
 }
 
 // GetRPID returns the configured Relying Party ID.

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -269,6 +269,46 @@ func TestConfig_Validate_DefaultsCompoundSubStatementScopeToAll(t *testing.T) {
 	}
 }
 
+func TestConfig_Validate_DefaultsECDSASignatureEncodingToDER(t *testing.T) {
+	testCases := []struct {
+		name     string
+		encoding protocol.ECDSASignatureEncoding
+		expected protocol.ECDSASignatureEncoding
+	}{
+		{
+			name:     "ShouldCoerceDefaultToDER",
+			encoding: protocol.ECDSASignatureEncodingDefault,
+			expected: protocol.ECDSASignatureEncodingDER,
+		},
+		{
+			name:     "ShouldPreserveExplicitDER",
+			encoding: protocol.ECDSASignatureEncodingDER,
+			expected: protocol.ECDSASignatureEncodingDER,
+		},
+		{
+			name:     "ShouldPreserveExplicitBER",
+			encoding: protocol.ECDSASignatureEncodingBER,
+			expected: protocol.ECDSASignatureEncodingBER,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &Config{
+				RPID:      "example.com",
+				RPOrigins: []string{"https://example.com"},
+				Attestation: protocol.AttestationPolicy{
+					Signature: protocol.SignaturePolicy{ECDSAEncoding: tc.encoding},
+				},
+			}
+
+			require.NoError(t, config.validate())
+			assert.Equal(t, tc.expected, config.Attestation.Signature.ECDSAEncoding)
+			assert.Equal(t, config.Attestation, config.GetAttestationPolicy())
+		})
+	}
+}
+
 func TestConfig_Validate_FilteringMutuallyExclusive(t *testing.T) {
 	aaguidA := uuid.MustParse("00000000-0000-0000-0000-00000000000a")
 	aaguidB := uuid.MustParse("00000000-0000-0000-0000-00000000000b")


### PR DESCRIPTION
Adds the signature attestation policy which selects the ASN.1 encodings accepted for an ECDSA attestation signature, either DER alone or BER as well, with the zero value evaluating as DER so an unset policy accepts only the encoding the specification requires. Some authenticators emit a signature whose integers carry the padding BER permits and DER forbids, which crypto/x509 rejects with no way to relax it, so a signature the policy admits under BER is decoded and its two integers re-encoded as DER before verification. Verification itself is unchanged: the same signature over the same data by the same key is required, and only the encoding handed to the verifier differs.

The relaxation is confined to the minimal encoding requirement DER places on an INTEGER, which is the deviation the BER integer option of go-webauthn/x already permits for assertions. A signature which is not a sequence of exactly two positive integers, which carries a non-minimal or indefinite length, or which trails data after either the signature or the integers within it is rejected under both encodings, and one which cannot be decoded fails the attestation rather than being passed on to be verified unchanged. Re-encoding from the decoded integers emits their minimal form, so the result is a function of those integers alone and a signature which is already DER normalizes itself.

The policy reaches every attestation signature: the certificate check of the android-key, packed, fido-u2f and tpm formats, and the credential public key check of android-key and packed self attestation.