### PR TITLE
fix(webauthn): use session relying party id

### DIFF
--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -364,7 +364,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 	shouldVerifyUser := session.UserVerification == protocol.VerificationRequired
 	shouldVerifyUserPresence := true
 
-	rpID := webauthn.Config.RPID
+	rpID := session.GetRelyingPartyID(webauthn.Config.RPID)
 	rpOrigins := webauthn.Config.RPOrigins
 	rpTopOrigins := webauthn.Config.RPTopOrigins
 

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -1393,6 +1393,44 @@ func TestValidateLoginLatchesUserVerified(t *testing.T) {
 	assert.True(t, credential.Flags.BackupState)
 }
 
+func TestValidateLoginUsesSessionRelyingPartyID(t *testing.T) {
+	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
+
+	webauthn := &WebAuthn{
+		Config: &Config{
+			RPID:      "example.com",
+			RPOrigins: []string{"https://example.org"},
+		},
+	}
+
+	userID := []byte(testUserID)
+
+	user := &defaultUser{
+		id: userID,
+		credentials: []Credential{
+			{
+				ID:        credentialID,
+				PublicKey: credPubKey,
+				Flags: CredentialFlags{
+					UserPresent:    true,
+					BackupEligible: true,
+				},
+			},
+		},
+	}
+
+	session := SessionData{
+		UserID:         userID,
+		Challenge:      challenge,
+		RelyingPartyID: "example.org",
+	}
+
+	credential, err := webauthn.ValidateLogin(user, session, parsedResponse)
+	require.NoError(t, err)
+	require.NotNil(t, credential)
+	assert.Equal(t, credentialID, credential.ID)
+}
+
 func TestValidatePasskeyLogin_Full(t *testing.T) {
 	parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256(t)
 

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -164,7 +164,7 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 	var clientDataHash []byte
 
-	if clientDataHash, err = parsedResponse.Verify(session.Challenge, webauthn.Config.RPID, webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
+	if clientDataHash, err = parsedResponse.Verify(session.Challenge, session.GetRelyingPartyID(webauthn.Config.RPID), webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -790,8 +790,34 @@ func TestCreateCredential_Full(t *testing.T) {
 	}
 }
 
-// TestCreateCredential_RejectsBackupStateWithoutBackupEligibility covers §7.1 step 18, which requires the BS bit to
-// be unset when the BE bit is unset. The equivalent assertion step is covered by the login validation.
+func TestCreateCredentialUsesSessionRelyingPartyID(t *testing.T) {
+	body, challenge, credentialID := testRegistrationSpecVectorNoneES256(t)
+
+	parsedResponse, err := protocol.ParseCredentialCreationResponseBytes(body)
+	require.NoError(t, err)
+
+	userID := []byte(testUserID)
+
+	w := &WebAuthn{
+		Config: &Config{
+			RPID:      "example.com",
+			RPOrigins: []string{"https://example.org"},
+		},
+	}
+
+	session := SessionData{
+		Challenge:      challenge,
+		RelyingPartyID: "example.org",
+		UserID:         userID,
+		CredParams:     []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+	}
+
+	credential, err := w.CreateCredential(&defaultUser{id: userID}, session, parsedResponse)
+	require.NoError(t, err)
+	require.NotNil(t, credential)
+	assert.Equal(t, credentialID, credential.ID)
+}
+
 func TestCreateCredential_RejectsBackupStateWithoutBackupEligibility(t *testing.T) {
 	body, challenge, _ := testRegistrationSpecVectorNoneES256Flags(t, protocol.FlagUserPresent|protocol.FlagBackupState|protocol.FlagAttestedCredentialData)
 

--- a/webauthn/types_session.go
+++ b/webauthn/types_session.go
@@ -75,3 +75,18 @@ type SessionData struct {
 	CredParams       []protocol.CredentialParameter          `json:"credParams,omitempty" msg:"params,omitempty"`
 	Mediation        protocol.CredentialMediationRequirement `json:"mediation,omitempty" msg:"cmr,omitempty"`
 }
+
+// GetRelyingPartyID returns the Relying Party ID the ceremony was begun with, which is the value the rpIdHash in the
+// authenticator data must be verified against. The Begin* functions always record it, so it reflects any per-ceremony
+// override applied by [WithRegistrationRelyingPartyID] or [WithLoginRelyingPartyID].
+//
+// The supplied fallback, which callers take from [Config.RPID], is returned when the session carries no Relying Party
+// ID. That is the case for a session encoded before this member existed, and for one a caller constructed directly,
+// neither of which can have used a per-ceremony override.
+func (s SessionData) GetRelyingPartyID(fallback string) string {
+	if len(s.RelyingPartyID) == 0 {
+		return fallback
+	}
+
+	return s.RelyingPartyID
+}

--- a/webauthn/types_session_test.go
+++ b/webauthn/types_session_test.go
@@ -14,6 +14,39 @@ import (
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )
 
+func TestSessionData_GetRelyingPartyID(t *testing.T) {
+	testCases := []struct {
+		name     string
+		session  SessionData
+		fallback string
+		expected string
+	}{
+		{
+			name:     "ShouldUseSessionValue",
+			session:  SessionData{RelyingPartyID: "a.example.com"},
+			fallback: "example.com",
+			expected: "a.example.com",
+		},
+		{
+			name:     "ShouldFallBackWhenSessionValueIsEmpty",
+			session:  SessionData{},
+			fallback: "example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "ShouldFallBackToEmptyWhenNeitherIsSet",
+			session:  SessionData{},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.session.GetRelyingPartyID(tc.fallback))
+		})
+	}
+}
+
 func TestSessionData_MsgpRoundTrip(t *testing.T) {
 	original := newPopulatedSessionData()
 


### PR DESCRIPTION
This fixes an issue where an overridden Relying Party ID set in the session was not honored.