### PR TITLE
fix(protocol): compound attestation sub-statement unmarshalling

### DIFF
--- a/protocol/attestation.go
+++ b/protocol/attestation.go
@@ -78,12 +78,69 @@ type AttestationObject struct {
 	// The attestation statement data sent back if attestation is requested.
 	AttStatement map[string]any `json:"attStmt,omitempty"`
 
+	// SubStatements holds the sub-statements of a compound attestation statement, which §8.9 encodes as an array
+	// rather than as the map every other format uses for its attestation statement. It is populated by
+	// [AttestationObject.UnmarshalCBOR] when, and only when, Format is "compound", and for such an attestation
+	// AttStatement is empty because the wire format carries no map to put there.
+	//
+	// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+	SubStatements []NonCompoundAttestationObject `json:"-"`
+
 	// Type is the attestation type as conveyed by the authenticator, one of the values defined by
 	// [metadata.AuthenticatorAttestationType] (i.e. "basic_full", "basic_surrogate", "attca", "anonca", "none").
 	// It is populated as a side-effect of a successful [AttestationObject.VerifyAttestation]; before that the field
 	// is empty. This field is excluded from serialization because the attestation object wire format does not carry
 	// this value; it is derived by the format-specific verifier.
 	Type string `json:"-"`
+}
+
+// attestationObjectEncoded is the wire form of an [AttestationObject], with the attestation statement left undecoded
+// so it can be decoded as the map every attestation statement format uses or as the array §8.9 defines for the
+// compound format. Which of the two applies is determined by the fmt member of the same map, so the statement cannot
+// be decoded until the rest of the object has been.
+type attestationObjectEncoded struct {
+	RawAuthData  []byte                  `json:"authData"`
+	Format       string                  `json:"fmt"`
+	AttStatement webauthncbor.RawMessage `json:"attStmt,omitempty"`
+}
+
+// UnmarshalCBOR implements the CBOR unmarshalling of an attestation object, decoding the attestation statement
+// according to the attestation statement format the object declares.
+//
+// Every format defined by §8 other than compound encodes its attestation statement as a map, which is decoded into
+// [AttestationObject.AttStatement]. The compound format encodes an array of sub-statements instead, which is decoded
+// into [AttestationObject.SubStatements]. A single field cannot hold both, and the shape is not self-describing to
+// the decoder, hence the two passes.
+//
+// [AttestationObject.AuthData] is not populated here; it is unmarshalled from [AttestationObject.RawAuthData] by the
+// response parser, which is also where the attested credential data is required to be present.
+//
+// The receiver is zeroed first so that decoding into one which already holds an attestation object replaces it
+// rather than adding to it. Only one of the two statement members is written by any given object, the statement is
+// not written at all by an object which carries none, and [AttestationObject.AuthData] and [AttestationObject.Type]
+// are populated after decoding rather than during it, so without this every one of them could outlive the object it
+// describes. Decoding a map into a non-nil map merges into it, so a statement decoded over another would otherwise
+// inherit the members the new one does not carry.
+//
+// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+func (a *AttestationObject) UnmarshalCBOR(data []byte) (err error) {
+	var encoded attestationObjectEncoded
+
+	if err = webauthncbor.Unmarshal(data, &encoded); err != nil {
+		return err
+	}
+
+	*a = AttestationObject{RawAuthData: encoded.RawAuthData, Format: encoded.Format}
+
+	if len(encoded.AttStatement) == 0 {
+		return nil
+	}
+
+	if AttestationFormat(a.Format) == AttestationFormatCompound {
+		return webauthncbor.Unmarshal(encoded.AttStatement, &a.SubStatements)
+	}
+
+	return webauthncbor.Unmarshal(encoded.AttStatement, &a.AttStatement)
 }
 
 // NonCompoundAttestationObject is a subset of [AttestationObject] used within compound attestation statements. Each

