### PR TITLE
fix(webauthn): deprecations and handle check

### DIFF
--- a/protocol/client.go
+++ b/protocol/client.go
@@ -36,6 +36,12 @@ type CollectedClientData struct {
 	CrossOrigin bool `json:"crossOrigin,omitempty"`
 
 	// TokenBinding contains information about the state of the Token Binding protocol.
+	//
+	// WebAuthn Level 3 removes this member from the CollectedClientData dictionary. It is retained because a client
+	// implementing Level 1 or Level 2 may still include it, and a member present in the client data has to be
+	// modelled to be validated; it is not something a Relying Party should expect to receive.
+	//
+	// Deprecated: removed from the CollectedClientData dictionary by WebAuthn Level 3.
 	TokenBinding *TokenBinding `json:"tokenBinding,omitempty"`
 
 	// Hint is an opaque field that may be added by the client. Chromium-based browsers include this field to remind
@@ -60,12 +66,18 @@ const (
 // Relying Party. Its absence indicates that the client doesn't support token binding.
 //
 // Specification: §5.8.1. Client Data Used in WebAuthn Signatures (https://www.w3.org/TR/webauthn/#dom-collectedclientdata-tokenbinding)
+//
+// Deprecated: WebAuthn Level 3 removes the tokenBinding member from the CollectedClientData dictionary; see
+// [CollectedClientData.TokenBinding].
 type TokenBinding struct {
 	Status TokenBindingStatus `json:"status"`
 	ID     string             `json:"id,omitempty"`
 }
 
 // TokenBindingStatus represents the state of Token Binding between the client and the Relying Party.
+//
+// Deprecated: WebAuthn Level 3 removes the tokenBinding member from the CollectedClientData dictionary; see
+// [CollectedClientData.TokenBinding].
 type TokenBindingStatus string
 
 const (
@@ -79,6 +91,10 @@ const (
 
 	// NotSupported indicates token binding not supported
 	// when communicating with the Relying Party.
+	//
+	// This value is accepted but has not been a member of the TokenBindingStatus enumeration since WebAuthn Level 1,
+	// which is why it is not rejected: a client which still sends it is behaving as an older level of the
+	// specification allowed, and failing the ceremony over an advisory member would serve no purpose.
 	NotSupported TokenBindingStatus = "not-supported"
 )
 

--- a/protocol/const.go
+++ b/protocol/const.go
@@ -35,6 +35,19 @@ const (
 	DefaultChallengeLength = 32
 )
 
+const (
+	// MinimumUserHandleLength defines the minimum length of the user handle, i.e. the user entity id. A client
+	// throws a TypeError when the length of the user handle falls outside these bounds.
+	//
+	// Specification: §5.1.3. Create a New Credential (https://www.w3.org/TR/webauthn-3/#sctn-createCredential)
+	MinimumUserHandleLength = 1
+
+	// MaximumUserHandleLength defines the maximum length of the user handle, i.e. the user entity id.
+	//
+	// Specification: §5.4.3. User Account Parameters for Credential Generation (https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialuserentity)
+	MaximumUserHandleLength = 64
+)
+
 var (
 	// internalRemappedAuthenticatorTransport handles remapping of AuthenticatorTransport values. Specifically it is
 	// intentional on remapping only transports that never made recommendation but are being used in the wild. It

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -234,6 +234,22 @@ const (
 	AttestationFormatNone AttestationFormat = none
 )
 
+// PublicKeyCredentialHints represents an entry of the hints member, which conveys the Relying Party's belief about
+// how the user will satisfy the request, in descending order of preference.
+//
+// The IDL types the hints member as a sequence of strings rather than as this enumeration, and requires clients to
+// ignore values they do not recognise, so values are deliberately not validated against the constants below: a
+// Relying Party may send a hint ratified after this release, or one a particular user agent understands. Clients
+// also ignore the second and later appearances of a repeated hint.
+//
+// Hints may contradict the authenticator attachment and the transports of the allowed credentials. Where they do,
+// a client which implements hints gives the hints precedence; see
+// [PublicKeyCredentialHints.AuthenticatorAttachment] for how a registration ceremony pairs the two for the benefit
+// of clients which do not.
+//
+// WebAuthn Level 3.
+//
+// Specification: §5.8.7. User-agent Hints Enumeration (https://www.w3.org/TR/webauthn-3/#enum-hints)
 type PublicKeyCredentialHints string
 
 const (
@@ -262,6 +278,26 @@ const (
 	// authenticatorAttachment SHOULD be set to cross-platform.
 	PublicKeyCredentialHintHybrid PublicKeyCredentialHints = "hybrid"
 )
+
+// AuthenticatorAttachment returns the authenticator attachment a Relying Party using this hint during registration
+// SHOULD also set, so user agents which predate hints filter authenticators consistently with the hint. An
+// identifier this library does not model, which includes any hint ratified after this release, returns an empty
+// value rather than a guess.
+//
+// A user agent which does implement hints gives them precedence over the authenticator attachment, so pairing the
+// two cannot narrow a ceremony such a user agent would otherwise honour.
+//
+// Specification: §5.8.7. User-agent Hints Enumeration (https://www.w3.org/TR/webauthn-3/#enum-hints)
+func (h PublicKeyCredentialHints) AuthenticatorAttachment() AuthenticatorAttachment {
+	switch h {
+	case PublicKeyCredentialHintSecurityKey, PublicKeyCredentialHintHybrid:
+		return CrossPlatform
+	case PublicKeyCredentialHintClientDevice:
+		return Platform
+	default:
+		return ""
+	}
+}
 
 func (a *PublicKeyCredentialRequestOptions) GetAllowedCredentialIDs() [][]byte {
 	var allowedCredentialIDs = make([][]byte, len(a.AllowedCredentials))

--- a/protocol/options_test.go
+++ b/protocol/options_test.go
@@ -64,6 +64,26 @@ func TestPublicKeyCredentialRequestOptions_GetAllowedCredentialIDs(t *testing.T)
 	}
 }
 
+func TestPublicKeyCredentialHints_AuthenticatorAttachment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     PublicKeyCredentialHints
+		expected AuthenticatorAttachment
+	}{
+		{"ShouldMapSecurityKeyToCrossPlatform", PublicKeyCredentialHintSecurityKey, CrossPlatform},
+		{"ShouldMapHybridToCrossPlatform", PublicKeyCredentialHintHybrid, CrossPlatform},
+		{"ShouldMapClientDeviceToPlatform", PublicKeyCredentialHintClientDevice, Platform},
+		{"ShouldNotGuessForAnUnknownHint", "future-hint", ""},
+		{"ShouldNotGuessForAnEmptyHint", "", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.AuthenticatorAttachment())
+		})
+	}
+}
+
 func TestCredentialDescriptor_SignalUnknownCredential(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -37,11 +37,6 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		entityUserID any
 	)
 
