### PR TITLE
fix(protocol): bind credential public key curve to its algorithm

### DIFF
--- a/protocol/webauthncose/const.go
+++ b/protocol/webauthncose/const.go
@@ -6,132 +6,39 @@ const (
 
 const ecCoordSize = 32
 
-// COSEAlgorithmIdentifier is a number identifying a cryptographic algorithm. The algorithm identifiers SHOULD be values
-// registered in the IANA COSE Algorithms registry [https://www.w3.org/TR/webauthn/#biblio-iana-cose-algs-reg], for
-// instance, -7 for "ES256" and -257 for "RS256".
-//
-// Specification: §5.8.5. Cryptographic Algorithm Identifier (https://www.w3.org/TR/webauthn/#sctn-alg-identifier)
-type COSEAlgorithmIdentifier int
+type Error struct {
+	// Short name for the type of error that has occurred.
+	Type string `json:"type"`
 
-const (
-	// AlgES256 ECDSA with SHA-256.
-	AlgES256 COSEAlgorithmIdentifier = -7
+	// Additional details about the error.
+	Details string `json:"error"`
 
-	// AlgEdDSA EdDSA.
-	AlgEdDSA COSEAlgorithmIdentifier = -8
+	// Information to help debug the error.
+	DevInfo string `json:"debug"`
+}
 
-	// AlgESP256 is ECDSA using P-256 curve with pre-hashed SHA-256 input.
-	AlgESP256 COSEAlgorithmIdentifier = -9
-
-	// AlgEd25519 is EdDSA using the Ed25519 curve specifically. Unlike [AlgEdDSA] which is the generic EdDSA
-	// identifier, this explicitly specifies the Ed25519 curve.
-	AlgEd25519 COSEAlgorithmIdentifier = -19
-
-	// AlgES384 ECDSA with SHA-384.
-	AlgES384 COSEAlgorithmIdentifier = -35
-
-	// AlgES512 ECDSA with SHA-512.
-	AlgES512 COSEAlgorithmIdentifier = -36
-
-	// AlgPS256 RSASSA-PSS with SHA-256.
-	AlgPS256 COSEAlgorithmIdentifier = -37
-
-	// AlgPS384 RSASSA-PSS with SHA-384.
-	AlgPS384 COSEAlgorithmIdentifier = -38
-
-	// AlgPS512 RSASSA-PSS with SHA-512.
-	AlgPS512 COSEAlgorithmIdentifier = -39
-
-	// AlgES256K is ECDSA using secp256k1 curve and SHA-256.
-	AlgES256K COSEAlgorithmIdentifier = -47
-
-	// AlgMLDSA44 is ML-DSA with parameter set ML-DSA-44 (FIPS 204).
-	AlgMLDSA44 COSEAlgorithmIdentifier = -48
-
-	// AlgMLDSA65 is ML-DSA with parameter set ML-DSA-65 (FIPS 204).
-	AlgMLDSA65 COSEAlgorithmIdentifier = -49
-
-	// AlgMLDSA87 is ML-DSA with parameter set ML-DSA-87 (FIPS 204).
-	AlgMLDSA87 COSEAlgorithmIdentifier = -50
-
-	// AlgESP384 is ECDSA using P-384 curve with pre-hashed SHA-384 input.
-	AlgESP384 COSEAlgorithmIdentifier = -51
-
-	// AlgESP512 is ECDSA using P-521 curve with pre-hashed SHA-512 input.
-	AlgESP512 COSEAlgorithmIdentifier = -52
-
-	// AlgRS256 RSASSA-PKCS1-v1_5 with SHA-256.
-	AlgRS256 COSEAlgorithmIdentifier = -257
-
-	// AlgRS384 RSASSA-PKCS1-v1_5 with SHA-384.
-	AlgRS384 COSEAlgorithmIdentifier = -258
-
-	// AlgRS512 RSASSA-PKCS1-v1_5 with SHA-512.
-	AlgRS512 COSEAlgorithmIdentifier = -259
-
-	// AlgRS1 RSASSA-PKCS1-v1_5 with SHA-1.
-	AlgRS1 COSEAlgorithmIdentifier = -65535
+var (
+	ErrUnsupportedKey = &Error{
+		Type:    "invalid_key_type",
+		Details: "Unsupported Public Key Type",
+	}
+	ErrUnsupportedAlgorithm = &Error{
+		Type:    "unsupported_key_algorithm",
+		Details: "Unsupported public key algorithm",
+	}
+	ErrSigNotProvidedOrInvalid = &Error{
+		Type:    "signature_not_provided_or_invalid",
+		Details: "Signature invalid or not provided",
+	}
 )
 
-// COSEKeyType is The Key type derived from the IANA COSE AuthData.
-type COSEKeyType int
+func (err *Error) Error() string {
+	return err.Details
+}
 
-const (
-	// KeyTypeReserved is a reserved value.
-	KeyTypeReserved COSEKeyType = iota
+func (passedError *Error) WithDetails(details string) *Error {
+	err := *passedError
+	err.Details = details
 
-	// OctetKey is an Octet Key.
-	OctetKey
-
-	// EllipticKey is an Elliptic Curve Public Key.
-	EllipticKey
-
-	// RSAKey is an RSA Public Key.
-	RSAKey
-
-	// Symmetric Keys.
-	Symmetric
-
-	// HSSLMS is the public key for HSS/LMS hash-based digital signature.
-	HSSLMS
-
-	// WalnutDSA is the public key for Walnut Digital Signature Algorithm.
-	WalnutDSA
-
-	// AKP is the key type for algorithm key pairs (i.e. ML-DSA).
-	AKP
-)
-
-// COSEEllipticCurve is an enumerator that represents the COSE Elliptic Curves.
-//
-// Specification: https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
-type COSEEllipticCurve int
-
-const (
-	// EllipticCurveReserved is the COSE EC Reserved value.
-	EllipticCurveReserved COSEEllipticCurve = iota
-
-	// P256 represents NIST P-256 also known as secp256r1.
-	P256
-
-	// P384 represents NIST P-384 also known as secp384r1.
-	P384
-
-	// P521 represents NIST P-521 also known as secp521r1.
-	P521
-
-	// X25519 for use w/ ECDH only.
-	X25519
-
-	// X448 for use w/ ECDH only.
-	X448
-
-	// Ed25519 for use w/ EdDSA only.
-	Ed25519
-
-	// Ed448 for use w/ EdDSA only.
-	Ed448
-
-	// Secp256k1 is the SECG secp256k1 curve.
-	Secp256k1
-)
+	return &err
+}

--- a/protocol/webauthncose/cose_algorithm_identifier.go
+++ b/protocol/webauthncose/cose_algorithm_identifier.go
@@ -1,0 +1,157 @@
+package webauthncose
+
+import (
+	"strconv"
+	"crypto"
+	"crypto/x509"
+)
+
+// COSEAlgorithmIdentifier is a number identifying a cryptographic algorithm. The algorithm identifiers SHOULD be values
+// registered in the IANA COSE Algorithms registry [https://www.w3.org/TR/webauthn/#biblio-iana-cose-algs-reg], for
+// instance, -7 for "ES256" and -257 for "RS256".
+//
+// Specification: §5.8.5. Cryptographic Algorithm Identifier (https://www.w3.org/TR/webauthn/#sctn-alg-identifier)
+type COSEAlgorithmIdentifier int
+
+const (
+	// AlgES256 ECDSA with SHA-256.
+	AlgES256 COSEAlgorithmIdentifier = -7
+
+	// AlgEdDSA EdDSA.
+	AlgEdDSA COSEAlgorithmIdentifier = -8
+
+	// AlgESP256 is ECDSA using P-256 curve with pre-hashed SHA-256 input.
+	AlgESP256 COSEAlgorithmIdentifier = -9
+
+	// AlgEd25519 is EdDSA using the Ed25519 curve specifically. Unlike [AlgEdDSA] which is the generic EdDSA
+	// identifier, this explicitly specifies the Ed25519 curve.
+	AlgEd25519 COSEAlgorithmIdentifier = -19
+
+	// AlgES384 ECDSA with SHA-384.
+	AlgES384 COSEAlgorithmIdentifier = -35
+
+	// AlgES512 ECDSA with SHA-512.
+	AlgES512 COSEAlgorithmIdentifier = -36
+
+	// AlgPS256 RSASSA-PSS with SHA-256.
+	AlgPS256 COSEAlgorithmIdentifier = -37
+
+	// AlgPS384 RSASSA-PSS with SHA-384.
+	AlgPS384 COSEAlgorithmIdentifier = -38
+
+	// AlgPS512 RSASSA-PSS with SHA-512.
+	AlgPS512 COSEAlgorithmIdentifier = -39
+
+	// AlgES256K is ECDSA using secp256k1 curve and SHA-256.
+	AlgES256K COSEAlgorithmIdentifier = -47
+
+	// AlgMLDSA44 is ML-DSA with parameter set ML-DSA-44 (FIPS 204).
+	AlgMLDSA44 COSEAlgorithmIdentifier = -48
+
+	// AlgMLDSA65 is ML-DSA with parameter set ML-DSA-65 (FIPS 204).
+	AlgMLDSA65 COSEAlgorithmIdentifier = -49
+
+	// AlgMLDSA87 is ML-DSA with parameter set ML-DSA-87 (FIPS 204).
+	AlgMLDSA87 COSEAlgorithmIdentifier = -50
+
+	// AlgESP384 is ECDSA using P-384 curve with pre-hashed SHA-384 input.
+	AlgESP384 COSEAlgorithmIdentifier = -51
+
+	// AlgESP512 is ECDSA using P-521 curve with pre-hashed SHA-512 input.
+	AlgESP512 COSEAlgorithmIdentifier = -52
+
+	// AlgRS256 RSASSA-PKCS1-v1_5 with SHA-256.
+	AlgRS256 COSEAlgorithmIdentifier = -257
+
+	// AlgRS384 RSASSA-PKCS1-v1_5 with SHA-384.
+	AlgRS384 COSEAlgorithmIdentifier = -258
+
+	// AlgRS512 RSASSA-PKCS1-v1_5 with SHA-512.
+	AlgRS512 COSEAlgorithmIdentifier = -259
+
+	// AlgRS1 RSASSA-PKCS1-v1_5 with SHA-1.
+	AlgRS1 COSEAlgorithmIdentifier = -65535
+)
+
+// String returns the short name under which the algorithm is registered, falling back to its numeric identifier for
+// an algorithm this library does not model.
+//
+// This is deliberately distinct from the name member of [COSESignatureAlgorithmDetails], which describes the
+// primitives the algorithm composes (i.e. "ECDSA-SHA256") rather than naming the algorithm itself.
+//
+// Registry: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+func (a COSEAlgorithmIdentifier) String() string {
+	if name, ok := coseAlgorithmNames[a]; ok {
+		return name
+	}
+
+	return strconv.Itoa(int(a))
+}
+
+// coseAlgorithmNames maps each algorithm identifier this library models to the short name under which it is
+// registered, backing [COSEAlgorithmIdentifier.String].
+//
+// Registry: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+var coseAlgorithmNames = map[COSEAlgorithmIdentifier]string{
+	AlgES256:   "ES256",
+	AlgEdDSA:   "EdDSA",
+	AlgESP256:  "ESP256",
+	AlgEd25519: "Ed25519",
+	AlgES384:   "ES384",
+	AlgES512:   "ES512",
+	AlgPS256:   "PS256",
+	AlgPS384:   "PS384",
+	AlgPS512:   "PS512",
+	AlgES256K:  "ES256K",
+	AlgMLDSA44: "ML-DSA-44",
+	AlgMLDSA65: "ML-DSA-65",
+	AlgMLDSA87: "ML-DSA-87",
+	AlgESP384:  "ESP384",
+	AlgESP512:  "ESP512",
+	AlgRS256:   "RS256",
+	AlgRS384:   "RS384",
+	AlgRS512:   "RS512",
+	AlgRS1:     "RS1",
+}
+
+var COSESignatureAlgorithmDetails = map[COSEAlgorithmIdentifier]struct {
+	name   string
+	hash   crypto.Hash
+	sigAlg x509.SignatureAlgorithm
+}{
+	AlgRS1:     {"SHA1-RSA", crypto.SHA1, x509.SHA1WithRSA},
+	AlgRS256:   {"SHA256-RSA", crypto.SHA256, x509.SHA256WithRSA},
+	AlgRS384:   {"SHA384-RSA", crypto.SHA384, x509.SHA384WithRSA},
+	AlgRS512:   {"SHA512-RSA", crypto.SHA512, x509.SHA512WithRSA},
+	AlgPS256:   {"SHA256-RSAPSS", crypto.SHA256, x509.SHA256WithRSAPSS},
+	AlgPS384:   {"SHA384-RSAPSS", crypto.SHA384, x509.SHA384WithRSAPSS},
+	AlgPS512:   {"SHA512-RSAPSS", crypto.SHA512, x509.SHA512WithRSAPSS},
+	AlgES256:   {"ECDSA-SHA256", crypto.SHA256, x509.ECDSAWithSHA256},
+	AlgESP256:  {"ECDSA-SHA256-Prehashed", crypto.SHA256, x509.ECDSAWithSHA256},
+	AlgES384:   {"ECDSA-SHA384", crypto.SHA384, x509.ECDSAWithSHA384},
+	AlgESP384:  {"ECDSA-SHA384-Prehashed", crypto.SHA384, x509.ECDSAWithSHA384},
+	AlgES512:   {"ECDSA-SHA512", crypto.SHA512, x509.ECDSAWithSHA512},
+	AlgESP512:  {"ECDSA-SHA512-Prehashed", crypto.SHA512, x509.ECDSAWithSHA512},
+	AlgEdDSA:   {"EdDSA", crypto.SHA512, x509.PureEd25519},
+	AlgEd25519: {"Ed25519", crypto.SHA512, x509.PureEd25519},
+}
+
+// coseAlgorithmCurves binds each elliptic curve algorithm this library verifies with to the curve §5.8.5 requires a
+// key using that algorithm to specify.
+//
+// The specification requires the crv parameter for ES256, ES384, ES512 and EdDSA. It states no requirement for the
+// fully specified algorithms ESP256, ESP384, ESP512 and Ed25519, because those identifiers name their curve
+// themselves and leave nothing for the parameter to settle. A crv such a key does carry is still held to the curve
+// its algorithm names, as a key which contradicts itself is malformed however the requirement is written.
+//
+// Specification: §5.8.5. Cryptographic Algorithm Identifier (https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier)
+var coseAlgorithmCurves = map[COSEAlgorithmIdentifier]coseAlgorithmCurve{
+	AlgES256:   {curve: P256, required: true},
+	AlgES384:   {curve: P384, required: true},
+	AlgES512:   {curve: P521, required: true},
+	AlgEdDSA:   {curve: Ed25519, required: true},
+	AlgESP256:  {curve: P256},
+	AlgESP384:  {curve: P384},
+	AlgESP512:  {curve: P521},
+	AlgEd25519: {curve: Ed25519},
+}