--- a/protocol/attestation_compound.go
+++ b/protocol/attestation_compound.go
@@ -37,10 +37,7 @@ func init() {
 func attestationFormatValidationHandlerCompound(att AttestationObject, clientDataHash []byte, mds metadata.Provider, policy AttestationPolicy, signature SignaturePolicy) (attestationType string, x5cs []any, err error) {
 	var (
 		aaguid   uuid.UUID
-		raw      any
 		ok       bool
-		stmts    []any
-		subStmt  map[string]any
 		attStmts []NonCompoundAttestationObject
 	)
 
@@ -50,39 +47,23 @@ func attestationFormatValidationHandlerCompound(att AttestationObject, clientDat
 		}
 	}
 
-	if raw, ok = att.AttStatement[stmtAttStmt]; !ok {
-		return "", nil, ErrInvalidAttestation.WithDetails("Compound statement missing attStmt")
-	}
-
-	if stmts, ok = raw.([]any); !ok {
-		return "", nil, ErrInvalidAttestation.WithDetails("Compound statement attStmt isn't an array")
-	}
-
-	if len(stmts) < 2 {
+	// The sub-statements are decoded from the attStmt array by [AttestationObject.UnmarshalCBOR], which is where the
+	// §8.9 shape is enforced; an attStmt which is absent, or which is not an array, leaves this empty.
+	if len(att.SubStatements) < 2 {
 		return "", nil, ErrInvalidAttestation.WithDetails("Compound statement attStmt isn't an array with at least two other statements")
 	}
 
-	for _, stmt := range stmts {
-		if subStmt, ok = stmt.(map[string]any); !ok {
-			return "", nil, ErrInvalidAttestation.WithDetails("Compound statement attStmt contains one or more items that isn't an object")
-		}
-
-		var attStmt NonCompoundAttestationObject
-
-		if attStmt.Format, ok = subStmt[stmtFmt].(string); !ok {
-			return "", nil, ErrInvalidAttestation.WithDetails("Compound sub-statement does not have a format")
-		}
-
-		if attStmt.AttStatement, ok = subStmt[stmtAttStmt].(map[string]any); !ok {
-			return "", nil, ErrInvalidAttestation.WithDetails("Compound sub-statement does not have an attestation statement")
-		}
-
+	for _, attStmt := range att.SubStatements {
 		switch AttestationFormat(attStmt.Format) {
 		case AttestationFormatCompound:
 			return "", nil, ErrInvalidAttestation.WithDetails("Compound sub-statement has a format of compound which is not allowed")
 		case "":
 			return "", nil, ErrInvalidAttestation.WithDetails("Compound sub-statement has an empty format which is not allowed")
 		default:
+			if attStmt.AttStatement == nil {
+				return "", nil, ErrInvalidAttestation.WithDetails("Compound sub-statement does not have an attestation statement")
+			}
+
 			if _, ok = attestationRegistry[AttestationFormat(attStmt.Format)]; !ok {
 				return "", nil, ErrAttestationFormat.WithInfo(fmt.Sprintf("Attestation sub-statement format %s is unsupported", attStmt.Format))
 			}

--- a/protocol/attestation_compound_e2e_test.go
+++ b/protocol/attestation_compound_e2e_test.go
@@ -1,0 +1,302 @@
+package protocol
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"maps"
+	"testing"
+
+	cbor "github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/metadata"
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+)
+
+// TestCompoundAttestation_SpecShapeDecodes asserts that a compound attestation object encoded as §8.9 defines it —
+// where attStmt is an array of sub-statements rather than a map — survives CBOR decoding and exposes its
+// sub-statements.
+//
+// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+func TestCompoundAttestation_SpecShapeDecodes(t *testing.T) {
+	rawAuthData, packed, _ := compoundE2EPackedSelfVector(t)
+
+	data := compoundE2EEncode(t, rawAuthData, packed, packed)
+
+	var att AttestationObject
+
+	require.NoError(t, webauthncbor.Unmarshal(data, &att))
+
+	assert.Equal(t, string(AttestationFormatCompound), att.Format)
+	assert.Equal(t, rawAuthData, att.RawAuthData)
+
+	require.Len(t, att.SubStatements, 2)
+
+	for i, sub := range att.SubStatements {
+		assert.Equal(t, string(AttestationFormatPacked), sub.Format, "sub-statement %d", i)
+		assert.Equal(t, packed, sub.AttStatement, "sub-statement %d", i)
+	}
+}
+
+// TestCompoundAttestation_SpecShapeVerifies drives a §8.9 conformant compound attestation object through the real
+// registration path: the response parser, then the attestation verification procedure. Both sub-statements are the
+// §16.3 packed self attestation of the shared authenticator data, so both verify against the credential public key
+// that authenticator data carries.
+//
+// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+//
+// Specification: §16.3. ES256 Credential with Self Attestation (https://www.w3.org/TR/webauthn-3/#sctn-test-vectors-packed-self-es256)
+func TestCompoundAttestation_SpecShapeVerifies(t *testing.T) {
+	rawAuthData, packed, clientDataJSON := compoundE2EPackedSelfVector(t)
+
+	response := AuthenticatorAttestationResponse{
+		AuthenticatorResponse: AuthenticatorResponse{ClientDataJSON: clientDataJSON},
+		AttestationObject:     compoundE2EEncode(t, rawAuthData, packed, packed),
+	}
+
+	parsed, err := response.Parse()
+	require.NoError(t, err)
+
+	require.Len(t, parsed.AttestationObject.SubStatements, 2)
+
+	sum := sha256.Sum256(clientDataJSON)
+
+	require.NoError(t, parsed.AttestationObject.VerifyAttestation(sum[:], nil, AttestationPolicy{}, SignaturePolicy{}))
+
+	assert.Equal(t, string(metadata.BasicSurrogate), parsed.AttestationObject.Type)
+}
+
+// TestCompoundAttestation_SpecShapeRejectsUnverifiableSubStatement asserts the default (all) scope still rejects a
+// compound attestation when one of its sub-statements does not verify, now that the statement actually reaches the
+// verification procedure.
+func TestCompoundAttestation_SpecShapeRejectsUnverifiableSubStatement(t *testing.T) {
+	rawAuthData, packed, clientDataJSON := compoundE2EPackedSelfVector(t)
+
+	tampered := maps.Clone(packed)
+
+	signature := bytes.Clone(packed[stmtSignature].([]byte))
+	signature[len(signature)-1] ^= 0xff
+	tampered[stmtSignature] = signature
+
+	var att AttestationObject
+
+	require.NoError(t, webauthncbor.Unmarshal(compoundE2EEncode(t, rawAuthData, packed, tampered), &att))
+
+	sum := sha256.Sum256(clientDataJSON)
+
+	require.Error(t, att.VerifyAttestation(sum[:], nil, AttestationPolicy{}, SignaturePolicy{}))
+}
+
+// TestCompoundAttestation_SpecShapeRejectsMalformedAttStmt asserts the decoder rejects a compound attStmt which is
+// not the array of sub-statement maps §8.9 defines. These are the shapes the verification handler used to be
+// responsible for and which now cannot reach it.
+func TestCompoundAttestation_SpecShapeRejectsMalformedAttStmt(t *testing.T) {
+	rawAuthData, _, _ := compoundE2EPackedSelfVector(t)
+
+	testCases := []struct {
+		name    string
+		attStmt any
+	}{
+		{name: "ShouldRejectAttStmtNotAnArray", attStmt: "nope"},
+		{name: "ShouldRejectAttStmtAsAMap", attStmt: map[string]any{stmtAttStmt: []any{}}},
+		{name: "ShouldRejectAttStmtContainingNonObject", attStmt: []any{123, 456}},
+		{name: "ShouldRejectAttStmtContainingByteString", attStmt: []any{[]byte{0x01}, []byte{0x02}}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := cbor.Marshal(map[string]any{
+				stmtAuthData: rawAuthData,
+				stmtFmt:      string(AttestationFormatCompound),
+				stmtAttStmt:  tc.attStmt,
+			})
+			require.NoError(t, err)
+
+			var att AttestationObject
+
+			require.Error(t, webauthncbor.Unmarshal(data, &att))
+		})
+	}
+}
+
+// TestCompoundAttestation_SpecShapeRejectsArrayForNonCompoundFormat asserts the array shape belongs to the compound
+// format alone: a format which encodes its attestation statement as a map does not silently accept an array.
+func TestCompoundAttestation_SpecShapeRejectsArrayForNonCompoundFormat(t *testing.T) {
+	rawAuthData, _, _ := compoundE2EPackedSelfVector(t)
+
+	data, err := cbor.Marshal(map[string]any{
+		stmtAuthData: rawAuthData,
+		stmtFmt:      string(AttestationFormatPacked),
+		stmtAttStmt:  []any{map[string]any{stmtFmt: string(AttestationFormatPacked)}},
+	})
+	require.NoError(t, err)
+
+	var att AttestationObject
+
+	require.Error(t, webauthncbor.Unmarshal(data, &att))
+}
+
+func TestCompoundAttestation_NestingLimitAdmitsCertificateChain(t *testing.T) {
+	rawAuthData, _, _ := compoundE2EPackedSelfVector(t)
+
+	chained := map[string]any{
+		stmtAlgorithm: int64(-7),
+		stmtSignature: []byte{0x01},
+		stmtX5C:       []any{[]byte{0x02}},
+	}
+
+	var att AttestationObject
+
+	require.NoError(t, webauthncbor.Unmarshal(compoundE2EEncode(t, rawAuthData, chained, chained), &att))
+
+	require.Len(t, att.SubStatements, 2)
+
+	for i, sub := range att.SubStatements {
+		assert.Equal(t, []any{[]byte{0x02}}, sub.AttStatement[stmtX5C], "sub-statement %d", i)
+	}
+}
+
+func TestCompoundAttestation_NestingLimitStillBounded(t *testing.T) {
+	var value any = "leaf"
+
+	for range 6 {
+		value = map[string]any{"a": value}
+	}
+
+	data, err := cbor.Marshal(value)
+	require.NoError(t, err)
+
+	var out any
+
+	require.ErrorContains(t, webauthncbor.Unmarshal(data, &out), "max nested level")
+}
+
+func TestAttestationObjectUnmarshalCBORRejectsMalformedObject(t *testing.T) {
+	rawAuthData, _, _ := compoundE2EPackedSelfVector(t)
+
+	deep := any(map[string]any{stmtAttStmt: []any{map[string]any{stmtAttStmt: map[string]any{stmtX5C: []any{[]byte{0x01}}}}}})
+
+	testCases := []struct {
+		name  string
+		value any
+	}{
+		{name: "ShouldRejectTopLevelArray", value: []any{stmtFmt, string(AttestationFormatNone)}},
+		{name: "ShouldRejectTopLevelByteString", value: []byte{0x01, 0x02}},
+		{name: "ShouldRejectFormatOfTheWrongType", value: map[string]any{stmtAuthData: rawAuthData, stmtFmt: int64(7)}},
+		{name: "ShouldRejectAuthDataOfTheWrongType", value: map[string]any{stmtAuthData: "not bytes", stmtFmt: string(AttestationFormatNone)}},
+		{name: "ShouldRejectObjectExceedingTheNestingLimit", value: map[string]any{stmtAuthData: rawAuthData, stmtFmt: string(AttestationFormatCompound), stmtAttStmt: []any{deep, deep}}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := cbor.Marshal(tc.value)
+			require.NoError(t, err)
+
+			var att AttestationObject
+
+			require.Error(t, webauthncbor.Unmarshal(data, &att))
+		})
+	}
+}
+
+func TestAttestationObjectUnmarshalCBORReusedReceiver(t *testing.T) {
+	rawAuthData, packed, _ := compoundE2EPackedSelfVector(t)
+
+	var att AttestationObject
+
+	require.NoError(t, webauthncbor.Unmarshal(compoundE2EEncode(t, rawAuthData, packed, packed), &att))
+	require.Len(t, att.SubStatements, 2)
+
+	att.Type = "basic_surrogate"
+	att.AuthData = AuthenticatorData{Counter: 42}
+
+	require.NoError(t, webauthncbor.Unmarshal(reuseE2EEncode(t, rawAuthData, string(AttestationFormatPacked), packed), &att))
+
+	assert.Equal(t, string(AttestationFormatPacked), att.Format)
+	assert.Empty(t, att.SubStatements, "sub-statements of the compound object survived into a packed object")
+	assert.Equal(t, packed, att.AttStatement)
+	assert.Empty(t, att.Type, "attestation type of the previous object survived")
+	assert.Zero(t, att.AuthData, "authenticator data of the previous object survived")
+
+	sparse := map[string]any{stmtAlgorithm: int64(-257)}
+
+	require.NoError(t, webauthncbor.Unmarshal(reuseE2EEncode(t, rawAuthData, string(AttestationFormatPacked), sparse), &att))
+	assert.Equal(t, sparse, att.AttStatement, "members of the previous attestation statement were merged into this one")
+
+	// §8.7 gives the none format an empty map as its entire attestation statement, which is the shape the §16.2 test
+	// vector carries, so the statement member is present and the decoder takes its ordinary path. Decoding it over a
+	// populated receiver must not leave the previous statement's members behind.
+	require.NoError(t, webauthncbor.Unmarshal(reuseE2EEncode(t, rawAuthData, string(AttestationFormatNone), map[string]any{}), &att))
+
+	assert.Equal(t, string(AttestationFormatNone), att.Format)
+	assert.Empty(t, att.AttStatement, "attestation statement survived into a none attestation carrying an empty one")
+	assert.Empty(t, att.SubStatements)
+
+	// An object which omits the statement member altogether leaves the decoder early instead, so it has to be
+	// asserted separately and against an equally populated receiver.
+	require.NoError(t, webauthncbor.Unmarshal(reuseE2EEncode(t, rawAuthData, string(AttestationFormatPacked), sparse), &att))
+	require.Equal(t, sparse, att.AttStatement)
+
+	require.NoError(t, webauthncbor.Unmarshal(reuseE2EEncode(t, rawAuthData, string(AttestationFormatNone), nil), &att))
+
+	assert.Equal(t, string(AttestationFormatNone), att.Format)
+	assert.Empty(t, att.AttStatement, "attestation statement survived into an object which carries none")
+	assert.Empty(t, att.SubStatements)
+}
+
+const stmtAuthData = "authData"
+
+func compoundE2EPackedSelfVector(t *testing.T) (rawAuthData []byte, packed map[string]any, clientDataJSON []byte) {
+	t.Helper()
+
+	const (
+		attestationObjectHex = "a363666d74667061636b65646761747453746d74a263616c672663736967584630440220067a20754ab925005dbf378097c92120031581c73228d1fb4f5b881bcd7da98302207fc7b147558c7c0eba3af18bd9d121fa3d3a26d17fe3f220272178f473b6006d68617574684461746158a4bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b55d00000000df850e09db6afbdfab51697791506cfc0020455ef34e2043a87db3d4afeb39bbcb6cc32df9347c789a865ecdca129cbef58ca5010203262001215820eb151c8176b225cc651559fecf07af450fd85802046656b34c18f6cf193843c5225820927b8aa427a2be1b8834d233a2d34f61f13bfd44119c325d5896e183fee484f2"
+		clientDataJSONHex    = "7b2274797065223a22776562617574686e2e637265617465222c226368616c6c656e6765223a2265476e4374334c55745936366b336a506a796e6962506b31716e666644616966715a774c33417032392d55222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73652c22657874726144617461223a22636c69656e74446174614a534f4e206d617920626520657874656e6465642077697468206164646974696f6e616c206669656c647320696e20746865206675747572652c207375636820617320746869733a205539685458764b453255526b4d6e625f307859485667227d"
+	)
+
+	var att AttestationObject
+
+	require.NoError(t, webauthncbor.Unmarshal(specTestDecodeHex(t, attestationObjectHex), &att))
+	require.Equal(t, string(AttestationFormatPacked), att.Format)
+	require.NotEmpty(t, att.AttStatement)
+
+	return att.RawAuthData, att.AttStatement, specTestDecodeHex(t, clientDataJSONHex)
+}
+
+func reuseE2EEncode(t *testing.T, rawAuthData []byte, format string, attStmt map[string]any) []byte {
+	t.Helper()
+
+	object := map[string]any{stmtAuthData: rawAuthData, stmtFmt: format}
+
+	if attStmt != nil {
+		object[stmtAttStmt] = attStmt
+	}
+
+	data, err := cbor.Marshal(object)
+	require.NoError(t, err)
+
+	return data
+}
+
+func compoundE2EEncode(t *testing.T, rawAuthData []byte, statements ...map[string]any) []byte {
+	t.Helper()
+
+	subs := make([]any, len(statements))
+
+	for i, statement := range statements {
+		subs[i] = map[string]any{
+			stmtFmt:     string(AttestationFormatPacked),
+			stmtAttStmt: statement,
+		}
+	}
+
+	data, err := cbor.Marshal(map[string]any{
+		stmtAuthData: rawAuthData,
+		stmtFmt:      string(AttestationFormatCompound),
+		stmtAttStmt:  subs,
+	})
+	require.NoError(t, err)
+
+	return data
+}

--- a/protocol/attestation_compound_test.go
+++ b/protocol/attestation_compound_test.go
@@ -31,11 +31,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 
 		base := AttestationObject{
 			Format: string(AttestationFormatCompound),
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-				},
+			SubStatements: []NonCompoundAttestationObject{
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 			},
 			AuthData: AuthenticatorData{
 				AttData: AttestedCredentialData{
@@ -61,30 +59,23 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 				err:      "Error occurred parsing AAGUID",
 			},
 			{
-				name: "ShouldRejectMissingAttStmt",
+				// An attStmt which is absent, or which is not an array of sub-statements, is rejected by
+				// [AttestationObject.UnmarshalCBOR] and reaches the handler as no sub-statements at all. See
+				// TestCompoundAttestation_SpecShapeRejectsMalformedAttStmt for the decoding side.
+				name: "ShouldRejectNoSubStatements",
 				mutate: func(a AttestationObject) AttestationObject {
-					delete(a.AttStatement, stmtAttStmt)
+					a.SubStatements = nil
 
 					return a
 				},
 				expected: ErrInvalidAttestation.Type,
-				err:      "Compound statement missing attStmt",
-			},
-			{
-				name: "ShouldRejectAttStmtNotArray",
-				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = "nope"
-
-					return a
-				},
-				expected: ErrInvalidAttestation.Type,
-				err:      "Compound statement attStmt isn't an array",
+				err:      "at least two",
 			},
 			{
 				name: "ShouldRejectAttStmtWithLessThanTwoItems",
 				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					a.SubStatements = []NonCompoundAttestationObject{
+						{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 					}
 
 					return a
@@ -93,37 +84,26 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 				err:      "at least two",
 			},
 			{
-				name: "ShouldRejectAttStmtContainingNonObject",
-				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-						123,
-					}
-
-					return a
-				},
-				expected: ErrInvalidAttestation.Type,
-				err:      "isn't an object",
-			},
-			{
+				// A sub-statement whose fmt member is absent decodes to the empty string, which is indistinguishable
+				// from one which carries an empty fmt and is rejected the same way.
 				name: "ShouldRejectSubStatementMissingFmt",
 				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtAttStmt: map[string]any{}},
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					a.SubStatements = []NonCompoundAttestationObject{
+						{AttStatement: map[string]any{}},
+						{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 					}
 
 					return a
 				},
 				expected: ErrInvalidAttestation.Type,