-	// Specification: §5.1.3. Create a New Credential, step 5 (https://www.w3.org/TR/webauthn-3/#sctn-createCredential)
-	if n := len(user.WebAuthnID()); n < protocol.MinimumUserHandleLength || n > protocol.MaximumUserHandleLength {
-		return nil, nil, fmt.Errorf("error generating credential creation: the user id must be between %d and %d bytes but it has a length of %d", protocol.MinimumUserHandleLength, protocol.MaximumUserHandleLength, n)
-	}
-
 	if challenge, err = protocol.CreateChallenge(); err != nil {
 		return nil, nil, err
 	}
@@ -101,6 +96,15 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		return nil, nil, fmt.Errorf("error generating credential creation: the challenge must be at least 16 bytes")
 	}
 
+	// The user handle is validated after the options have been applied, and the validated value is what the session
+	// records, because a [RegistrationOption] receives the whole creation options and may therefore replace the user
+	// entity id derived from the [User] above.
+	var handle []byte
+
+	if handle, err = userHandle(creation.Response.User.ID); err != nil {
+		return nil, nil, fmt.Errorf("error generating credential creation: %w", err)
+	}
+
 	if creation.Response.Timeout == 0 {
 		switch creation.Response.AuthenticatorSelection.UserVerification {
 		case protocol.VerificationDiscouraged:
@@ -115,7 +119,7 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 	session = &SessionData{
 		Challenge:        creation.Response.Challenge.String(),
 		RelyingPartyID:   creation.Response.RelyingParty.ID,
-		UserID:           user.WebAuthnID(),
+		UserID:           handle,
 		UserVerification: creation.Response.AuthenticatorSelection.UserVerification,
 		Extensions:       creation.Response.Extensions.Session(),
 		CredParams:       creation.Response.Parameters,
@@ -139,11 +143,20 @@ func normalizeCreationOptions(response *protocol.PublicKeyCredentialCreationOpti
 		response.Extensions.AppIDExclude = ""
 	}
 
-	// For compatibility with user agents which predate hints, the attachment the most preferred hint implies is set
-	// when the Relying Party did not select one itself; see
-	// [protocol.PublicKeyCredentialHints.AuthenticatorAttachment].
-	if len(response.Hints) != 0 && response.AuthenticatorSelection.AuthenticatorAttachment == "" {
-		response.AuthenticatorSelection.AuthenticatorAttachment = response.Hints[0].AuthenticatorAttachment()
+	// For compatibility with user agents which predate hints, the attachment implied by the most preferred hint which
+	// implies one is set when the Relying Party did not select an attachment itself; see
+	// [protocol.PublicKeyCredentialHints.AuthenticatorAttachment]. The hints are scanned in order rather than only the
+	// first being consulted because a Relying Party is expected to send a more specific hint ahead of less specific
+	// ones, and the more specific hint may be one this library does not model. The attachment is left unset when no
+	// hint implies one.
+	if response.AuthenticatorSelection.AuthenticatorAttachment == "" {
+		for _, hint := range response.Hints {
+			if attachment := hint.AuthenticatorAttachment(); attachment != "" {
+				response.AuthenticatorSelection.AuthenticatorAttachment = attachment
+
+				break
+			}
+		}
 	}
 }
 

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -37,6 +37,11 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		entityUserID any
 	)
 
+	// Specification: §5.1.3. Create a New Credential, step 5 (https://www.w3.org/TR/webauthn-3/#sctn-createCredential)
+	if n := len(user.WebAuthnID()); n < protocol.MinimumUserHandleLength || n > protocol.MaximumUserHandleLength {
+		return nil, nil, fmt.Errorf("error generating credential creation: the user id must be between %d and %d bytes but it has a length of %d", protocol.MinimumUserHandleLength, protocol.MaximumUserHandleLength, n)
+	}
+
 	if challenge, err = protocol.CreateChallenge(); err != nil {
 		return nil, nil, err
 	}
@@ -105,12 +110,7 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		}
 	}
 