--- a/protocol/webauthncose/cose_elliptic_curve.go
+++ b/protocol/webauthncose/cose_elliptic_curve.go
@@ -1,0 +1,64 @@
+package webauthncose
+
+import "strconv"
+
+// COSEEllipticCurve is an enumerator that represents the COSE Elliptic Curves.
+//
+// Specification: https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
+type COSEEllipticCurve int
+
+const (
+	// EllipticCurveReserved is the COSE EC Reserved value.
+	EllipticCurveReserved COSEEllipticCurve = iota
+
+	// P256 represents NIST P-256 also known as secp256r1.
+	P256
+
+	// P384 represents NIST P-384 also known as secp384r1.
+	P384
+
+	// P521 represents NIST P-521 also known as secp521r1.
+	P521
+
+	// X25519 for use w/ ECDH only.
+	X25519
+
+	// X448 for use w/ ECDH only.
+	X448
+
+	// Ed25519 for use w/ EdDSA only.
+	Ed25519
+
+	// Ed448 for use w/ EdDSA only.
+	Ed448
+
+	// Secp256k1 is the SECG secp256k1 curve.
+	Secp256k1
+)
+
+// String returns the name under which the curve is registered, falling back to its numeric identifier for a curve
+// this library does not model.
+//
+// Registry: https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
+func (c COSEEllipticCurve) String() string {
+	if name, ok := coseEllipticCurveNames[c]; ok {
+		return name
+	}
+
+	return strconv.Itoa(int(c))
+}
+
+// coseEllipticCurveNames maps each curve this library models to the name under which it is registered, backing
+// [COSEEllipticCurve.String].
+//
+// Registry: https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
+var coseEllipticCurveNames = map[COSEEllipticCurve]string{
+	P256:      "P-256",
+	P384:      "P-384",
+	P521:      "P-521",
+	X25519:    "X25519",
+	X448:      "X448",
+	Ed25519:   "Ed25519",
+	Ed448:     "Ed448",
+	Secp256k1: "secp256k1",
+}