-				err:      "does not have a format",
+				err:      "empty format",
 			},
 			{
 				name: "ShouldRejectSubStatementMissingAttStmt",
 				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: string(AttestationFormatPacked)},
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					a.SubStatements = []NonCompoundAttestationObject{
+						{Format: string(AttestationFormatPacked)},
+						{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 					}
 
 					return a
@@ -134,9 +114,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			{
 				name: "ShouldRejectSubStatementWithCompoundFmt",
 				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: string(AttestationFormatCompound), stmtAttStmt: map[string]any{}},
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					a.SubStatements = []NonCompoundAttestationObject{
+						{Format: string(AttestationFormatCompound), AttStatement: map[string]any{}},
+						{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 					}
 
 					return a
@@ -147,9 +127,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			{
 				name: "ShouldRejectSubStatementWithEmptyFmt",
 				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: "", stmtAttStmt: map[string]any{}},
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					a.SubStatements = []NonCompoundAttestationObject{
+						{Format: "", AttStatement: map[string]any{}},
+						{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 					}
 
 					return a
@@ -160,9 +140,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			{
 				name: "ShouldRejectUnsupportedSubStatementFmt",
 				mutate: func(a AttestationObject) AttestationObject {
-					a.AttStatement[stmtAttStmt] = []any{
-						map[string]any{stmtFmt: fmtUnregistered, stmtAttStmt: map[string]any{}},
-						map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
+					a.SubStatements = []NonCompoundAttestationObject{
+						{Format: fmtUnregistered, AttStatement: map[string]any{}},
+						{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 					}
 
 					return a
@@ -238,16 +218,14 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			Format:      string(AttestationFormatCompound),
 			RawAuthData: []byte{0xAA, 0xBB},
 			AuthData:    auth,
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{
-						stmtFmt:     string(AttestationFormatPacked),
-						stmtAttStmt: map[string]any{"k1": "v1"},
-					},
-					map[string]any{
-						stmtFmt:     string(AttestationFormatApple),
-						stmtAttStmt: map[string]any{"k2": "v2"},
-					},
+			SubStatements: []NonCompoundAttestationObject{
+				{
+					Format:       string(AttestationFormatPacked),
+					AttStatement: map[string]any{"k1": "v1"},
+				},
+				{
+					Format:       string(AttestationFormatApple),
+					AttStatement: map[string]any{"k2": "v2"},
 				},
 			},
 		}
@@ -298,11 +276,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			AuthData: AuthenticatorData{
 				AttData: AttestedCredentialData{AAGUID: make([]byte, 0)},
 			},
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatApple), stmtAttStmt: map[string]any{}},
-				},
+			SubStatements: []NonCompoundAttestationObject{
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+				{Format: string(AttestationFormatApple), AttStatement: map[string]any{}},
 			},
 		}
 
@@ -332,11 +308,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			AuthData: AuthenticatorData{
 				AttData: AttestedCredentialData{AAGUID: make([]byte, 0)},
 			},
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-				},
+			SubStatements: []NonCompoundAttestationObject{
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 			},
 		}
 