-	// The FIDO AppID Exclusion Extension is only meaningful when the exclude list contains a credential registered
-	// through the legacy FIDO U2F JavaScript API. Pruning here rather than inside the option makes the result
-	// independent of the order the options were supplied in.
-	if !hasU2FCredential(creation.Response.CredentialExcludeList) {
-		creation.Response.Extensions.AppIDExclude = ""
-	}
+	normalizeCreationOptions(&creation.Response)
 
 	session = &SessionData{
 		Challenge:        creation.Response.Challenge.String(),
@@ -127,6 +127,24 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 	}
 
 	return creation, session, nil
+}
+
+// normalizeCreationOptions applies the adjustments which depend on the creation options as a whole. It runs after
+// every [RegistrationOption] has been applied so the result does not depend on the order they were supplied in,
+// which is why neither adjustment lives inside the option that motivates it.
+func normalizeCreationOptions(response *protocol.PublicKeyCredentialCreationOptions) {
+	// The FIDO AppID Exclusion Extension is only meaningful when the exclude list contains a credential registered
+	// through the legacy FIDO U2F JavaScript API.
+	if !hasU2FCredential(response.CredentialExcludeList) {
+		response.Extensions.AppIDExclude = ""
+	}
+
+	// For compatibility with user agents which predate hints, the attachment the most preferred hint implies is set
+	// when the Relying Party did not select one itself; see
+	// [protocol.PublicKeyCredentialHints.AuthenticatorAttachment].
+	if len(response.Hints) != 0 && response.AuthenticatorSelection.AuthenticatorAttachment == "" {
+		response.AuthenticatorSelection.AuthenticatorAttachment = response.Hints[0].AuthenticatorAttachment()
+	}
 }
 
 // FinishRegistration takes the response from the authenticator and client and verify the credential against the user's

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -96,12 +96,11 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		return nil, nil, fmt.Errorf("error generating credential creation: the challenge must be at least 16 bytes")
 	}
 