--- a/protocol/webauthncose/cose_key_type.go
+++ b/protocol/webauthncose/cose_key_type.go
@@ -1,0 +1,30 @@
+package webauthncose
+
+// COSEKeyType is The Key type derived from the IANA COSE AuthData.
+type COSEKeyType int
+
+const (
+	// KeyTypeReserved is a reserved value.
+	KeyTypeReserved COSEKeyType = iota
+
+	// OctetKey is an Octet Key.
+	OctetKey
+
+	// EllipticKey is an Elliptic Curve Public Key.
+	EllipticKey
+
+	// RSAKey is an RSA Public Key.
+	RSAKey
+
+	// Symmetric Keys.
+	Symmetric
+
+	// HSSLMS is the public key for HSS/LMS hash-based digital signature.
+	HSSLMS
+
+	// WalnutDSA is the public key for Walnut Digital Signature Algorithm.
+	WalnutDSA
+
+	// AKP is the key type for algorithm key pairs (i.e. ML-DSA).
+	AKP
+)

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -66,7 +66,8 @@ type RSAPublicKeyData struct {
 type OKPPublicKeyData struct {
 	PublicKeyData
 
-	Curve int64
+	// The curve the key is on. §5.8.5 requires a key with algorithm -8 (EdDSA) to specify 6 (Ed25519) here.
+	Curve int64 `cbor:"-1,keyasint,omitempty" json:"crv"`
 
 	// A byte string that holds the x coordinate of the key.
 	XCoord []byte `cbor:"-2,keyasint,omitempty" json:"x"`
@@ -371,66 +372,57 @@ func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) hash.Hash {
 	return d.hash.New()
 }
 
-var COSESignatureAlgorithmDetails = map[COSEAlgorithmIdentifier]struct {
-	name   string
-	hash   crypto.Hash
-	sigAlg x509.SignatureAlgorithm
-}{
-	AlgRS1:     {"SHA1-RSA", crypto.SHA1, x509.SHA1WithRSA},
-	AlgRS256:   {"SHA256-RSA", crypto.SHA256, x509.SHA256WithRSA},
-	AlgRS384:   {"SHA384-RSA", crypto.SHA384, x509.SHA384WithRSA},
-	AlgRS512:   {"SHA512-RSA", crypto.SHA512, x509.SHA512WithRSA},
-	AlgPS256:   {"SHA256-RSAPSS", crypto.SHA256, x509.SHA256WithRSAPSS},
-	AlgPS384:   {"SHA384-RSAPSS", crypto.SHA384, x509.SHA384WithRSAPSS},
-	AlgPS512:   {"SHA512-RSAPSS", crypto.SHA512, x509.SHA512WithRSAPSS},
-	AlgES256:   {"ECDSA-SHA256", crypto.SHA256, x509.ECDSAWithSHA256},
-	AlgESP256:  {"ECDSA-SHA256-Prehashed", crypto.SHA256, x509.ECDSAWithSHA256},
-	AlgES384:   {"ECDSA-SHA384", crypto.SHA384, x509.ECDSAWithSHA384},
-	AlgESP384:  {"ECDSA-SHA384-Prehashed", crypto.SHA384, x509.ECDSAWithSHA384},
-	AlgES512:   {"ECDSA-SHA512", crypto.SHA512, x509.ECDSAWithSHA512},
-	AlgESP512:  {"ECDSA-SHA512-Prehashed", crypto.SHA512, x509.ECDSAWithSHA512},
-	AlgEdDSA:   {"EdDSA", crypto.SHA512, x509.PureEd25519},
-	AlgEd25519: {"Ed25519", crypto.SHA512, x509.PureEd25519},
+// coseAlgorithmCurve describes the elliptic curve a credential public key using a particular algorithm names.
+type coseAlgorithmCurve struct {
+	// curve is the curve §5.8.5 binds to the algorithm.
+	curve COSEEllipticCurve
+
+	// required records whether the specification requires the crv parameter to be present at all.
+	required bool
 }
 
-type Error struct {
-	// Short name for the type of error that has occurred.
-	Type string `json:"type"`
+// validateKeyCurve checks the curve a credential public key names against the one §5.8.5 binds to its algorithm. The
+// keyType names the COSE key type in the error so a failure identifies which of the two key structures produced it.
+//
+// An algorithm this map does not cover is not rejected here: the callers reject an algorithm they cannot verify with
+// on their own, and an algorithm which names no curve has nothing to check.
+//
+// Specification: §5.8.5. Cryptographic Algorithm Identifier (https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier)
+func validateKeyCurve(keyType string, algorithm, curve int64) error {
+	alg := COSEAlgorithmIdentifier(algorithm)
 
-	// Additional details about the error.
-	Details string `json:"error"`
-
-	// Information to help debug the error.
-	DevInfo string `json:"debug"`
-}
-
-var (
-	ErrUnsupportedKey = &Error{
-		Type:    "invalid_key_type",
-		Details: "Unsupported Public Key Type",
+	expected, ok := coseAlgorithmCurves[alg]
+	if !ok {
+		return nil
 	}
-	ErrUnsupportedAlgorithm = &Error{
-		Type:    "unsupported_key_algorithm",
-		Details: "Unsupported public key algorithm",
+
+	crv := COSEEllipticCurve(curve)
+
+	if crv == expected.curve {
+		return nil
 	}
-	ErrSigNotProvidedOrInvalid = &Error{
-		Type:    "signature_not_provided_or_invalid",
-		Details: "Signature invalid or not provided",
+
+	// The zero value is the reserved curve identifier, which is how an absent crv parameter decodes.
+	if crv == EllipticCurveReserved && !expected.required {
+		return nil
 	}
-)
 
-func (err *Error) Error() string {
-	return err.Details
-}
+	specified := "curve " + crv.String()
 
-func (passedError *Error) WithDetails(details string) *Error {
-	err := *passedError
-	err.Details = details
+	if crv == EllipticCurveReserved {
+		specified = "no curve"
+	}
 
-	return &err
+	return ErrUnsupportedKey.WithDetails(fmt.Sprintf("%s key with algorithm %s must specify curve %s but it specified %s", keyType, alg, expected.curve, specified))
 }
 
 func validateOKPPublicKey(k *OKPPublicKeyData) error {
+	// The curve is checked before the key material so that both key structures report what the key declares about
+	// itself before what it carries.
+	if err := validateKeyCurve("OKP", k.Algorithm, k.Curve); err != nil {
+		return err
+	}
+
 	if len(k.XCoord) != ed25519.PublicKeySize {
 		return ErrUnsupportedKey.WithDetails(fmt.Sprintf("OKP key x coordinate has invalid length %d, expected %d", len(k.XCoord), ed25519.PublicKeySize))
 	}
@@ -442,6 +434,10 @@ func validateEC2PublicKey(k *EC2PublicKeyData) error {
 	curve := ec2AlgCurve(k.Algorithm)
 	if curve == nil {
 		return ErrUnsupportedAlgorithm.WithDetails("Unsupported EC2 algorithm")
+	}
+
+	if err := validateKeyCurve("EC2", k.Algorithm, k.Curve); err != nil {
+		return err
 	}
 
 	byteLen := (curve.Params().BitSize + 7) / 8

--- a/protocol/webauthncose/webauthncose_curve_test.go
+++ b/protocol/webauthncose/webauthncose_curve_test.go
@@ -1,0 +1,165 @@
+package webauthncose
+
+import (
+	"crypto/ecdh"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+)
+
+// TestParsePublicKeyCurveBinding asserts the binding §5.8.5 places between a credential public key's algorithm and
+// the curve it names.
+//
+// The specification requires a key with algorithm -7 (ES256) to specify 1 (P-256) as its crv, -35 (ES384) to specify
+// 2 (P-384), -36 (ES512) to specify 3 (P-521), and -8 (EdDSA) to specify 6 (Ed25519). The fully specified algorithms
+// -9/-51/-52 (ESP256/384/512) and -19 (Ed25519) carry no such requirement because the algorithm identifier fixes the
+// curve on its own, so for those a crv is optional but may not contradict the algorithm.
+//
+// Specification: §5.8.5. Cryptographic Algorithm Identifier (https://www.w3.org/TR/webauthn-3/#sctn-alg-identifier)
+func TestParsePublicKeyCurveBinding(t *testing.T) {
+	okpPub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	p256, err := ecdh.P256().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	p256Pub := p256.PublicKey().Bytes()
+	p256X, p256Y := p256Pub[1:33], p256Pub[33:65]
+
+	p384, err := ecdh.P384().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	p384Pub := p384.PublicKey().Bytes()
+	p384X, p384Y := p384Pub[1:49], p384Pub[49:97]
+
+	ec2 := func(alg COSEAlgorithmIdentifier, crv any, x, y []byte) map[int64]any {
+		key := map[int64]any{1: int64(EllipticKey), 3: int64(alg), -2: x, -3: y}
+
+		if crv != nil {
+			key[-1] = crv
+		}
+
+		return key
+	}
+
+	okp := func(alg COSEAlgorithmIdentifier, crv any) map[int64]any {
+		key := map[int64]any{1: int64(OctetKey), 3: int64(alg), -2: []byte(okpPub)}
+
+		if crv != nil {
+			key[-1] = crv
+		}
+
+		return key
+	}
+
+	testCases := []struct {
+		name string
+		key  map[int64]any
+		err  string
+	}{
+		{
+			name: "ShouldAcceptES256WithP256",
+			key:  ec2(AlgES256, int64(P256), p256X, p256Y),
+		},
+		{
+			name: "ShouldRejectES256WithP521",
+			key:  ec2(AlgES256, int64(P521), p256X, p256Y),
+			err:  "EC2 key with algorithm ES256 must specify curve P-256 but it specified curve P-521",
+		},
+		{
+			name: "ShouldRejectES256WithoutCurve",
+			key:  ec2(AlgES256, nil, p256X, p256Y),
+			err:  "EC2 key with algorithm ES256 must specify curve P-256 but it specified no curve",
+		},
+		{
+			name: "ShouldAcceptES384WithP384",
+			key:  ec2(AlgES384, int64(P384), p384X, p384Y),
+		},
+		{
+			name: "ShouldRejectES384WithP256",
+			key:  ec2(AlgES384, int64(P256), p384X, p384Y),
+			err:  "EC2 key with algorithm ES384 must specify curve P-384 but it specified curve P-256",
+		},
+		{
+			name: "ShouldAcceptESP256WithP256",
+			key:  ec2(AlgESP256, int64(P256), p256X, p256Y),
+		},
+		{
+			// The fully specified algorithms name the curve themselves, so §5.8.5 does not require the crv.
+			name: "ShouldAcceptESP256WithoutCurve",
+			key:  ec2(AlgESP256, nil, p256X, p256Y),
+		},
+		{
+			name: "ShouldRejectESP256WithP384",
+			key:  ec2(AlgESP256, int64(P384), p256X, p256Y),
+			err:  "EC2 key with algorithm ESP256 must specify curve P-256 but it specified curve P-384",
+		},
+		{
+			name: "ShouldAcceptEdDSAWithEd25519",
+			key:  okp(AlgEdDSA, int64(Ed25519)),
+		},
+		{
+			name: "ShouldRejectEdDSAWithX25519",
+			key:  okp(AlgEdDSA, int64(X25519)),
+			err:  "OKP key with algorithm EdDSA must specify curve Ed25519 but it specified curve X25519",
+		},
+		{
+			name: "ShouldRejectEdDSAWithoutCurve",
+			key:  okp(AlgEdDSA, nil),
+			err:  "OKP key with algorithm EdDSA must specify curve Ed25519 but it specified no curve",
+		},
+		{
+			name: "ShouldAcceptEd25519WithoutCurve",
+			key:  okp(AlgEd25519, nil),
+		},
+		{
+			name: "ShouldRejectEd25519WithEd448",
+			key:  okp(AlgEd25519, int64(Ed448)),
+			err:  "OKP key with algorithm Ed25519 must specify curve Ed25519 but it specified curve Ed448",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := webauthncbor.Marshal(tc.key)
+			require.NoError(t, err)
+
+			key, err := ParsePublicKey(data)
+
+			if tc.err != "" {
+				assert.Nil(t, key)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, key)
+		})
+	}
+}
+
+// TestOKPPublicKeyDataCurveDecodes asserts the crv parameter of an OKP key reaches the decoded structure. Without a
+// CBOR tag on the field the parameter is silently dropped, leaving the §5.8.5 curve requirement unenforceable and
+// the exported member permanently zero.
+func TestOKPPublicKeyDataCurveDecodes(t *testing.T) {
+	okpPub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	data, err := webauthncbor.Marshal(map[int64]any{
+		1: int64(OctetKey), 3: int64(AlgEdDSA), -1: int64(Ed25519), -2: []byte(okpPub),
+	})
+	require.NoError(t, err)
+
+	key, err := ParsePublicKey(data)
+	require.NoError(t, err)
+
+	require.IsType(t, OKPPublicKeyData{}, key)
+
+	assert.Equal(t, int64(Ed25519), key.(OKPPublicKeyData).Curve)
+}

--- a/protocol/webauthncose/webauthncose_test.go
+++ b/protocol/webauthncose/webauthncose_test.go
@@ -338,7 +338,8 @@ func TestParsePublicKey(t *testing.T) {
 			"7b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a224e35446169797479376f7a686c32463465744f4d763670706672504b41546f545170694856726d48686173222c226f726967696e223a2268747470733a2f2f6578616d706c652e6f7267222c2263726f73734f726967696e223a66616c73657d",
 			"bfabc37432958b063360d3ad6461c9c4735ae7f8edd46592a5e0f01452b2e4b51900000000",
 			"4c873571377ac019f257d6bf07249f63ac2487483c51bc511ce0f0e3266c840cb07a09cdc445a2f963d8603a9f0f6cf9ce709d7fc6a96c7c51ea08d33776010c",
-			OKPPublicKeyData{PublicKeyData: PublicKeyData{_struct: false, KeyType: 1, Algorithm: -8}, Curve: 0, XCoord: []uint8{0x89, 0xf8, 0x1e, 0xba, 0x4a, 0x1f, 0x51, 0xc, 0xb2, 0x43, 0xff, 0x7f, 0xb9, 0xe9, 0xcf, 0x89, 0x9b, 0xf6, 0x27, 0xe4, 0x9c, 0xe1, 0xac, 0x3c, 0x3e, 0xae, 0x8a, 0xdb, 0x2a, 0x8d, 0x7d, 0x7b}},
+			// The vector's key carries crv 6 (Ed25519); the curve is decoded now that the member has a CBOR tag.
+			OKPPublicKeyData{PublicKeyData: PublicKeyData{_struct: false, KeyType: 1, Algorithm: -8}, Curve: 6, XCoord: []uint8{0x89, 0xf8, 0x1e, 0xba, 0x4a, 0x1f, 0x51, 0xc, 0xb2, 0x43, 0xff, 0x7f, 0xb9, 0xe9, 0xcf, 0x89, 0x9b, 0xf6, 0x27, 0xe4, 0x9c, 0xe1, 0xac, 0x3c, 0x3e, 0xae, 0x8a, 0xdb, 0x2a, 0x8d, 0x7d, 0x7b}},
 			tpm2.TPMECCNistP256,
 			false,
 			false,
@@ -470,8 +471,9 @@ func TestParsePublicKeyValidation(t *testing.T) {
 		err   string
 	}{
 		{
+			// §5.8.5 requires a key with algorithm -8 (EdDSA) to specify 6 (Ed25519) as its crv.
 			"ShouldAcceptValidOKPKey",
-			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgEdDSA), map[int64]any{-2: []byte(okpPub)}),
+			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgEdDSA), map[int64]any{-1: int64(Ed25519), -2: []byte(okpPub)}),
 			"",
 		},
 		{
@@ -486,7 +488,7 @@ func TestParsePublicKeyValidation(t *testing.T) {
 		},
 		{
 			"ShouldRejectOKPWithInvalidXCoordLength",
-			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgEdDSA), map[int64]any{-2: make([]byte, 16)}),
+			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgEdDSA), map[int64]any{-1: int64(Ed25519), -2: make([]byte, 16)}),
 			"OKP key x coordinate has invalid length 16, expected 32",
 		},
 		{


### PR DESCRIPTION
§5.8.5 requires a credential public key using ES256, ES384, ES512 or EdDSA to specify the matching curve, but the curve was never checked against the algorithm and the OKP structure carried no CBOR tag on its curve member, so the parameter was discarded while decoding and the member was permanently zero. The curve is now decoded and validated for both the EC2 and OKP key types before the key material is examined. The fully specified algorithms ESP256, ESP384, ESP512 and Ed25519 name their curve themselves, so a key using one may omit the parameter, though a curve it does carry may not contradict the algorithm.

Stored keys are re-parsed on every assertion, so this applies to authentication as well as registration. COSE requires the parameter for both key types and the specification test vectors carry it, so only a key which contradicts itself is newly rejected. COSEAlgorithmIdentifier and COSEEllipticCurve gain a String method returning the short name each is registered under, so a rejection names what it saw rather than a bare identifier, and each enumeration moves to its own file.