### PR TITLE
feat(protocol): related origins well-known document

### DIFF
--- a/protocol/related_origins.go
+++ b/protocol/related_origins.go
@@ -36,6 +36,8 @@ const (
 	mimeApplicationJSON = "application/json"
 
 	methodsRelatedOrigins = http.MethodGet + ", " + http.MethodHead
+
+	maximumPort = 65535
 )
 
 // RelatedOriginLabeler derives the registrable domain label of an origin, which is the unit a client counts against
@@ -297,11 +299,22 @@ func relatedOriginNormalize(origin string) (normalized string, err error) {
 		return "", fmt.Errorf("the scheme must be either http or https but it is '%s'", uri.Scheme)
 	}
 
-	if uri.Host == "" {
+	if uri.Hostname() == "" {
 		return "", errors.New("the origin must have a host component")
 	}
 
 	host := strings.ToLower(uri.Host)
+
+	if port := uri.Port(); port == "" {
+		// A host may carry a colon with no port after it, which is not part of the serialization of an origin.
+		host = strings.TrimSuffix(host, ":")
+	} else {
+		var number int
+
+		if number, err = strconv.Atoi(port); err != nil || number > maximumPort {
+			return "", fmt.Errorf("the port must be no greater than %d but it is '%s'", maximumPort, port)
+		}
+	}
 
 	// The default port of the scheme is not part of the serialization of an origin. Trimming the suffix rather than
 	// rebuilding from the hostname preserves the brackets of an IPv6 address literal.

--- a/protocol/related_origins.go
+++ b/protocol/related_origins.go
@@ -1,0 +1,316 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	// WellKnownPathWebAuthn is the path of the well-known resource a Relying Party serves to declare the origins
+	// related to its Relying Party ID. A client fetches it from https://<rpid>/.well-known/webauthn when the origin
+	// of a ceremony does not match the Relying Party ID directly.
+	//
+	// Specification: §5.11. Related Origin Requests (https://www.w3.org/TR/webauthn-3/#sctn-related-origins)
+	WellKnownPathWebAuthn = "/.well-known/webauthn"
+
+	// MaximumRelatedOriginLabels is the number of distinct registrable domain labels a client processes when it reads
+	// the well-known resource. A client stops adding labels once it has seen this many, so origins whose label falls
+	// outside the budget are silently ignored; this is the limit [NewRelatedOrigins] holds the origins to.
+	//
+	// Specification: §5.11. Related Origin Requests (https://www.w3.org/TR/webauthn-3/#sctn-related-origins)
+	MaximumRelatedOriginLabels = 5
+)
+
+const (
+	headerAllow         = "Allow"
+	headerContentType   = "Content-Type"
+	headerContentLength = "Content-Length"
+
+	mimeApplicationJSON = "application/json"
+
+	methodsRelatedOrigins = http.MethodGet + ", " + http.MethodHead
+)
+
+// RelatedOriginLabeler derives the registrable domain label of an origin, which is the unit a client counts against
+// [MaximumRelatedOriginLabels]. Origins which share a label cost only one between them, which is what lets a Relying
+// Party list the same brand across many country code top level domains cheaply.
+//
+// [DefaultRelatedOriginLabeler] is used when none is supplied. Supply your own to count labels exactly for a
+// deployment which uses a multi-label public suffix; see that function for why the default cannot.
+type RelatedOriginLabeler func(origin string) (label string, err error)
+
+// RelatedOrigins is the document a Relying Party serves at [WellKnownPathWebAuthn] to declare which origins may run
+// ceremonies against its Relying Party ID.
+//
+// Build one with [NewRelatedOrigins], which validates and normalizes the origins, then serve it with whichever of
+// [RelatedOrigins.Bytes], [RelatedOrigins.WriteTo] or [RelatedOrigins.WriteResponse] suits the surrounding code. The
+// type is also an [http.Handler], so it can be mounted on a router directly:
+//
+//	related, err := protocol.NewRelatedOrigins("https://example.com", "https://example.com.au")
+//	if err != nil {
+//		return err
+//	}
+//
+//	mux.Handle(protocol.WellKnownPathWebAuthn, related)
+//
+// A [WebAuthn.RelatedOrigins] method in the webauthn package builds this from the configured origins.
+//
+// Specification: §5.11. Related Origin Requests (https://www.w3.org/TR/webauthn-3/#sctn-related-origins)
+type RelatedOrigins struct {
+	Origins []string `json:"origins"`
+}
+
+// NewRelatedOrigins validates the given origins and returns the [RelatedOrigins] document which declares them, using
+// [DefaultRelatedOriginLabeler] to count the registrable domain labels. See [NewRelatedOriginsWithLabeler] for the
+// validation performed and for supplying a labeler of your own.
+func NewRelatedOrigins(origins ...string) (related *RelatedOrigins, err error) {
+	return NewRelatedOriginsWithLabeler(nil, origins...)
+}
+
+// NewRelatedOriginsWithLabeler validates the given origins and returns the [RelatedOrigins] document which declares
+// them, counting registrable domain labels with the given [RelatedOriginLabeler]. A nil labeler selects
+// [DefaultRelatedOriginLabeler].
+//
+// Each origin must be an absolute http or https URL with a host. Every origin is normalized to its scheme and host
+// alone, with a default port and any path, query, fragment or userinfo removed, and origins which normalize to the
+// same value are collapsed to one. The order the origins were given in is otherwise preserved.
+//
+// An error is returned when the origins carry more than [MaximumRelatedOriginLabels] distinct labels, because a
+// client stops processing at that point and the excess origins would be ignored in production without any signal
+// that they had been.
+func NewRelatedOriginsWithLabeler(labeler RelatedOriginLabeler, origins ...string) (related *RelatedOrigins, err error) {
+	if len(origins) == 0 {
+		return nil, errors.New("error validating related origins: at least one origin is required")
+	}
+
+	if labeler == nil {
+		labeler = DefaultRelatedOriginLabeler
+	}
+
+	var (
+		normalized []string
+		origin     string
+		label      string
+	)
+
+	seen := make(map[string]struct{}, len(origins))
+	labels := make(map[string]struct{}, len(origins))
+
+	for _, raw := range origins {
+		if origin, err = relatedOriginNormalize(raw); err != nil {
+			return nil, fmt.Errorf("error validating related origin '%s': %w", raw, err)
+		}
+
+		if _, ok := seen[origin]; ok {
+			continue
+		}
+
+		seen[origin] = struct{}{}
+
+		if label, err = labeler(origin); err != nil {
+			return nil, fmt.Errorf("error validating related origin '%s': error determining the registrable domain label: %w", raw, err)
+		}
+
+		labels[label] = struct{}{}
+
+		normalized = append(normalized, origin)
+	}
+
+	if n := len(labels); n > MaximumRelatedOriginLabels {
+		return nil, fmt.Errorf("error validating related origins: the origins have %d distinct registrable domain labels but clients only process %d of them, so origins beyond that limit are ignored", n, MaximumRelatedOriginLabels)
+	}
+
+	return &RelatedOrigins{Origins: normalized}, nil
+}
+
+// MarshalJSON implements the [json.Marshaler] interface, encoding an absent origin list as an empty array rather than
+// as null so that the document is always the shape a client parses.
+func (r RelatedOrigins) MarshalJSON() (data []byte, err error) {
+	type alias RelatedOrigins
+
+	if r.Origins == nil {
+		return json.Marshal(alias{Origins: []string{}})
+	}
+
+	return json.Marshal(alias(r))
+}
+
+// Bytes returns the encoded well-known document.
+func (r RelatedOrigins) Bytes() (data []byte, err error) {
+	return json.Marshal(r)
+}
+
+// WriteTo writes the encoded well-known document to the given [io.Writer], implementing the [io.WriterTo] interface.
+func (r RelatedOrigins) WriteTo(w io.Writer) (n int64, err error) {
+	var data []byte
+
+	if data, err = r.Bytes(); err != nil {
+		return 0, err
+	}
+
+	var written int
+
+	written, err = w.Write(data)
+
+	return int64(written), err
+}
+
+// WriteResponse writes the encoded well-known document to the given [http.ResponseWriter] along with the headers
+// which describe it, responding with a status of 200. No caching headers are set; the caching policy of the resource
+// is left to the Relying Party.
+//
+// Use [RelatedOrigins.ServeHTTP] instead to have the request method handled as well.
+func (r RelatedOrigins) WriteResponse(w http.ResponseWriter) (err error) {
+	var data []byte
+
+	if data, err = r.Bytes(); err != nil {
+		return err
+	}
+
+	w.Header().Set(headerContentType, mimeApplicationJSON)
+	w.Header().Set(headerContentLength, strconv.Itoa(len(data)))
+	w.WriteHeader(http.StatusOK)
+
+	_, err = w.Write(data)
+
+	return err
+}
+
+// ServeHTTP implements the [http.Handler] interface so the document can be mounted on a router at
+// [WellKnownPathWebAuthn] directly. The resource is read only, so a request with a method other than GET or HEAD is
+// answered with a status of 405 and an Allow header.
+func (r RelatedOrigins) ServeHTTP(w http.ResponseWriter, request *http.Request) {
+	switch request.Method {
+	case http.MethodGet, http.MethodHead:
+		break
+	default:
+		w.Header().Set(headerAllow, methodsRelatedOrigins)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+
+		return
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+
+	if data, err = r.Bytes(); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set(headerContentType, mimeApplicationJSON)
+	w.Header().Set(headerContentLength, strconv.Itoa(len(data)))
+	w.WriteHeader(http.StatusOK)
+
+	// A response to HEAD carries the headers which describe the document but not the document itself.
+	if request.Method == http.MethodHead {
+		return
+	}
+
+	//nolint:errcheck // The headers have been written, so a failed body write can only be reported by hanging up.
+	w.Write(data)
+}
+
+// DefaultRelatedOriginLabeler derives the registrable domain label of an origin by taking the leading label of the
+// last two labels of its host. An IP address literal, and a host of a single label such as localhost, is its own
+// label.
+//
+// This is exact when the public suffix of the host is a single label, which covers https://example.com and
+// https://www.example.com alike, and it is deliberately imprecise otherwise: the public suffix of
+// https://example.co.uk is two labels, so this returns 'co' where the registrable domain label is 'example'. The
+// effect is to over-count against [MaximumRelatedOriginLabels], which rejects a set of origins a client would have
+// accepted rather than serving one a client would truncate.
+//
+// A deployment which lists origins under a multi-label public suffix should count labels exactly by passing a
+// labeler backed by a public suffix list to [NewRelatedOriginsWithLabeler]; this module does not depend on such a
+// list so that consumers who do not need one do not carry it:
+//
+//	labeler := func(origin string) (label string, err error) {
+//		uri, err := url.Parse(origin)
+//		if err != nil {
+//			return "", err
+//		}
+//
+//		domain, err := publicsuffix.EffectiveTLDPlusOne(uri.Hostname())
+//		if err != nil {
+//			return "", err
+//		}
+//
+//		label, _, _ = strings.Cut(domain, ".")
+//
+//		return label, nil
+//	}
+func DefaultRelatedOriginLabeler(origin string) (label string, err error) {
+	var uri *url.URL
+
+	if uri, err = url.Parse(origin); err != nil {
+		return "", fmt.Errorf("error parsing origin '%s': %w", origin, err)
+	}
+
+	host := uri.Hostname()
+
+	if host == "" {
+		return "", fmt.Errorf("error determining the label of origin '%s': the origin has no host component", origin)
+	}
+
+	// A fully qualified host may carry a trailing root label, which is not one of the labels being counted.
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+
+	if ip := net.ParseIP(host); ip != nil {
+		return host, nil
+	}
+
+	labels := strings.Split(host, ".")
+
+	if len(labels) < 2 {
+		return host, nil
+	}
+
+	return labels[len(labels)-2], nil
+}
+
+// relatedOriginNormalize reduces an origin to the scheme and host which identify it, rejecting values which are not
+// an origin a client could match a ceremony against.
+func relatedOriginNormalize(origin string) (normalized string, err error) {
+	var uri *url.URL
+
+	if uri, err = url.Parse(origin); err != nil || uri.Scheme == "" {
+		return "", errors.New("the origin must be an absolute URL with a http or https scheme")
+	}
+
+	scheme := strings.ToLower(uri.Scheme)
+
+	switch scheme {
+	case "http", "https":
+		break
+	default:
+		return "", fmt.Errorf("the scheme must be either http or https but it is '%s'", uri.Scheme)
+	}
+
+	if uri.Host == "" {
+		return "", errors.New("the origin must have a host component")
+	}
+
+	host := strings.ToLower(uri.Host)
+
+	// The default port of the scheme is not part of the serialization of an origin. Trimming the suffix rather than
+	// rebuilding from the hostname preserves the brackets of an IPv6 address literal.
+	switch scheme {
+	case "http":
+		host = strings.TrimSuffix(host, ":80")
+	case "https":
+		host = strings.TrimSuffix(host, ":443")
+	}
+
+	return (&url.URL{Scheme: scheme, Host: host}).String(), nil
+}

--- a/protocol/related_origins_test.go
+++ b/protocol/related_origins_test.go
@@ -90,6 +90,46 @@ func TestNewRelatedOrigins(t *testing.T) {
 			expected: []string{"http://example.com"},
 		},
 		{
+			name:     "ShouldNormalizeAwayAnEmptyPort",
+			have:     []string{"https://example.com:"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "ShouldNormalizeAwayAnEmptyPortOfAnIPv6Literal",
+			have:     []string{"https://[::1]:"},
+			expected: []string{"https://[::1]"},
+		},
+		{
+			name:     "ShouldDeduplicateAnEmptyPortAgainstNoPort",
+			have:     []string{"https://example.com", "https://example.com:"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name: "ShouldRejectAPortAboveTheMaximum",
+			have: []string{"https://example.com:65536"},
+			err:  "error validating related origin 'https://example.com:65536': the port must be no greater than 65535 but it is '65536'",
+		},
+		{
+			name: "ShouldRejectAPortWhichOverflows",
+			have: []string{"https://example.com:999999999999999999999"},
+			err:  "error validating related origin 'https://example.com:999999999999999999999': the port must be no greater than 65535 but it is '999999999999999999999'",
+		},
+		{
+			name: "ShouldRejectAPortAboveTheMaximumOfAnIPv6Literal",
+			have: []string{"https://[::1]:70000"},
+			err:  "error validating related origin 'https://[::1]:70000': the port must be no greater than 65535 but it is '70000'",
+		},
+		{
+			name:     "ShouldAcceptTheMaximumPort",
+			have:     []string{"https://example.com:65535"},
+			expected: []string{"https://example.com:65535"},
+		},
+		{
+			name: "ShouldRejectAPortWithoutAHost",
+			have: []string{"https://:8443"},
+			err:  "error validating related origin 'https://:8443': the origin must have a host component",
+		},
+		{
 			name:     "ShouldPreserveTheBracketsOfAnIPv6Literal",
 			have:     []string{"https://[::1]:443", "https://[::1]:8443"},
 			expected: []string{"https://[::1]", "https://[::1]:8443"},

--- a/protocol/related_origins_test.go
+++ b/protocol/related_origins_test.go
@@ -1,0 +1,371 @@
+package protocol
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRelatedOrigins(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     []string
+		expected []string
+		err      string
+	}{
+		{
+			name:     "ShouldAcceptASingleOrigin",
+			have:     []string{"https://example.com"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "ShouldAcceptOriginsSharingALabel",
+			have:     []string{"https://example.com", "https://example.com.au", "https://example.de"},
+			expected: []string{"https://example.com", "https://example.com.au", "https://example.de"},
+		},
+		{
+			name:     "ShouldPreserveANonDefaultPort",
+			have:     []string{"https://example.com:8443"},
+			expected: []string{"https://example.com:8443"},
+		},
+		{
+			name:     "ShouldNormalizeAwayAPath",
+			have:     []string{"https://example.com/"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "ShouldNormalizeAwayAQueryAndFragment",
+			have:     []string{"https://example.com/x?y=z"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "ShouldDeduplicateOriginsWhichNormalizeToTheSameValue",
+			have:     []string{"https://example.com", "https://example.com/", "https://example.com/path"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "ShouldAcceptAnHTTPOrigin",
+			have:     []string{"http://localhost:8080"},
+			expected: []string{"http://localhost:8080"},
+		},
+		{
+			name: "ShouldRejectNoOrigins",
+			have: nil,
+			err:  "error validating related origins: at least one origin is required",
+		},
+		{
+			name: "ShouldRejectAnEmptyOrigin",
+			have: []string{""},
+			err:  "error validating related origin '': the origin must be an absolute URL with a http or https scheme",
+		},
+		{
+			name: "ShouldRejectAnOriginWithoutAScheme",
+			have: []string{"example.com"},
+			err:  "error validating related origin 'example.com': the origin must be an absolute URL with a http or https scheme",
+		},
+		{
+			name: "ShouldRejectANonHTTPScheme",
+			have: []string{"ftp://example.com"},
+			err:  "error validating related origin 'ftp://example.com': the scheme must be either http or https but it is 'ftp'",
+		},
+		{
+			name: "ShouldRejectAnAndroidAPKKeyHash",
+			have: []string{"android:apk-key-hash:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+			err:  "error validating related origin 'android:apk-key-hash:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA': the scheme must be either http or https but it is 'android'",
+		},
+		{
+			name:     "ShouldNormalizeAwayTheDefaultHTTPSPort",
+			have:     []string{"https://example.com:443"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "ShouldNormalizeAwayTheDefaultHTTPPort",
+			have:     []string{"http://example.com:80"},
+			expected: []string{"http://example.com"},
+		},
+		{
+			name:     "ShouldPreserveTheBracketsOfAnIPv6Literal",
+			have:     []string{"https://[::1]:443", "https://[::1]:8443"},
+			expected: []string{"https://[::1]", "https://[::1]:8443"},
+		},
+		{
+			name:     "ShouldLowercaseTheSchemeAndHost",
+			have:     []string{"HTTPS://EXAMPLE.COM"},
+			expected: []string{"https://example.com"},
+		},
+		{
+			name: "ShouldRejectAnOriginWithoutAHost",
+			have: []string{"https:///path"},
+			err:  "error validating related origin 'https:///path': the origin must have a host component",
+		},
+		{
+			name: "ShouldRejectMoreLabelsThanClientsProcess",
+			have: []string{"https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com", "https://f.com"},
+			err:  "error validating related origins: the origins have 6 distinct registrable domain labels but clients only process 5 of them, so origins beyond that limit are ignored",
+		},
+		{
+			name: "ShouldAcceptExactlyTheLabelLimit",
+			have: []string{"https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com"},
+			expected: []string{
+				"https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			related, err := NewRelatedOrigins(tc.have...)
+
+			if tc.err != "" {
+				assert.Nil(t, related)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, related)
+			assert.Equal(t, tc.expected, related.Origins)
+		})
+	}
+}
+
+// TestNewRelatedOriginsWithLabeler covers the label derivation being replaceable, which is how a deployment using a
+// multi-label public suffix obtains exact label counting without this module depending on a public suffix list.
+func TestNewRelatedOriginsWithLabeler(t *testing.T) {
+	// Stands in for a public suffix list backed labeler: every origin below has the registrable domain label
+	// 'example', so the six of them cost one label rather than six.
+	labeler := func(origin string) (label string, err error) {
+		return "example", nil
+	}
+
+	// Every one of these is the registrable domain 'example' under a multi-label public suffix, so a client counts
+	// one label for the set. The default labeler sees six distinct labels instead: co, com, ne, or, ac and gov.
+	origins := []string{
+		"https://example.co.uk", "https://example.com.au", "https://example.ne.jp",
+		"https://example.or.kr", "https://example.ac.nz", "https://example.gov.uk",
+	}
+
+	t.Run("ShouldRejectTheseOriginsWithTheDefaultLabeler", func(t *testing.T) {
+		related, err := NewRelatedOrigins(origins...)
+
+		assert.Nil(t, related)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "distinct registrable domain labels")
+	})
+
+	t.Run("ShouldAcceptTheseOriginsWithAPublicSuffixLabeler", func(t *testing.T) {
+		related, err := NewRelatedOriginsWithLabeler(labeler, origins...)
+
+		require.NoError(t, err)
+		require.NotNil(t, related)
+		assert.Equal(t, origins, related.Origins)
+	})
+
+	t.Run("ShouldPropagateALabelerError", func(t *testing.T) {
+		related, err := NewRelatedOriginsWithLabeler(func(origin string) (string, error) {
+			return "", errors.New("no label for you")
+		}, "https://example.com")
+
+		assert.Nil(t, related)
+		assert.EqualError(t, err, "error validating related origin 'https://example.com': error determining the registrable domain label: no label for you")
+	})
+
+	t.Run("ShouldUseTheDefaultLabelerWhenNil", func(t *testing.T) {
+		related, err := NewRelatedOriginsWithLabeler(nil, "https://example.com")
+
+		require.NoError(t, err)
+		require.NotNil(t, related)
+		assert.Equal(t, []string{"https://example.com"}, related.Origins)
+	})
+}
+
+func TestDefaultRelatedOriginLabeler(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     string
+		expected string
+		err      string
+	}{
+		{name: "ShouldUseTheRegistrableLabel", have: "https://example.com", expected: "example"},
+		{name: "ShouldIgnoreASubdomain", have: "https://www.example.com", expected: "example"},
+		{name: "ShouldIgnoreAPort", have: "https://example.com:8443", expected: "example"},
+		{name: "ShouldLowercaseTheLabel", have: "https://EXAMPLE.com", expected: "example"},
+		{name: "ShouldUseTheWholeHostWhenSingleLabel", have: "http://localhost:8080", expected: "localhost"},
+		{name: "ShouldUseTheWholeHostForAnIPv4Address", have: "https://127.0.0.1", expected: "127.0.0.1"},
+		{name: "ShouldUseTheWholeHostForAnIPv6Address", have: "https://[::1]:8443", expected: "::1"},
+
+		// The documented imprecision of the default labeler: a multi-label public suffix yields the suffix's own
+		// leading label rather than the registrable one, which over-counts against the limit.
+		{name: "ShouldOverCountAMultiLabelPublicSuffix", have: "https://example.co.uk", expected: "co"},
+
+		{name: "ShouldErrorOnAnUnparseableOrigin", have: "https://exa mple.com", err: "error parsing origin"},
+		{name: "ShouldErrorOnAnOriginWithoutAHost", have: "https:///path", err: "the origin has no host component"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, err := DefaultRelatedOriginLabeler(tc.have)
+
+			if tc.err != "" {
+				assert.Empty(t, label)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, label)
+		})
+	}
+}
+
+func TestRelatedOriginsBytes(t *testing.T) {
+	t.Run("ShouldProduceTheWellKnownDocument", func(t *testing.T) {
+		related, err := NewRelatedOrigins("https://example.com", "https://example.com.au")
+		require.NoError(t, err)
+
+		data, err := related.Bytes()
+
+		require.NoError(t, err)
+		assert.Equal(t, `{"origins":["https://example.com","https://example.com.au"]}`, string(data))
+	})
+
+	t.Run("ShouldProduceAnEmptyArrayForTheZeroValue", func(t *testing.T) {
+		data, err := RelatedOrigins{}.Bytes()
+
+		require.NoError(t, err)
+		assert.Equal(t, `{"origins":[]}`, string(data))
+	})
+}
+
+func TestRelatedOriginsWriteTo(t *testing.T) {
+	t.Run("ShouldWriteTheDocumentAndReportTheCount", func(t *testing.T) {
+		related, err := NewRelatedOrigins("https://example.com")
+		require.NoError(t, err)
+
+		builder := &strings.Builder{}
+
+		n, err := related.WriteTo(builder)
+
+		require.NoError(t, err)
+		assert.Equal(t, `{"origins":["https://example.com"]}`, builder.String())
+		assert.Equal(t, int64(builder.Len()), n)
+	})
+
+	t.Run("ShouldSatisfyIOWriterTo", func(t *testing.T) {
+		related, err := NewRelatedOrigins("https://example.com")
+		require.NoError(t, err)
+
+		var writerTo io.WriterTo = related
+
+		builder := &strings.Builder{}
+
+		_, err = writerTo.WriteTo(builder)
+
+		require.NoError(t, err)
+		assert.Equal(t, `{"origins":["https://example.com"]}`, builder.String())
+	})
+
+	t.Run("ShouldPropagateAWriteError", func(t *testing.T) {
+		related, err := NewRelatedOrigins("https://example.com")
+		require.NoError(t, err)
+
+		n, err := related.WriteTo(&testErrorWriter{err: errors.New("disk on fire")})
+
+		assert.EqualError(t, err, "disk on fire")
+		assert.Equal(t, int64(0), n)
+	})
+}
+
+func TestRelatedOriginsWriteResponse(t *testing.T) {
+	t.Run("ShouldWriteTheDocumentWithTheJSONContentType", func(t *testing.T) {
+		related, err := NewRelatedOrigins("https://example.com")
+		require.NoError(t, err)
+
+		recorder := httptest.NewRecorder()
+
+		require.NoError(t, related.WriteResponse(recorder))
+
+		result := recorder.Result()
+
+		defer result.Body.Close()
+
+		assert.Equal(t, http.StatusOK, result.StatusCode)
+		assert.Equal(t, "application/json", result.Header.Get("Content-Type"))
+		assert.Equal(t, `{"origins":["https://example.com"]}`, recorder.Body.String())
+	})
+}
+
+func TestRelatedOriginsServeHTTP(t *testing.T) {
+	related, err := NewRelatedOrigins("https://example.com")
+	require.NoError(t, err)
+
+	t.Run("ShouldSatisfyHTTPHandler", func(t *testing.T) {
+		var handler http.Handler = related
+
+		assert.NotNil(t, handler)
+	})
+
+	t.Run("ShouldServeAGet", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		related.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, WellKnownPathWebAuthn, nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+		assert.Equal(t, `{"origins":["https://example.com"]}`, recorder.Body.String())
+	})
+
+	t.Run("ShouldServeAHead", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+
+		related.ServeHTTP(recorder, httptest.NewRequest(http.MethodHead, WellKnownPathWebAuthn, nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+		assert.Empty(t, recorder.Body.String())
+	})
+
+	t.Run("ShouldRejectOtherMethodsWithAnAllowHeader", func(t *testing.T) {
+		for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+			t.Run(method, func(t *testing.T) {
+				recorder := httptest.NewRecorder()
+
+				related.ServeHTTP(recorder, httptest.NewRequest(method, WellKnownPathWebAuthn, nil))
+
+				assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+				assert.Equal(t, "GET, HEAD", recorder.Header().Get("Allow"))
+				assert.Empty(t, recorder.Body.String())
+			})
+		}
+	})
+
+	t.Run("ShouldMountOnAServeMuxAtTheWellKnownPath", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.Handle(WellKnownPathWebAuthn, related)
+
+		recorder := httptest.NewRecorder()
+
+		mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, WellKnownPathWebAuthn, nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, `{"origins":["https://example.com"]}`, recorder.Body.String())
+	})
+}
+
+// testErrorWriter is an [io.Writer] which always fails, used to cover the error paths of the writers.
+type testErrorWriter struct {
+	err error
+}
+
+func (w *testErrorWriter) Write(p []byte) (n int, err error) {
+	return 0, w.err
+}

--- a/webauthn/related_origins.go
+++ b/webauthn/related_origins.go
@@ -1,0 +1,27 @@
+package webauthn
+
+import (
+	"github.com/go-webauthn/webauthn/protocol"
+)
+
+// RelatedOrigins returns the [protocol.RelatedOrigins] document declaring the origins in [Config.RPOrigins], which is
+// what a Relying Party serves at [protocol.WellKnownPathWebAuthn] so clients accept ceremonies from origins which do
+// not match [Config.RPID] directly. The returned value is an [net/http.Handler], so it can be mounted as it is:
+//
+//	related, err := w.RelatedOrigins()
+//	if err != nil {
+//		return err
+//	}
+//
+//	mux.Handle(protocol.WellKnownPathWebAuthn, related)
+//
+// The origins are validated and normalized by [protocol.NewRelatedOrigins], so this returns an error when the
+// configured origins carry more than [protocol.MaximumRelatedOriginLabels] distinct registrable domain labels. A
+// Relying Party whose origins sit under a multi-label public suffix should count those labels with a public suffix
+// list by calling [protocol.NewRelatedOriginsWithLabeler] with [Config.RPOrigins] instead, and one which serves a set
+// of origins other than the configured ones should call [protocol.NewRelatedOrigins] with that set.
+//
+// Specification: §5.11. Related Origin Requests (https://www.w3.org/TR/webauthn-3/#sctn-related-origins)
+func (webauthn *WebAuthn) RelatedOrigins() (related *protocol.RelatedOrigins, err error) {
+	return protocol.NewRelatedOrigins(webauthn.Config.RPOrigins...)
+}

--- a/webauthn/related_origins_test.go
+++ b/webauthn/related_origins_test.go
@@ -1,0 +1,89 @@
+package webauthn
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-webauthn/webauthn/protocol"
+)
+
+func TestWebAuthnRelatedOrigins(t *testing.T) {
+	t.Run("ShouldBuildTheDocumentFromTheConfiguredOrigins", func(t *testing.T) {
+		w, err := New(&Config{
+			RPID:          "example.com",
+			RPDisplayName: "Test Display Name",
+			RPOrigins:     []string{"https://example.com", "https://example.com.au"},
+		})
+		require.NoError(t, err)
+
+		related, err := w.RelatedOrigins()
+
+		require.NoError(t, err)
+		require.NotNil(t, related)
+		assert.Equal(t, []string{"https://example.com", "https://example.com.au"}, related.Origins)
+
+		data, err := related.Bytes()
+
+		require.NoError(t, err)
+		assert.Equal(t, `{"origins":["https://example.com","https://example.com.au"]}`, string(data))
+	})
+
+	t.Run("ShouldNormalizeTheConfiguredOrigins", func(t *testing.T) {
+		w, err := New(&Config{
+			RPID:          "example.com",
+			RPDisplayName: "Test Display Name",
+			RPOrigins:     []string{"https://example.com:443", "https://example.com/"},
+		})
+		require.NoError(t, err)
+
+		related, err := w.RelatedOrigins()
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://example.com"}, related.Origins)
+	})
+
+	t.Run("ShouldServeTheDocumentAtTheWellKnownPath", func(t *testing.T) {
+		w, err := New(&Config{
+			RPID:          "example.com",
+			RPDisplayName: "Test Display Name",
+			RPOrigins:     []string{"https://example.com"},
+		})
+		require.NoError(t, err)
+
+		related, err := w.RelatedOrigins()
+		require.NoError(t, err)
+
+		mux := http.NewServeMux()
+		mux.Handle(protocol.WellKnownPathWebAuthn, related)
+
+		recorder := httptest.NewRecorder()
+
+		mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, protocol.WellKnownPathWebAuthn, nil))
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+		assert.Equal(t, `{"origins":["https://example.com"]}`, recorder.Body.String())
+	})
+
+	t.Run("ShouldErrorWhenTheConfiguredOriginsExceedTheLabelLimit", func(t *testing.T) {
+		w, err := New(&Config{
+			RPID:          "example.com",
+			RPDisplayName: "Test Display Name",
+			RPOrigins: []string{
+				"https://a.com", "https://b.com", "https://c.com",
+				"https://d.com", "https://e.com", "https://f.com",
+			},
+		})
+		require.NoError(t, err)
+
+		related, err := w.RelatedOrigins()
+
+		assert.Nil(t, related)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "6 distinct registrable domain labels")
+	})
+}