@@ -372,11 +346,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 					AAGUID: u[:],
 				},
 			},
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-				},
+			SubStatements: []NonCompoundAttestationObject{
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 			},
 		}
 
@@ -409,11 +381,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 					AAGUID: make([]byte, 0),
 				},
 			},
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-				},
+			SubStatements: []NonCompoundAttestationObject{
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 			},
 		}
 
@@ -439,11 +409,9 @@ func TestAttestationFormatValidationHandlerCompound(t *testing.T) {
 			AuthData: AuthenticatorData{
 				AttData: AttestedCredentialData{AAGUID: make([]byte, 0)},
 			},
-			AttStatement: map[string]any{
-				stmtAttStmt: []any{
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-				},
+			SubStatements: []NonCompoundAttestationObject{
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+				{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
 			},
 		}
 
@@ -655,9 +623,9 @@ func TestAttestationFormatValidationHandlerCompoundSubStatementScope(t *testing.
 				}
 
 				att := compoundScopeTestAttestation(nil)
-				att.AttStatement[stmtAttStmt] = []any{
-					map[string]any{stmtFmt: fmtUnregistered, stmtAttStmt: map[string]any{}},
-					map[string]any{stmtFmt: string(AttestationFormatApple), stmtAttStmt: map[string]any{}},
+				att.SubStatements = []NonCompoundAttestationObject{
+					{Format: fmtUnregistered, AttStatement: map[string]any{}},
+					{Format: string(AttestationFormatApple), AttStatement: map[string]any{}},
 				}
 
 				_, _, err := attestationFormatValidationHandlerCompound(att, []byte("hash"), nil, tc.policy, SignaturePolicy{})
@@ -722,11 +690,9 @@ func compoundScopeTestAttestation(aaguid []byte) AttestationObject {
 		AuthData: AuthenticatorData{
 			AttData: AttestedCredentialData{AAGUID: aaguid},
 		},
-		AttStatement: map[string]any{
-			stmtAttStmt: []any{
-				map[string]any{stmtFmt: string(AttestationFormatPacked), stmtAttStmt: map[string]any{}},
-				map[string]any{stmtFmt: string(AttestationFormatApple), stmtAttStmt: map[string]any{}},
-			},
+		SubStatements: []NonCompoundAttestationObject{
+			{Format: string(AttestationFormatPacked), AttStatement: map[string]any{}},
+			{Format: string(AttestationFormatApple), AttStatement: map[string]any{}},
 		},
 	}
 }

--- a/protocol/webauthncbor/webauthncbor.go
+++ b/protocol/webauthncbor/webauthncbor.go
@@ -2,7 +2,20 @@ package webauthncbor
 
 import cbor "github.com/fxamacker/cbor/v2"
 
-const nestedLevelsAllowed = 4
+// nestedLevelsAllowed bounds the depth of the CBOR structures this package will decode.
+//
+// CTAP2 limits its own message encodings to 4 levels of any combination of maps and arrays. The attestation object is a
+// WebAuthn structure rather than a CTAP message though, and the compound attestation statement format introduced by
+// WebAuthn Level 3 needs 5.
+//
+// Specification: §8.9. Compound Attestation Statement Format (https://www.w3.org/TR/webauthn-3/#sctn-compound-attestation)
+const nestedLevelsAllowed = 5
+
+// RawMessage is a raw encoded CBOR value, which callers can use to defer the decoding of a member whose shape
+// depends on another member of the same structure. It is an alias so that a value of this type satisfies the
+// underlying library's own marshalling interfaces, and exists so that consumers of this package do not have to
+// import that library directly.
+type RawMessage = cbor.RawMessage
 
 // ctap2CBORDecMode is the cbor.DecMode following the CTAP2 canonical CBOR encoding form
 // (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding)


### PR DESCRIPTION
This fixes an issue where the sub-statements of a compound attestation statement would fail to unmarshal. The compound format encodes its sub-statements as an array rather than as the map that every other format uses for its attestation statement, a shape the generic decoding of the attestation object could not represent, and one which also exceeds the CBOR nesting depth inherited from the CTAP2 message encoding rules.

The attestation object now implements CBOR unmarshalling itself, leaving the attestation statement undecoded until the declared format is known and then decoding it either as the usual map or, for the compound format, as an array into a dedicated sub-statement member. The nesting depth allowed by the CBOR decoders is raised from four levels to five to accommodate this, as the attestation object is a WebAuthn structure rather than a CTAP2 message and the compound format needs the additional level.