-	// The user handle is validated after the options have been applied, and the validated value is what the session
-	// records, because a [RegistrationOption] receives the whole creation options and may therefore replace the user
-	// entity id derived from the [User] above.
-	var handle []byte
-
-	if handle, err = userHandle(creation.Response.User.ID); err != nil {
+	// The user handle is validated after the options have been applied because a [RegistrationOption] receives the
+	// whole creation options and may therefore replace the user entity id derived from the [User] above, and it is
+	// the id which is actually sent to the client that has to satisfy the bounds. The session records the id of the
+	// [User] itself rather than this one, as that is what [WebAuthn.CreateCredential] is given to compare it against.
+	if err = validateUserHandle(creation.Response.User.ID); err != nil {
 		return nil, nil, fmt.Errorf("error generating credential creation: %w", err)
 	}
 
@@ -119,7 +118,7 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 	session = &SessionData{
 		Challenge:        creation.Response.Challenge.String(),
 		RelyingPartyID:   creation.Response.RelyingParty.ID,
-		UserID:           handle,
+		UserID:           user.WebAuthnID(),
 		UserVerification: creation.Response.AuthenticatorSelection.UserVerification,
 		Extensions:       creation.Response.Extensions.Session(),
 		CredParams:       creation.Response.Parameters,

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -981,7 +981,8 @@ func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
 // TestBeginRegistrationUserHandleAfterOptions covers the user handle bounds being enforced against the handle which
 // is actually sent to the client. A [RegistrationOption] receives the whole creation options, so one supplied by the
 // caller can replace the user entity id after it has been derived from the [User]; the bounds must hold for that
-// final value, and the session must record it rather than the handle the ceremony started from.
+// final value, while the session must still record the id of the [User], which is what
+// [WebAuthn.CreateCredential] compares it against.
 func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
 	withUserHandle := func(id any) RegistrationOption {
 		return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
@@ -995,6 +996,7 @@ func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
 		name           string
 		encodeAsString bool
 		opts           []RegistrationOption
+		entity         any
 		expected       []byte
 		err            string
 	}{
@@ -1009,15 +1011,17 @@ func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
 			err:  "error generating credential creation: the user id must be between 1 and 64 bytes but it has a length of 65",
 		},
 		{
-			name:     "ShouldRecordAHandleSetByAnOptionInTheSession",
+			name:     "ShouldSendAHandleSetByAnOptionButRecordTheUsersInTheSession",
 			opts:     []RegistrationOption{withUserHandle(protocol.URLEncodedBase64("replacement"))},
-			expected: []byte("replacement"),
+			entity:   protocol.URLEncodedBase64("replacement"),
+			expected: []byte(testUserID),
 		},
 		{
-			name:           "ShouldRecordAStringHandleInTheSession",
+			name:           "ShouldSendAStringHandleSetByAnOptionButRecordTheUsersInTheSession",
 			encodeAsString: true,
 			opts:           []RegistrationOption{withUserHandle("replacement")},
-			expected:       []byte("replacement"),
+			entity:         "replacement",
+			expected:       []byte(testUserID),
 		},
 		{
 			name: "ShouldRejectAHandleOfAnUnusableType",
@@ -1026,6 +1030,7 @@ func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
 		},
 		{
 			name:     "ShouldRecordTheUsersHandleWithoutAnOption",
+			entity:   protocol.URLEncodedBase64(testUserID),
 			expected: []byte(testUserID),
 		},
 	}
@@ -1051,7 +1056,9 @@ func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			require.NotNil(t, creation)
 			require.NotNil(t, session)
+			assert.Equal(t, tc.entity, creation.Response.User.ID)
 			assert.Equal(t, tc.expected, session.UserID)
 		})
 	}

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -940,6 +940,14 @@ func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
 			hints:    []protocol.PublicKeyCredentialHints{"future-hint"},
 			expected: "",
 		},