### PR DESCRIPTION
§5.11 lets a Relying Party declare the origins which may run ceremonies against its Relying Party ID by serving a JSON document at /.well-known/webauthn, but nothing here produced that document, leaving each Relying Party to hand write it and keep it in step with the origins it configures. RelatedOrigins models the document and NewRelatedOrigins builds one, requiring every origin to be an absolute http or https URL with a host and normalizing it to the scheme and host which identify it, with a default port and any path, query, fragment or userinfo removed and duplicates collapsed. An absent origin list marshals as an empty array rather than as null, and the document can be served through Bytes, WriteTo or WriteResponse, or mounted on a router as it is since the type implements http.Handler, answering a request whose method is neither GET nor HEAD with a 405 and an Allow header. WebAuthn.RelatedOrigins builds the document from the configured origins.

A client processes a limited number of registrable domain labels and silently ignores origins whose label falls outside that budget, so a set carrying more labels than the five clients are required to support is rejected at construction rather than served as a document a client would truncate without any signal it had done so. Labels are counted by DefaultRelatedOriginLabeler, which takes the leading label of the last two labels of the host and is therefore exact only when the public suffix is a single label; under a multi-label public suffix such as co.uk it over-counts, rejecting a set a client would have accepted rather than the reverse. A deployment which needs the count to be exact passes a labeler backed by a public suffix list to NewRelatedOriginsWithLabeler, so consumers who do not need such a list do not carry one.