### PR TITLE
feat!: opaque origin configuration

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -145,14 +145,14 @@ func (car CredentialAssertionResponse) Parse() (par *ParsedCredentialAssertionDa
 // documentation. It's important to note that the credentialBytes field is the CBOR representation of the credential.
 //
 // Specification: §7.2 Verifying an Authentication Assertion (https://www.w3.org/TR/webauthn/#sctn-verifying-assertion)
-func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPartyID, appID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, credentialBytes []byte, signature SignaturePolicy) error {
+func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPartyID, appID string, rpOrigins, rpOpaqueOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, credentialBytes []byte, signature SignaturePolicy) error {
 	// Steps 4 through 6 in verifying the assertion data (https://www.w3.org/TR/webauthn/#verifying-assertion) are
 	// "assertive" steps, i.e. "Let JSONtext be the result of running UTF-8 decode on the value of cData."
 	// We handle these steps in part as we verify but also beforehand
 	//
 	// Handle steps 7 through 10 of assertion by verifying stored data against the Collected Client Data
 	// returned by the authenticator.
-	validError := p.Response.CollectedClientData.Verify(storedChallenge, AssertCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin)
+	validError := p.Response.CollectedClientData.Verify(storedChallenge, AssertCeremony, rpOrigins, rpOpaqueOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin)
 	if validError != nil {
 		return validError
 	}

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -351,7 +351,7 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := par.Verify(tc.challenge, tc.relyingPartyID, tc.appID, tc.rpOrigins, nil, TopOriginExplicitVerificationMode, false, false, true, tc.credentialBytes, SignaturePolicy{})
+			err := par.Verify(tc.challenge, tc.relyingPartyID, tc.appID, tc.rpOrigins, nil, nil, TopOriginExplicitVerificationMode, false, false, true, tc.credentialBytes, SignaturePolicy{})
 
 			if tc.err == "" {
 				assert.NoError(t, err)

--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -60,7 +60,7 @@ func TestAttestationVerify(t *testing.T) {
 
 			pcc.Response = *parsedAttestationResponse
 
-			_, err = pcc.Verify(options.Response.Challenge.String(), options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, TopOriginExplicitVerificationMode, false, false, false, nil, options.Response.Parameters, AttestationPolicy{}, SignaturePolicy{})
+			_, err = pcc.Verify(options.Response.Challenge.String(), options.Response.RelyingParty.ID, []string{options.Response.RelyingParty.Name}, nil, nil, TopOriginExplicitVerificationMode, false, false, false, nil, options.Response.Parameters, AttestationPolicy{}, SignaturePolicy{})
 
 			require.NoError(t, err)
 		})

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -111,8 +111,13 @@ func FullyQualifiedOrigin(rawOrigin string) (fqOrigin string, err error) {
 // Note: the rpTopOriginsVerify parameter does not accept the TopOriginVerificationMode value of
 // TopOriginDefaultVerificationMode as it's expected this value is updated by the config validation process.
 //
+// The rpOpaqueOrigins parameter carries the origins which are not http or https tuple origins, i.e. those for which
+// [IsOpaqueOrigin] returns true. They widen the set the ceremony origin is matched against, and only that set; the
+// Top Origin is deliberately never matched against them as a Top Origin is by definition the origin of a top-level
+// browsing context.
+//
 //nolint:gocyclo
-func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyType, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin bool) (err error) {
+func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyType, rpOrigins, rpOpaqueOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin bool) (err error) {
 	// Registration Step 3. Verify that the value of C.type is webauthn.create.
 
 	// Assertion Step 7. Verify that the value of C.type is the string webauthn.get.
@@ -137,10 +142,18 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	// Registration Step 5 & Assertion Step 9. Verify that the value of C.origin matches
 	// the Relying Party's origin.
 
-	if !IsOriginInHaystack(c.Origin, rpOrigins) {
+	if !IsOriginInHaystack(c.Origin, rpOrigins) && !IsOriginInHaystack(c.Origin, rpOpaqueOrigins) {
+		possibleOrigins := rpOrigins
+
+		if len(rpOpaqueOrigins) != 0 {
+			possibleOrigins = make([]string, 0, len(rpOrigins)+len(rpOpaqueOrigins))
+			possibleOrigins = append(possibleOrigins, rpOrigins...)
+			possibleOrigins = append(possibleOrigins, rpOpaqueOrigins...)
+		}
+
 		return ErrVerification.
 			WithDetails("Error validating origin").
-			WithInfo(fmt.Sprintf("Expected Values: %s, Received: %s", rpOrigins, c.Origin))
+			WithInfo(fmt.Sprintf("Expected Values: %s, Received: %s", possibleOrigins, c.Origin))
 	}
 
 	if !allowCrossOrigin && c.CrossOrigin {

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -15,6 +15,7 @@ func TestVerifyCollectedClientData(t *testing.T) {
 		topOrigin       string
 		crossOrigin     bool
 		rpOrigins       []string
+		rpOpaqueOrigins []string
 		rpTopOrigins    []string
 		topOriginMode   TopOriginVerificationMode
 		allowCrossOrign bool
@@ -139,6 +140,61 @@ func TestVerifyCollectedClientData(t *testing.T) {
 			err:             "Error validating top origin",
 		},
 		{
+			name:            "ShouldSucceedOpaqueOrigin",
+			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+		},
+		{
+			name:            "ShouldFailOpaqueOriginNotConfigured",
+			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"android:apk-key-hash:9C4B4AEEF05536E730EC4B802E767F67"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			errType:         "verification_error",
+			errDetails:      "Error validating origin",
+			errInfo:         "Expected Values: [https://example.com android:apk-key-hash:9C4B4AEEF05536E730EC4B802E767F67], Received: android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+		},
+		{
+			name:            "ShouldFailOpaqueTopOriginImplicit",
+			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			topOrigin:       "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginImplicitVerificationMode,
+			err:             "Error validating top origin",
+		},
+		{
+			name:            "ShouldFailOpaqueTopOriginAuto",
+			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			topOrigin:       "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginAutoVerificationMode,
+			err:             "Error validating top origin",
+		},
+		{
+			name:            "ShouldFailOpaqueTopOriginExplicit",
+			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			topOrigin:       "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			crossOrigin:     true,
+			allowCrossOrign: true,
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			err:             "Error validating top origin",
+		},
+		{
 			name:          "ShouldFailCeremonyMismatch",
 			origin:        "http://example.com",
 			crossOrigin:   false,
@@ -172,7 +228,7 @@ func TestVerifyCollectedClientData(t *testing.T) {
 				ceremony = ccd.Type
 			}
 
-			err = ccd.Verify(challenge.String(), ceremony, rpOrigins, rpTopOrigins, tc.topOriginMode, tc.allowCrossOrign)
+			err = ccd.Verify(challenge.String(), ceremony, rpOrigins, tc.rpOpaqueOrigins, rpTopOrigins, tc.topOriginMode, tc.allowCrossOrign)
 
 			switch {
 			case tc.err != "":
@@ -195,7 +251,7 @@ func TestVerifyCollectedClientData_IncorrectChallenge(t *testing.T) {
 	bogusChallenge, err := CreateChallenge()
 	require.NoError(t, err)
 
-	AssertIsProtocolError(t, ccd.Verify(bogusChallenge.String(), ccd.Type, []string{ccd.Origin}, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode, true), "verification_error", "Error validating challenge", fmt.Sprintf("Expected b Value: \"%s\"\nReceived b: \"%s\"\n", bogusChallenge.String(), challenge.String()))
+	AssertIsProtocolError(t, ccd.Verify(bogusChallenge.String(), ccd.Type, []string{ccd.Origin}, nil, []string{ccd.TopOrigin}, TopOriginExplicitVerificationMode, true), "verification_error", "Error validating challenge", fmt.Sprintf("Expected b Value: \"%s\"\nReceived b: \"%s\"\n", bogusChallenge.String(), challenge.String()))
 }
 
 func TestVerifyCollectedClientData_TokenBinding(t *testing.T) {
@@ -240,7 +296,7 @@ func TestVerifyCollectedClientData_TokenBinding(t *testing.T) {
 			ccd := setupCollectedClientData(newChallenge, "http://example.com", "", false)
 			ccd.TokenBinding = tc.tokenBinding
 
-			err = ccd.Verify(newChallenge.String(), CreateCeremony, []string{ccd.Origin}, nil, TopOriginExplicitVerificationMode, false)
+			err = ccd.Verify(newChallenge.String(), CreateCeremony, []string{ccd.Origin}, nil, nil, TopOriginExplicitVerificationMode, false)
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
 			} else {

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -169,9 +169,9 @@ func (ccr CredentialCreationResponse) Parse() (pcc *ParsedCredentialCreationData
 // Verify the Client and Attestation data.
 //
 // Specification: §7.1. Registering a New Credential (https://www.w3.org/TR/webauthn/#sctn-registering-a-new-credential)
-func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, mds metadata.Provider, credParams []CredentialParameter, policy AttestationPolicy, signature SignaturePolicy) (clientDataHash []byte, err error) {
+func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingPartyID string, rpOrigins, rpOpaqueOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin, verifyUser, verifyUserPresence bool, mds metadata.Provider, credParams []CredentialParameter, policy AttestationPolicy, signature SignaturePolicy) (clientDataHash []byte, err error) {
 	// Handles steps 3 through 6 - Verifying the Client Data against the Relying Party's stored data.
-	if err = pcc.Response.CollectedClientData.Verify(storedChallenge, CreateCeremony, rpOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin); err != nil {
+	if err = pcc.Response.CollectedClientData.Verify(storedChallenge, CreateCeremony, rpOrigins, rpOpaqueOrigins, rpTopOrigins, rpTopOriginsVerify, allowCrossOrigin); err != nil {
 		return nil, err
 	}
 

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -270,7 +270,7 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 				Raw:                       tc.fields.Raw,
 			}
 
-			actual, err := pcc.Verify(tc.args.storedChallenge.String(), tc.args.relyingPartyID, tc.args.relyingPartyOrigin, nil, TopOriginExplicitVerificationMode, false, tc.args.verifyUser, false, nil, tc.args.credParams, AttestationPolicy{}, SignaturePolicy{})
+			actual, err := pcc.Verify(tc.args.storedChallenge.String(), tc.args.relyingPartyID, tc.args.relyingPartyOrigin, nil, nil, TopOriginExplicitVerificationMode, false, tc.args.verifyUser, false, nil, tc.args.credParams, AttestationPolicy{}, SignaturePolicy{})
 
 			assert.Equal(t, tc.expected, actual)
 

--- a/protocol/related_origins.go
+++ b/protocol/related_origins.go
@@ -281,6 +281,19 @@ func DefaultRelatedOriginLabeler(origin string) (label string, err error) {
 	return labels[len(labels)-2], nil
 }
 
+// IsOpaqueOrigin returns true when the origin is not one a [RelatedOrigins] document can express, i.e. anything which
+// is not an absolute http or https URL with a host component. An opaque origin is matched by simple string comparison
+// rather than by the origin equality semantics of [IsOriginInHaystack], and a client never resolves one through the
+// well-known resource, so a Relying Party which accepts an opaque origin such as 'android:apk-key-hash:...' declares
+// it separately from the origins it serves at [WellKnownPathWebAuthn].
+//
+// Specification: §5.11. Related Origin Requests (https://www.w3.org/TR/webauthn-3/#sctn-related-origins)
+func IsOpaqueOrigin(origin string) bool {
+	_, err := relatedOriginNormalize(origin)
+
+	return err != nil
+}
+
 // relatedOriginNormalize reduces an origin to the scheme and host which identify it, rejecting values which are not
 // an origin a client could match a ceremony against.
 func relatedOriginNormalize(origin string) (normalized string, err error) {

--- a/protocol/related_origins_test.go
+++ b/protocol/related_origins_test.go
@@ -401,6 +401,31 @@ func TestRelatedOriginsServeHTTP(t *testing.T) {
 	})
 }
 
+func TestIsOpaqueOrigin(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     string
+		expected bool
+	}{
+		{name: "ShouldNotConsiderAnHTTPSOriginOpaque", have: "https://example.com", expected: false},
+		{name: "ShouldNotConsiderAnHTTPOriginOpaque", have: "http://localhost:8080", expected: false},
+		{name: "ShouldNotConsiderAnUppercaseSchemeOpaque", have: "HTTPS://example.com", expected: false},
+		{name: "ShouldNotConsiderAnIPv6LiteralOpaque", have: "https://[::1]:8443", expected: false},
+		{name: "ShouldConsiderAnAndroidKeyHashOpaque", have: "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: true},
+		{name: "ShouldConsiderAnUnknownSchemeOpaque", have: "ios:bundle-id:com.example.app", expected: true},
+		{name: "ShouldConsiderASchemelessValueOpaque", have: "example.com", expected: true},
+		{name: "ShouldConsiderAnHTTPSURLWithoutAHostOpaque", have: "https:///path", expected: true},
+		{name: "ShouldConsiderAnUnparseableValueOpaque", have: "https://exa mple.com", expected: true},
+		{name: "ShouldConsiderAnEmptyValueOpaque", have: "", expected: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsOpaqueOrigin(tc.have))
+		})
+	}
+}
+
 // testErrorWriter is an [io.Writer] which always fails, used to cover the error paths of the writers.
 type testErrorWriter struct {
 	err error

--- a/protocol/specification_vectors_e2e_test.go
+++ b/protocol/specification_vectors_e2e_test.go
@@ -276,7 +276,7 @@ func TestSpecVectors_Registration_E2E(t *testing.T) {
 
 			challenge := base64.RawURLEncoding.EncodeToString(specTestDecodeHex(t, tc.challenge))
 
-			_, err = pcc.Verify(challenge, specTestRPID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, tc.mds, tc.credParams, AttestationPolicy{}, SignaturePolicy{})
+			_, err = pcc.Verify(challenge, specTestRPID, []string{specTestOrigin}, nil, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, tc.mds, tc.credParams, AttestationPolicy{}, SignaturePolicy{})
 
 			if tc.err == "" {
 				assert.NoError(t, err)
@@ -533,7 +533,7 @@ func TestSpecVectors_Authentication_E2E(t *testing.T) {
 			challenge := base64.RawURLEncoding.EncodeToString(specTestDecodeHex(t, tc.challenge))
 			credPubKey := specTestDecodeHex(t, tc.credentialPubKey)
 
-			err = par.Verify(challenge, specTestRPID, tc.appID, []string{specTestOrigin}, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, credPubKey, SignaturePolicy{})
+			err = par.Verify(challenge, specTestRPID, tc.appID, []string{specTestOrigin}, nil, tc.rpTopOrigins, tc.rpTopOriginVerificationMode, tc.allowCrossOrigin, false, true, credPubKey, SignaturePolicy{})
 
 			if tc.err == "" {
 				assert.NoError(t, err)

--- a/protocol/webauthncose/cose_algorithm_identifier.go
+++ b/protocol/webauthncose/cose_algorithm_identifier.go
@@ -1,9 +1,9 @@
 package webauthncose
 
 import (
-	"strconv"
 	"crypto"
 	"crypto/x509"
+	"strconv"
 )
 
 // COSEAlgorithmIdentifier is a number identifying a cryptographic algorithm. The algorithm identifiers SHOULD be values

--- a/webauthn/const.go
+++ b/webauthn/const.go
@@ -7,6 +7,10 @@ import (
 const (
 	errFmtFieldNotValidDomainString = "field '%s' is not a valid domain string: %w"
 	errFmtConfigValidate            = "error occurred validating the configuration: %w"
+
+	errFmtOriginsNotRelated      = "when the 'RPOpaqueOrigins' field is configured the '%s' field must only contain origins a Related Origin Requests document can declare: %w"
+	errFmtOriginsNotRelatedValue = "when the 'RPOpaqueOrigins' field is configured the '%s' field must only contain origins a Related Origin Requests document can declare but the value '%s' is opaque"
+	errFmtOriginsNotOpaqueValue  = "the 'RPOpaqueOrigins' field must only contain opaque origins but the value '%s' is not opaque; it belongs in the 'RPOrigins' field"
 )
 
 const (

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -366,6 +366,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 
 	rpID := session.GetRelyingPartyID(webauthn.Config.RPID)
 	rpOrigins := webauthn.Config.RPOrigins
+	rpOpaqueOrigins := webauthn.Config.RPOpaqueOrigins
 	rpTopOrigins := webauthn.Config.RPTopOrigins
 
 	if appID, err = parsedResponse.GetAppID(session.Extensions, credential.AttestationFormat); err != nil {
@@ -373,7 +374,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 	}
 
 	// Handle steps 4 through 16.
-	if err = parsedResponse.Verify(session.Challenge, rpID, appID, rpOrigins, rpTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, credential.PublicKey, webauthn.Config.Signature); err != nil {
+	if err = parsedResponse.Verify(session.Challenge, rpID, appID, rpOrigins, rpOpaqueOrigins, rpTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, credential.PublicKey, webauthn.Config.Signature); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -1671,6 +1671,100 @@ func testLoginSpecVectorNoneES256(t *testing.T) (parsedResponse *protocol.Parsed
 	return parsedResponse, credPubKey, challenge, credentialID
 }
 
+// TestValidateLoginOpaqueOrigin covers [Config.RPOpaqueOrigins] reaching the assertion verifier. The client data of
+// the vector is signed over, so replacing its origin invalidates the assertion signature; the origin is verified well
+// before the signature is, which is what lets the signature failure stand as proof the origin was accepted.
+func TestValidateLoginOpaqueOrigin(t *testing.T) {
+	const origin = "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"
+
+	testCases := []struct {
+		name            string
+		rpOpaqueOrigins []string
+		err             string
+	}{
+		{
+			name:            "ShouldAcceptAConfiguredOpaqueOrigin",
+			rpOpaqueOrigins: []string{origin},
+			err:             "Error validating the assertion signature: <nil>",
+		},
+		{
+			name: "ShouldRejectAnOpaqueOriginWhichIsNotConfigured",
+			err:  "Error validating origin",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsedResponse, credPubKey, challenge, credentialID := testLoginSpecVectorNoneES256Origin(t, origin)
+
+			userID := []byte(testUserID)
+
+			w := &WebAuthn{
+				Config: &Config{
+					RPID:            "example.org",
+					RPOrigins:       []string{"https://example.org"},
+					RPOpaqueOrigins: tc.rpOpaqueOrigins,
+				},
+			}
+
+			user := &defaultUser{
+				id: userID,
+				credentials: []Credential{
+					{
+						ID:        credentialID,
+						PublicKey: credPubKey,
+						Flags: CredentialFlags{
+							UserPresent:    true,
+							BackupEligible: true,
+						},
+					},
+				},
+			}
+
+			credential, err := w.ValidateLogin(user, SessionData{Challenge: challenge, UserID: userID}, parsedResponse)
+
+			assert.Nil(t, credential)
+			assert.EqualError(t, err, tc.err)
+		})
+	}
+}
+
+// testLoginSpecVectorNoneES256Origin returns the spec test vector data for NoneES256 authentication with the origin
+// of the client data replaced by origin, which invalidates the assertion signature over it.
+func testLoginSpecVectorNoneES256Origin(t *testing.T, origin string) (parsedResponse *protocol.ParsedCredentialAssertionData, credPubKey []byte, challenge string, credentialID []byte) {
+	t.Helper()
+
+	parsedResponse, credPubKey, challenge, credentialID = testLoginSpecVectorNoneES256(t)
+
+	var clientData map[string]any
+
+	require.NoError(t, json.Unmarshal(parsedResponse.Raw.AssertionResponse.ClientDataJSON, &clientData))
+
+	clientData["origin"] = origin
+
+	raw, err := json.Marshal(clientData)
+	require.NoError(t, err)
+
+	body := map[string]any{
+		"id":    base64.RawURLEncoding.EncodeToString(credentialID),
+		"rawId": base64.RawURLEncoding.EncodeToString(credentialID),
+		"type":  "public-key",
+		"response": map[string]any{
+			"authenticatorData": base64.RawURLEncoding.EncodeToString(parsedResponse.Raw.AssertionResponse.AuthenticatorData),
+			"clientDataJSON":    base64.RawURLEncoding.EncodeToString(raw),
+			"signature":         base64.RawURLEncoding.EncodeToString(parsedResponse.Response.Signature),
+		},
+	}
+
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	parsedResponse, err = protocol.ParseCredentialRequestResponseBytes(data)
+	require.NoError(t, err)
+
+	return parsedResponse, credPubKey, challenge, credentialID
+}
+
 func TestBeginLoginOptionError(t *testing.T) {
 	w, err := New(&Config{RPID: "example.com", RPDisplayName: "Test", RPOrigins: []string{"https://example.com"}})
 	require.NoError(t, err)

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -164,7 +164,7 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 	var clientDataHash []byte
 
-	if clientDataHash, err = parsedResponse.Verify(session.Challenge, session.GetRelyingPartyID(webauthn.Config.RPID), webauthn.Config.RPOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
+	if clientDataHash, err = parsedResponse.Verify(session.Challenge, session.GetRelyingPartyID(webauthn.Config.RPID), webauthn.Config.RPOrigins, webauthn.Config.RPOpaqueOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -1081,6 +1081,109 @@ func testRegistrationSpecVectorNoneES256Flags(t *testing.T, flags protocol.Authe
 	return body, challenge, credentialID
 }
 
+// testRegistrationSpecVectorNoneES256Origin returns the spec test vector data for NoneES256 registration with the
+// origin of the client data replaced by origin. The none attestation statement format conveys no signature over the
+// client data, so the origin can be varied without invalidating the vector.
+func testRegistrationSpecVectorNoneES256Origin(t *testing.T, origin string) (body []byte, challenge string, credentialID []byte) {
+	t.Helper()
+
+	body, challenge, credentialID = testRegistrationSpecVectorNoneES256(t)
+
+	var response map[string]any
+
+	require.NoError(t, json.Unmarshal(body, &response))
+
+	inner, ok := response["response"].(map[string]any)
+	require.True(t, ok)
+
+	encoded, ok := inner["clientDataJSON"].(string)
+	require.True(t, ok)
+
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+
+	var clientData map[string]any
+
+	require.NoError(t, json.Unmarshal(raw, &clientData))
+
+	clientData["origin"] = origin
+
+	if raw, err = json.Marshal(clientData); err != nil {
+		require.NoError(t, err)
+	}
+
+	inner["clientDataJSON"] = base64.RawURLEncoding.EncodeToString(raw)
+
+	body, err = json.Marshal(response)
+	require.NoError(t, err)
+
+	return body, challenge, credentialID
+}
+
+// TestCreateCredentialOpaqueOrigin covers [Config.RPOpaqueOrigins] widening the set of origins a ceremony may be
+// performed from, which is the only place an origin that is not an http or https tuple origin can be declared.
+func TestCreateCredentialOpaqueOrigin(t *testing.T) {
+	const origin = "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"
+
+	testCases := []struct {
+		name            string
+		rpOpaqueOrigins []string
+		err             string
+	}{
+		{
+			name:            "ShouldAcceptAConfiguredOpaqueOrigin",
+			rpOpaqueOrigins: []string{origin},
+		},
+		{
+			name: "ShouldRejectAnOpaqueOriginWhichIsNotConfigured",
+			err:  "Error validating origin",
+		},
+		{
+			name:            "ShouldRejectAnOpaqueOriginWhichDoesNotMatch",
+			rpOpaqueOrigins: []string{"android:apk-key-hash:9C4B4AEEF05536E730EC4B802E767F67"},
+			err:             "Error validating origin",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, challenge, credentialID := testRegistrationSpecVectorNoneES256Origin(t, origin)
+
+			parsedResponse, err := protocol.ParseCredentialCreationResponseBytes(body)
+			require.NoError(t, err)
+
+			userID := []byte(testUserID)
+
+			w := &WebAuthn{
+				Config: &Config{
+					RPID:            "example.org",
+					RPOrigins:       []string{"https://example.org"},
+					RPOpaqueOrigins: tc.rpOpaqueOrigins,
+				},
+			}
+
+			session := SessionData{
+				Challenge:  challenge,
+				UserID:     userID,
+				CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+			}
+
+			credential, err := w.CreateCredential(&defaultUser{id: userID}, session, parsedResponse)
+
+			if tc.err != "" {
+				assert.Nil(t, credential)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, credential)
+			assert.Equal(t, credentialID, credential.ID)
+		})
+	}
+}
+
 // testRegistrationSpecVectorPackedSelfES256 returns the spec test vector data for Packed Self ES256 registration.
 // See: https://www.w3.org/TR/webauthn-3/#sctn-test-vectors-packed-self-es256
 func testRegistrationSpecVectorPackedSelfES256(t *testing.T) (body []byte, challenge string, credentialID []byte) {

--- a/webauthn/related_origins.go
+++ b/webauthn/related_origins.go
@@ -16,7 +16,10 @@ import (
 //	mux.Handle(protocol.WellKnownPathWebAuthn, related)
 //
 // The origins are validated and normalized by [protocol.NewRelatedOrigins], so this returns an error when the
-// configured origins carry more than [protocol.MaximumRelatedOriginLabels] distinct registrable domain labels. A
+// configured origins carry more than [protocol.MaximumRelatedOriginLabels] distinct registrable domain labels, or
+// when one of them is opaque. Configuring [Config.RPOpaqueOrigins] holds [Config.RPOrigins] to exactly those rules at
+// validation time, which makes this call infallible for such a Relying Party; one which instead lists its opaque
+// origins in [Config.RPOrigins] must keep them out of the document by calling [protocol.NewRelatedOrigins] itself. A
 // Relying Party whose origins sit under a multi-label public suffix should count those labels with a public suffix
 // list by calling [protocol.NewRelatedOriginsWithLabeler] with [Config.RPOrigins] instead, and one which serves a set
 // of origins other than the configured ones should call [protocol.NewRelatedOrigins] with that set.

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -41,16 +41,32 @@ type Config struct {
 
 	// RPOrigins configures the list of Relying Party Server Origins that are permitted. The provided origins can either
 	// be fully qualified origins or strings for simple string comparison. The strings are matched using canonical
-	// origin matching semantics specifically if they start with 'http://' or 'https://' if the provided origin has a
-	// case-insensitive equal scheme and host component they are equal, otherwise simple string comparison is utilized
+	// origin matching semantics, specifically if they start with 'http://' or 'https://' if the provided origin has a
+	// case-insensitive equal scheme and host component, they are equal, otherwise simple string comparison is utilized
 	// to determine equality.
+	//
+	// See Also: [RPOpaqueOrigins].
 	RPOrigins []string
+
+	// RPOpaqueOrigins configures the list of opaque Relying Party Server Origins that are permitted, i.e. those for
+	// which [protocol.IsOpaqueOrigin] returns true because they are not an absolute http or https URL with a host
+	// (i.e. "android:apk-key-hash:..."). These are matched by simple string comparison, they are never matched
+	// against the Top Origin of a cross-origin ceremony, and they are never declared in the Related Origin Requests
+	// document returned by [WebAuthn.RelatedOrigins].
+	//
+	// Configuring this field constrains the other origin fields to what a Related Origin Requests document can
+	// express, so that the origins a client resolves and the origins this Relying Party accepts cannot drift apart:
+	// [Config.RPOrigins] and [Config.RPTopOrigins] must then hold only non-opaque origins, and [Config.RPOrigins]
+	// must carry no more than [protocol.MaximumRelatedOriginLabels] distinct registrable domain labels.
+	RPOpaqueOrigins []string
 
 	// RPTopOrigins configures the list of Relying Party Server Top Origins that are permitted. The provided origins can
 	// either be fully qualified origins or strings for simple string comparison. The strings are matched using
 	// canonical origin matching semantics specifically if they start with 'http://' or 'https://' if the provided
 	// origin has a case-insensitive equal scheme and host component they are equal, otherwise simple string comparison
 	// is utilized to determine equality.
+	//
+	// See Also: [RPOpaqueOrigins].
 	RPTopOrigins []string
 
 	// RPTopOriginVerificationMode determines the verification mode for the Top Origin value used in cross-origin
@@ -188,6 +204,10 @@ func (config *Config) validate() (err error) {
 		return fmt.Errorf("must provide at least one value to the 'RPOrigins' field")
 	}
 
+	if err = config.validateOpaqueOrigins(); err != nil {
+		return err
+	}
+
 	if config.RPTopOriginVerificationMode == protocol.TopOriginDefaultVerificationMode {
 		config.RPTopOriginVerificationMode = protocol.TopOriginExplicitVerificationMode
 	}
@@ -201,6 +221,37 @@ func (config *Config) validate() (err error) {
 	}
 
 	config.validated = true
+
+	return nil
+}
+
+// validateOpaqueOrigins enforces the separation [Config.RPOpaqueOrigins] draws between the origins a client resolves
+// through a Related Origin Requests document and the origins which can only ever be matched by simple string
+// comparison. It is a no op unless that field is populated, so a Relying Party which lists an opaque origin in
+// [Config.RPOrigins] keeps the behavior it has always had.
+//
+// The Top Origins are held to the same standard as the Origins minus the label budget, which applies to the origins
+// declared in the document rather than to the origin of a top level browsing context.
+func (config *Config) validateOpaqueOrigins() (err error) {
+	if len(config.RPOpaqueOrigins) == 0 {
+		return nil
+	}
+
+	for _, origin := range config.RPOpaqueOrigins {
+		if !protocol.IsOpaqueOrigin(origin) {
+			return fmt.Errorf(errFmtOriginsNotOpaqueValue, origin)
+		}
+	}
+
+	if _, err = protocol.NewRelatedOrigins(config.RPOrigins...); err != nil {
+		return fmt.Errorf(errFmtOriginsNotRelated, "RPOrigins", err)
+	}
+
+	for _, origin := range config.RPTopOrigins {
+		if protocol.IsOpaqueOrigin(origin) {
+			return fmt.Errorf(errFmtOriginsNotRelatedValue, "RPTopOrigins", origin)
+		}
+	}
 
 	return nil
 }
@@ -233,6 +284,11 @@ func (c *Config) GetOrigins() []string {
 	return c.RPOrigins
 }
 
+// GetOpaqueOrigins returns the configured opaque Relying Party Origins.
+func (c *Config) GetOpaqueOrigins() []string {
+	return c.RPOpaqueOrigins
+}
+
 // GetTopOrigins returns the configured Relying Party Top Origins.
 func (c *Config) GetTopOrigins() []string {
 	return c.RPTopOrigins
@@ -263,6 +319,7 @@ func (c *Config) GetSignaturePolicy() protocol.SignaturePolicy {
 type ConfigProvider interface {
 	GetRPID() string
 	GetOrigins() []string
+	GetOpaqueOrigins() []string
 	GetTopOrigins() []string
 	GetTopOriginVerificationMode() protocol.TopOriginVerificationMode
 	GetMetaDataProvider() metadata.Provider

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -16,6 +16,7 @@ func TestConfig_Getters(t *testing.T) {
 		config                        *Config
 		expectedRPID                  string
 		expectedOrigins               []string
+		expectedOpaqueOrigins         []string
 		expectedTopOrigins            []string
 		expectedTopOriginVerification protocol.TopOriginVerificationMode
 		expectedMetaDataProviderIsNil bool
@@ -26,6 +27,7 @@ func TestConfig_Getters(t *testing.T) {
 			config: &Config{
 				RPID:                        "example.com",
 				RPOrigins:                   []string{"https://example.com"},
+				RPOpaqueOrigins:             []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
 				RPTopOrigins:                []string{"https://top.example.com"},
 				RPTopOriginVerificationMode: protocol.TopOriginExplicitVerificationMode,
 				Attestation: protocol.AttestationPolicy{
@@ -34,6 +36,7 @@ func TestConfig_Getters(t *testing.T) {
 			},
 			expectedRPID:                  "example.com",
 			expectedOrigins:               []string{"https://example.com"},
+			expectedOpaqueOrigins:         []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
 			expectedTopOrigins:            []string{"https://top.example.com"},
 			expectedTopOriginVerification: protocol.TopOriginExplicitVerificationMode,
 			expectedMetaDataProviderIsNil: true,
@@ -59,6 +62,7 @@ func TestConfig_Getters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedRPID, tc.config.GetRPID())
 			assert.Equal(t, tc.expectedOrigins, tc.config.GetOrigins())
+			assert.Equal(t, tc.expectedOpaqueOrigins, tc.config.GetOpaqueOrigins())
 			assert.Equal(t, tc.expectedTopOrigins, tc.config.GetTopOrigins())
 			assert.Equal(t, tc.expectedTopOriginVerification, tc.config.GetTopOriginVerificationMode())
 			assert.Equal(t, tc.expectedAttestationPolicy, tc.config.GetAttestationPolicy())
@@ -123,6 +127,99 @@ func TestNew(t *testing.T) {
 				assert.EqualError(t, err, tc.err)
 				assert.Error(t, tc.config.validate())
 			}
+		})
+	}
+}
+
+func TestConfig_Validate_OpaqueOrigins(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config *Config
+		err    string
+	}{
+		{
+			name: "ShouldPassOpaqueOriginsAlongsideNonOpaqueOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com", "https://example.com.au"},
+				RPTopOrigins:    []string{"https://top.example.com"},
+				RPOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+		},
+		{
+			name: "ShouldPassAnOpaqueOriginInRPOriginsWhenNoOpaqueOriginsAreConfigured",
+			config: &Config{
+				RPID:      "example.com",
+				RPOrigins: []string{"https://example.com", "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+		},
+		{
+			name: "ShouldPassMoreThanTheRelatedOriginLabelBudgetWhenNoOpaqueOriginsAreConfigured",
+			config: &Config{
+				RPID:      "example.com",
+				RPOrigins: []string{"https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com", "https://f.com"},
+			},
+		},
+		{
+			name: "ShouldFailAnOpaqueOriginInRPOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com", "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+				RPOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+			err: "error occurred validating the configuration: when the 'RPOpaqueOrigins' field is configured the 'RPOrigins' field must only contain origins a Related Origin Requests document can declare: error validating related origin 'android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk': the scheme must be either http or https but it is 'android'",
+		},
+		{
+			name: "ShouldFailMoreThanTheRelatedOriginLabelBudgetInRPOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com", "https://f.com"},
+				RPOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+			err: "error occurred validating the configuration: when the 'RPOpaqueOrigins' field is configured the 'RPOrigins' field must only contain origins a Related Origin Requests document can declare: error validating related origins: the origins have 6 distinct registrable domain labels but clients only process 5 of them, so origins beyond that limit are ignored",
+		},
+		{
+			name: "ShouldPassTheRelatedOriginLabelBudgetInRPOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://a.com", "https://b.com", "https://c.com", "https://d.com", "https://e.com", "https://www.a.com"},
+				RPOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+		},
+		{
+			name: "ShouldFailAnOpaqueOriginInRPTopOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com"},
+				RPTopOrigins:    []string{"https://top.example.com", "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+				RPOpaqueOrigins: []string{"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+			err: "error occurred validating the configuration: when the 'RPOpaqueOrigins' field is configured the 'RPTopOrigins' field must only contain origins a Related Origin Requests document can declare but the value 'android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk' is opaque",
+		},
+		{
+			name: "ShouldFailANonOpaqueOriginInRPOpaqueOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com"},
+				RPOpaqueOrigins: []string{"https://app.example.com"},
+			},
+			err: "error occurred validating the configuration: the 'RPOpaqueOrigins' field must only contain opaque origins but the value 'https://app.example.com' is not opaque; it belongs in the 'RPOrigins' field",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(tc.config)
+
+			if tc.err == "" {
+				require.NoError(t, err)
+				assert.NotNil(t, w)
+
+				return
+			}
+
+			assert.Nil(t, w)
+			assert.EqualError(t, err, tc.err)
 		})
 	}
 }


### PR DESCRIPTION
Config gains a RPOpaqueOrigins field for origins which are not http or https tuple origins, such as the android:apk-key-hash values an Android client reports. They are matched by simple string comparison and never against the Top Origin of a cross-origin ceremony.

Populating it holds the other fields to what a Related Origin Requests document can express: RPOrigins must be non-opaque and within the MaximumRelatedOriginLabels budget, and RPTopOrigins must be non-opaque. A Relying Party which keeps its opaque origins in RPOrigins is unaffected.

BREAKING CHANGE: The rpOpaqueOrigins parameter has been added to protocol.CollectedClientData.Verify, protocol.ParsedCredentialCreationData.Verify and protocol.ParsedCredentialAssertionData.Verify, immediately after the existing rpOrigins parameter; callers which accept no opaque origins should pass nil. The webauthn.ConfigProvider interface has also gained a GetOpaqueOrigins method which implementations outside this module must provide.