+		{
+			// A Relying Party is expected to send a more specific hint before less specific ones so a user agent
+			// which does not recognise the former can act on the latter, so an unrecognised leading hint must not
+			// stop a recognised one behind it from supplying the attachment.
+			name:     "ShouldUseTheFirstRecognisedHint",
+			hints:    []protocol.PublicKeyCredentialHints{"future-hint", protocol.PublicKeyCredentialHintSecurityKey},
+			expected: protocol.CrossPlatform,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -966,6 +974,85 @@ func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
 
 			assert.Equal(t, tc.expected, creation.Response.AuthenticatorSelection.AuthenticatorAttachment)
 			assert.Equal(t, tc.hints, creation.Response.Hints)
+		})
+	}
+}
+
+// TestBeginRegistrationUserHandleAfterOptions covers the user handle bounds being enforced against the handle which
+// is actually sent to the client. A [RegistrationOption] receives the whole creation options, so one supplied by the
+// caller can replace the user entity id after it has been derived from the [User]; the bounds must hold for that
+// final value, and the session must record it rather than the handle the ceremony started from.
+func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
+	withUserHandle := func(id any) RegistrationOption {
+		return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
+			cco.User.ID = id
+
+			return nil
+		}
+	}
+
+	testCases := []struct {
+		name           string
+		encodeAsString bool
+		opts           []RegistrationOption
+		expected       []byte
+		err            string
+	}{
+		{
+			name: "ShouldRejectAnEmptyHandleSetByAnOption",
+			opts: []RegistrationOption{withUserHandle(protocol.URLEncodedBase64(nil))},
+			err:  "error generating credential creation: the user id must be between 1 and 64 bytes but it has a length of 0",
+		},
+		{
+			name: "ShouldRejectAnOverlengthHandleSetByAnOption",
+			opts: []RegistrationOption{withUserHandle(protocol.URLEncodedBase64(bytes.Repeat([]byte("a"), 65)))},
+			err:  "error generating credential creation: the user id must be between 1 and 64 bytes but it has a length of 65",
+		},
+		{
+			name:     "ShouldRecordAHandleSetByAnOptionInTheSession",
+			opts:     []RegistrationOption{withUserHandle(protocol.URLEncodedBase64("replacement"))},
+			expected: []byte("replacement"),
+		},
+		{
+			name:           "ShouldRecordAStringHandleInTheSession",
+			encodeAsString: true,
+			opts:           []RegistrationOption{withUserHandle("replacement")},
+			expected:       []byte("replacement"),
+		},
+		{
+			name: "ShouldRejectAHandleOfAnUnusableType",
+			opts: []RegistrationOption{withUserHandle(42)},
+			err:  "error generating credential creation: the user id must be a string, []byte, or protocol.URLEncodedBase64 but it has a type of int",
+		},
+		{
+			name:     "ShouldRecordTheUsersHandleWithoutAnOption",
+			expected: []byte(testUserID),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(&Config{
+				RPID:                 "example.com",
+				RPDisplayName:        "Test Display Name",
+				RPOrigins:            []string{"https://example.com"},
+				EncodeUserIDAsString: tc.encodeAsString,
+			})
+			require.NoError(t, err)
+
+			creation, session, err := w.BeginRegistration(&defaultUser{id: []byte(testUserID)}, tc.opts...)
+
+			if tc.err != "" {
+				assert.Nil(t, creation)
+				assert.Nil(t, session)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.Equal(t, tc.expected, session.UserID)
 		})
 	}
 }

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -894,10 +894,6 @@ func TestBeginRegistrationUserIDLength(t *testing.T) {
 	}
 }
 
-// TestBeginRegistrationHintsSetAuthenticatorAttachment covers the compatibility guidance of §5.8.7, which asks a
-// Relying Party using a hint to also set the authenticator attachment the hint implies so user agents which predate
-// hints behave consistently. A user agent which does implement hints gives them precedence over the attachment, so
-// this cannot narrow a ceremony such a client would otherwise honour.
 func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -941,9 +937,6 @@ func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
 			expected: "",
 		},
 		{
-			// A Relying Party is expected to send a more specific hint before less specific ones so a user agent
-			// which does not recognise the former can act on the latter, so an unrecognised leading hint must not
-			// stop a recognised one behind it from supplying the attachment.
 			name:     "ShouldUseTheFirstRecognisedHint",
 			hints:    []protocol.PublicKeyCredentialHints{"future-hint", protocol.PublicKeyCredentialHintSecurityKey},
 			expected: protocol.CrossPlatform,
@@ -978,11 +971,6 @@ func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
 	}
 }
 
-// TestBeginRegistrationUserHandleAfterOptions covers the user handle bounds being enforced against the handle which
-// is actually sent to the client. A [RegistrationOption] receives the whole creation options, so one supplied by the
-// caller can replace the user entity id after it has been derived from the [User]; the bounds must hold for that
-// final value, while the session must still record the id of the [User], which is what
-// [WebAuthn.CreateCredential] compares it against.
 func TestBeginRegistrationUserHandleAfterOptions(t *testing.T) {
 	withUserHandle := func(id any) RegistrationOption {
 		return func(cco *protocol.PublicKeyCredentialCreationOptions) error {

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -96,7 +96,7 @@ func TestWithRegistrationRelyingPartyID(t *testing.T) {
 			w, err := New(tc.have)
 			assert.NoError(t, err)
 
-			user := &defaultUser{}
+			user := &defaultUser{id: []byte(testUserID)}
 
 			creation, _, err := w.BeginRegistration(user, tc.opts...)
 			if tc.err != "" {
@@ -843,6 +843,131 @@ func TestCreateCredential_RejectsBackupStateWithoutBackupEligibility(t *testing.
 
 	assert.Nil(t, credential)
 	assert.EqualError(t, err, "Backup State Flag is true but Backup Eligible flag is false which is invalid")
+}
+
+func TestBeginRegistrationUserIDLength(t *testing.T) {
+	testCases := []struct {
+		name string
+		id   []byte
+		err  string
+	}{
+		{
+			name: "ShouldRejectEmpty",
+			id:   nil,
+			err:  "error generating credential creation: the user id must be between 1 and 64 bytes but it has a length of 0",
+		},
+		{
+			name: "ShouldAcceptMinimum",
+			id:   bytes.Repeat([]byte("a"), 1),
+		},
+		{
+			name: "ShouldAcceptMaximum",
+			id:   bytes.Repeat([]byte("a"), 64),
+		},
+		{
+			name: "ShouldRejectAboveMaximum",
+			id:   bytes.Repeat([]byte("a"), 65),
+			err:  "error generating credential creation: the user id must be between 1 and 64 bytes but it has a length of 65",
+		},
+	}
+
+	w, err := New(&Config{
+		RPID:          "example.com",
+		RPDisplayName: "Test Display Name",
+		RPOrigins:     []string{"https://example.com"},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			creation, session, err := w.BeginRegistration(&defaultUser{id: tc.id})
+
+			if tc.err != "" {
+				assert.Nil(t, creation)
+				assert.Nil(t, session)
+				assert.EqualError(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+				require.NotNil(t, creation)
+			}
+		})
+	}
+}
+
+// TestBeginRegistrationHintsSetAuthenticatorAttachment covers the compatibility guidance of §5.8.7, which asks a
+// Relying Party using a hint to also set the authenticator attachment the hint implies so user agents which predate
+// hints behave consistently. A user agent which does implement hints gives them precedence over the attachment, so
+// this cannot narrow a ceremony such a client would otherwise honour.
+func TestBeginRegistrationHintsSetAuthenticatorAttachment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hints    []protocol.PublicKeyCredentialHints
+		selected protocol.AuthenticatorAttachment
+		expected protocol.AuthenticatorAttachment
+	}{
+		{
+			name:     "ShouldSetCrossPlatformForSecurityKey",
+			hints:    []protocol.PublicKeyCredentialHints{protocol.PublicKeyCredentialHintSecurityKey},
+			expected: protocol.CrossPlatform,
+		},
+		{
+			name:     "ShouldSetPlatformForClientDevice",
+			hints:    []protocol.PublicKeyCredentialHints{protocol.PublicKeyCredentialHintClientDevice},
+			expected: protocol.Platform,
+		},
+		{
+			name:     "ShouldSetCrossPlatformForHybrid",
+			hints:    []protocol.PublicKeyCredentialHints{protocol.PublicKeyCredentialHintHybrid},
+			expected: protocol.CrossPlatform,
+		},
+		{
+			name:     "ShouldUseTheFirstHint",
+			hints:    []protocol.PublicKeyCredentialHints{protocol.PublicKeyCredentialHintClientDevice, protocol.PublicKeyCredentialHintSecurityKey},
+			expected: protocol.Platform,
+		},
+		{
+			name:     "ShouldNotOverrideAnExplicitAttachment",
+			hints:    []protocol.PublicKeyCredentialHints{protocol.PublicKeyCredentialHintSecurityKey},
+			selected: protocol.Platform,
+			expected: protocol.Platform,
+		},
+		{
+			name:     "ShouldNotSetAnAttachmentWithoutHints",
+			expected: "",
+		},
+		{
+			name:     "ShouldNotSetAnAttachmentForAnUnknownHint",
+			hints:    []protocol.PublicKeyCredentialHints{"future-hint"},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(&Config{
+				RPID:          "example.com",
+				RPDisplayName: "Test Display Name",
+				RPOrigins:     []string{"https://example.com"},
+				AuthenticatorSelection: protocol.AuthenticatorSelection{
+					AuthenticatorAttachment: tc.selected,
+				},
+			})
+			require.NoError(t, err)
+
+			var opts []RegistrationOption
+
+			if len(tc.hints) != 0 {
+				opts = append(opts, WithPublicKeyCredentialHints(tc.hints))
+			}
+
+			creation, _, err := w.BeginRegistration(&defaultUser{id: []byte(testUserID)}, opts...)
+			require.NoError(t, err)
+			require.NotNil(t, creation)
+
+			assert.Equal(t, tc.expected, creation.Response.AuthenticatorSelection.AuthenticatorAttachment)
+			assert.Equal(t, tc.hints, creation.Response.Hints)
+		})
+	}
 }
 
 func TestFinishRegistration_Success(t *testing.T) {

--- a/webauthn/util.go
+++ b/webauthn/util.go
@@ -2,6 +2,7 @@ package webauthn
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/go-webauthn/webauthn/protocol"
 )
@@ -46,6 +47,35 @@ func isCredentialIDInCredentials(credentialID []byte, credentials []Credential) 
 // ptr returns a pointer to the given value.
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// userHandle returns the byte form of a user entity id, having checked it against the user handle bounds. The member
+// is typed as an any because it is encoded either as a base64url string or as a plain string depending on
+// [Config.EncodeUserIDAsString], and because a [RegistrationOption] supplied by the caller may replace it with either
+// form. An id of any other type cannot be measured against the bounds and is rejected rather than passed to the
+// client.
+//
+// A client throws a TypeError when the length of the handle it is given is not between 1 and 64 bytes inclusive, so
+// a ceremony every user agent would reject fails here instead.
+//
+// Specification: §5.1.3. Create a New Credential, step 5 (https://www.w3.org/TR/webauthn-3/#sctn-createCredential)
+func userHandle(id any) (handle []byte, err error) {
+	switch v := id.(type) {
+	case protocol.URLEncodedBase64:
+		handle = v
+	case []byte:
+		handle = v
+	case string:
+		handle = []byte(v)
+	default:
+		return nil, fmt.Errorf("the user id must be a string, []byte, or protocol.URLEncodedBase64 but it has a type of %T", id)
+	}
+
+	if n := len(handle); n < protocol.MinimumUserHandleLength || n > protocol.MaximumUserHandleLength {
+		return nil, fmt.Errorf("the user id must be between %d and %d bytes but it has a length of %d", protocol.MinimumUserHandleLength, protocol.MaximumUserHandleLength, n)
+	}
+
+	return handle, nil
 }
 
 // hasU2FCredential reports whether any of the given descriptors originated from the legacy FIDO U2F JavaScript

--- a/webauthn/util.go
+++ b/webauthn/util.go
@@ -49,17 +49,20 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-// userHandle returns the byte form of a user entity id, having checked it against the user handle bounds. The member
-// is typed as an any because it is encoded either as a base64url string or as a plain string depending on
-// [Config.EncodeUserIDAsString], and because a [RegistrationOption] supplied by the caller may replace it with either
-// form. An id of any other type cannot be measured against the bounds and is rejected rather than passed to the
-// client.
+// validateUserHandle checks a user entity id against the user handle bounds. The member is typed as an any because it
+// is encoded either as a base64url string or as a plain string depending on [Config.EncodeUserIDAsString], and because
+// a [RegistrationOption] supplied by the caller may replace it with either form. An id of any other type cannot be
+// measured against the bounds and is rejected rather than passed to the client.
 //
 // A client throws a TypeError when the length of the handle it is given is not between 1 and 64 bytes inclusive, so
-// a ceremony every user agent would reject fails here instead.
+// a ceremony every user agent would reject fails here instead. The handle itself is not returned because the id which
+// is sent to the client is only ever validated here; the value the ceremony is completed against is the id of the
+// [User], which the caller already holds.
 //
 // Specification: §5.1.3. Create a New Credential, step 5 (https://www.w3.org/TR/webauthn-3/#sctn-createCredential)
-func userHandle(id any) (handle []byte, err error) {
+func validateUserHandle(id any) (err error) {
+	var handle []byte
+
 	switch v := id.(type) {
 	case protocol.URLEncodedBase64:
 		handle = v
@@ -68,14 +71,14 @@ func userHandle(id any) (handle []byte, err error) {
 	case string:
 		handle = []byte(v)
 	default:
-		return nil, fmt.Errorf("the user id must be a string, []byte, or protocol.URLEncodedBase64 but it has a type of %T", id)
+		return fmt.Errorf("the user id must be a string, []byte, or protocol.URLEncodedBase64 but it has a type of %T", id)
 	}
 
 	if n := len(handle); n < protocol.MinimumUserHandleLength || n > protocol.MaximumUserHandleLength {
-		return nil, fmt.Errorf("the user id must be between %d and %d bytes but it has a length of %d", protocol.MinimumUserHandleLength, protocol.MaximumUserHandleLength, n)
+		return fmt.Errorf("the user id must be between %d and %d bytes but it has a length of %d", protocol.MinimumUserHandleLength, protocol.MaximumUserHandleLength, n)
 	}
 
-	return handle, nil
+	return nil
 }
 
 // hasU2FCredential reports whether any of the given descriptors originated from the legacy FIDO U2F JavaScript


### PR DESCRIPTION
This fixes an issue where the handle length was not checked and a few fields were not deprecated when they were from the spec.