### PR TITLE
feat(webauthn): ceremony origin binding

### DIFF
--- a/protocol/options.go
+++ b/protocol/options.go
@@ -40,6 +40,12 @@ type PublicKeyCredentialCreationOptions struct {
 	Attestation            ConveyancePreference       `json:"attestation,omitempty"`
 	AttestationFormats     []AttestationFormat        `json:"attestationFormats,omitempty"`
 	Extensions             AuthenticationExtensions   `json:"extensions,omitzero"`
+
+	// Origin binds the ceremony to the single origin the response must declare. Used internally only; not
+	// serialized, as the origin is not a member of the IDL and is never conveyed to the client. It is recorded in
+	// the [github.com/go-webauthn/webauthn/webauthn.SessionData] instead, which the Finish step verifies the
+	// collected client data against in place of the configured origins.
+	Origin string `json:"-"`
 }
 
 // The PublicKeyCredentialRequestOptions dictionary supplies get() with the data it needs to generate an assertion.
@@ -56,6 +62,12 @@ type PublicKeyCredentialRequestOptions struct {
 	UserVerification   UserVerificationRequirement `json:"userVerification,omitempty"`
 	Hints              []PublicKeyCredentialHints  `json:"hints,omitempty"`
 	Extensions         AuthenticationExtensions    `json:"extensions,omitzero"`
+
+	// Origin binds the ceremony to the single origin the response must declare. Used internally only; not
+	// serialized, as the origin is not a member of the IDL and is never conveyed to the client. It is recorded in
+	// the [github.com/go-webauthn/webauthn/webauthn.SessionData] instead, which the Finish step verifies the
+	// collected client data against in place of the configured origins.
+	Origin string `json:"-"`
 }
 
 // CredentialDescriptor represents the PublicKeyCredentialDescriptor IDL.

--- a/webauthn/const.go
+++ b/webauthn/const.go
@@ -11,6 +11,9 @@ const (
 	errFmtOriginsNotRelated      = "when the 'RPOpaqueOrigins' field is configured the '%s' field must only contain origins a Related Origin Requests document can declare: %w"
 	errFmtOriginsNotRelatedValue = "when the 'RPOpaqueOrigins' field is configured the '%s' field must only contain origins a Related Origin Requests document can declare but the value '%s' is opaque"
 	errFmtOriginsNotOpaqueValue  = "the 'RPOpaqueOrigins' field must only contain opaque origins but the value '%s' is not opaque; it belongs in the 'RPOrigins' field"
+
+	errFmtOriginBindOpaque       = "the ceremony origin '%s' can't be bound as it's opaque and an opaque origin is only conveyed in the ceremony response"
+	errFmtOriginBindUnconfigured = "the ceremony origin '%s' must be one of the origins in the 'RPOrigins' configuration"
 )
 
 const (

--- a/webauthn/doc.go
+++ b/webauthn/doc.go
@@ -57,6 +57,14 @@
 //  1. Using a client side library like [@simplewebauthn/browser].
 //  2. Some browsers support the [parseCreationOptionsFromJSON] static method on the WebAuthn object.
 //
+// # Origin Binding
+//
+// The origin of a ceremony response is verified against every origin in [Config.RPOrigins], which is what allows one
+// relying party to serve several of them. A relying party which knows the origin a particular ceremony was begun at can
+// narrow that to the one origin with [WithRegistrationOrigin] or [WithLoginOrigin], so a response collected at another
+// of its origins does not complete the ceremony. The bound value is recorded in [SessionData.Origin] and must be one of
+// the configured origins.
+//
 // # Extensions
 //
 // Extension inputs are requested with [WithExtensions] for a registration ceremony and [WithAssertionExtensions]

--- a/webauthn/login.go
+++ b/webauthn/login.go
@@ -117,6 +117,12 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 		return nil, nil, fmt.Errorf("error generating assertion: the relying party id failed to validate as it's not a valid domain string with error: %w", err)
 	}
 
+	if len(assertion.Response.Origin) != 0 {
+		if err = validateCeremonyOrigin(assertion.Response.Origin, webauthn.Config.RPOrigins); err != nil {
+			return nil, nil, fmt.Errorf("error generating assertion: %w", err)
+		}
+	}
+
 	if assertion.Response.Timeout == 0 {
 		switch assertion.Response.UserVerification {
 		case protocol.VerificationDiscouraged:
@@ -135,6 +141,7 @@ func (webauthn *WebAuthn) beginLogin(userID []byte, allowedCredentials []protoco
 	session = &SessionData{
 		Challenge:            assertion.Response.Challenge.String(),
 		RelyingPartyID:       assertion.Response.RelyingPartyID,
+		Origin:               assertion.Response.Origin,
 		UserID:               userID,
 		AllowedCredentialIDs: assertion.Response.GetAllowedCredentialIDs(),
 		UserVerification:     assertion.Response.UserVerification,
@@ -365,7 +372,7 @@ func (webauthn *WebAuthn) validateLogin(user User, session SessionData, parsedRe
 	shouldVerifyUserPresence := true
 
 	rpID := session.GetRelyingPartyID(webauthn.Config.RPID)
-	rpOrigins := webauthn.Config.RPOrigins
+	rpOrigins := session.GetOrigins(webauthn.Config.RPOrigins)
 	rpOpaqueOrigins := webauthn.Config.RPOpaqueOrigins
 	rpTopOrigins := webauthn.Config.RPTopOrigins
 

--- a/webauthn/login_opt.go
+++ b/webauthn/login_opt.go
@@ -42,6 +42,30 @@ func WithLoginRelyingPartyID(id string) LoginOption {
 	}
 }
 
+// WithLoginOrigin binds this login ceremony to a single origin, which [WebAuthn.ValidateLogin] verifies the collected
+// client data against in place of every origin in [Config.RPOrigins]. A Relying Party which serves several origins can
+// therefore hold a ceremony to the origin it was begun at, so an assertion collected at one of its other origins does
+// not complete it.
+//
+// The origin must be one of those configured in [Config.RPOrigins]; the option narrows that set and can't widen it, so
+// a value which is not configured fails at [WebAuthn.BeginLogin] rather than at the Finish step. It must also be a http
+// or https origin. An opaque origin such as 'android:apk-key-hash:...' is only ever conveyed in the response and so
+// can't be known when the ceremony begins; those configured in [Config.RPOpaqueOrigins] remain acceptable while a
+// ceremony is bound, as a Relying Party which accepts native clients cannot tell them apart from browser clients in
+// advance.
+//
+// The binding covers the ceremony origin only. A topOrigin is verified against [Config.RPTopOrigins] under the
+// configured [protocol.TopOriginVerificationMode] as usual.
+//
+// Specification: §7.2. Verifying an Authentication Assertion, step 13 (https://www.w3.org/TR/webauthn-3/#sctn-verifying-assertion)
+func WithLoginOrigin(origin string) LoginOption {
+	return func(cco *protocol.PublicKeyCredentialRequestOptions) error {
+		cco.Origin = origin
+
+		return nil
+	}
+}
+
 // WithAllowedCredentials adjusts the allowed credentials via a slice of [protocol.CredentialDescriptor] values,
 // discussed in the included specification sections with user-supplied values.
 //

--- a/webauthn/login_test.go
+++ b/webauthn/login_test.go
@@ -1729,6 +1729,172 @@ func TestValidateLoginOpaqueOrigin(t *testing.T) {
 	}
 }
 
+// TestBeginLoginOrigin covers [WithLoginOrigin] recording the bound origin in the session, and the narrowing rule
+// which requires the bound value to be one of the configured [Config.RPOrigins].
+func TestBeginLoginOrigin(t *testing.T) {
+	const opaque = "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"
+
+	testCases := []struct {
+		name            string
+		origin          string
+		rpOpaqueOrigins []string
+		expected        string
+		err             string
+	}{
+		{
+			name:     "ShouldNotBindAnOriginWhenTheOptionIsNotSupplied",
+			expected: "",
+		},
+		{
+			name:     "ShouldBindAConfiguredOrigin",
+			origin:   "https://b.example.com",
+			expected: "https://b.example.com",
+		},
+		{
+			name:   "ShouldRejectAnOriginWhichIsNotConfigured",
+			origin: "https://c.example.com",
+			err:    "error generating assertion: the ceremony origin 'https://c.example.com' must be one of the origins in the 'RPOrigins' configuration",
+		},
+		{
+			name:            "ShouldRejectAnOpaqueOriginEvenWhenItIsConfigured",
+			origin:          opaque,
+			rpOpaqueOrigins: []string{opaque},
+			err:             "error generating assertion: the ceremony origin 'android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk' can't be bound as it's opaque and an opaque origin is only conveyed in the ceremony response",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(&Config{
+				RPID:            "example.com",
+				RPDisplayName:   "Test",
+				RPOrigins:       []string{"https://a.example.com", "https://b.example.com"},
+				RPOpaqueOrigins: tc.rpOpaqueOrigins,
+			})
+			require.NoError(t, err)
+
+			var opts []LoginOption
+
+			if tc.origin != "" {
+				opts = append(opts, WithLoginOrigin(tc.origin))
+			}
+
+			assertion, session, err := w.BeginDiscoverableLogin(opts...)
+
+			if tc.err != "" {
+				assert.Nil(t, assertion)
+				assert.Nil(t, session)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.Equal(t, tc.expected, session.Origin)
+		})
+	}
+}
+
+// TestValidateLoginBoundOrigin covers [SessionData.Origin] narrowing the origins the assertion is verified against to
+// the single origin the ceremony was begun with. The opaque case relies on the origin being verified before the
+// signature, so the signature failure the modified client data causes stands as proof the origin was accepted.
+func TestValidateLoginBoundOrigin(t *testing.T) {
+	const (
+		originVector = "https://example.org"
+		originOther  = "https://other.example.org"
+		originOpaque = "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"
+	)
+
+	testCases := []struct {
+		name            string
+		responseOrigin  string
+		sessionOrigin   string
+		rpOpaqueOrigins []string
+		err             string
+	}{
+		{
+			name:          "ShouldAcceptTheBoundOrigin",
+			sessionOrigin: originVector,
+		},
+		{
+			name: "ShouldAcceptAnyConfiguredOriginWhenTheSessionIsNotBound",
+		},
+		{
+			name:          "ShouldRejectAnotherConfiguredOriginWhenTheSessionIsBound",
+			sessionOrigin: originOther,
+			err:           "Error validating origin",
+		},
+		{
+			name:            "ShouldAcceptAConfiguredOpaqueOriginWhileTheSessionIsBound",
+			responseOrigin:  originOpaque,
+			sessionOrigin:   originVector,
+			rpOpaqueOrigins: []string{originOpaque},
+			err:             "Error validating the assertion signature: <nil>",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				parsedResponse *protocol.ParsedCredentialAssertionData
+				credPubKey     []byte
+				challenge      string
+				credentialID   []byte
+			)
+
+			if tc.responseOrigin == "" {
+				parsedResponse, credPubKey, challenge, credentialID = testLoginSpecVectorNoneES256(t)
+			} else {
+				parsedResponse, credPubKey, challenge, credentialID = testLoginSpecVectorNoneES256Origin(t, tc.responseOrigin)
+			}
+
+			userID := []byte(testUserID)
+
+			w := &WebAuthn{
+				Config: &Config{
+					RPID:            "example.org",
+					RPOrigins:       []string{originVector, originOther},
+					RPOpaqueOrigins: tc.rpOpaqueOrigins,
+				},
+			}
+
+			user := &defaultUser{
+				id: userID,
+				credentials: []Credential{
+					{
+						ID:        credentialID,
+						PublicKey: credPubKey,
+						Flags: CredentialFlags{
+							UserPresent:    true,
+							BackupEligible: true,
+						},
+					},
+				},
+			}
+
+			session := SessionData{
+				Challenge: challenge,
+				Origin:    tc.sessionOrigin,
+				UserID:    userID,
+			}
+
+			credential, err := w.ValidateLogin(user, session, parsedResponse)
+
+			if tc.err != "" {
+				assert.Nil(t, credential)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, credential)
+			assert.Equal(t, credentialID, credential.ID)
+		})
+	}
+}
+
 // testLoginSpecVectorNoneES256Origin returns the spec test vector data for NoneES256 authentication with the origin
 // of the client data replaced by origin, which invalidates the assertion signature over it.
 func testLoginSpecVectorNoneES256Origin(t *testing.T, origin string) (parsedResponse *protocol.ParsedCredentialAssertionData, credPubKey []byte, challenge string, credentialID []byte) {

--- a/webauthn/registration.go
+++ b/webauthn/registration.go
@@ -92,6 +92,12 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 		return nil, nil, fmt.Errorf("error generating credential creation: the relying party display name must be provided via the configuration or a functional option for a creation")
 	}
 
+	if len(creation.Response.Origin) != 0 {
+		if err = validateCeremonyOrigin(creation.Response.Origin, webauthn.Config.RPOrigins); err != nil {
+			return nil, nil, fmt.Errorf("error generating credential creation: %w", err)
+		}
+	}
+
 	if len(creation.Response.Challenge) < protocol.MinimumChallengeLength {
 		return nil, nil, fmt.Errorf("error generating credential creation: the challenge must be at least 16 bytes")
 	}
@@ -118,6 +124,7 @@ func (webauthn *WebAuthn) BeginMediatedRegistration(user User, mediation protoco
 	session = &SessionData{
 		Challenge:        creation.Response.Challenge.String(),
 		RelyingPartyID:   creation.Response.RelyingParty.ID,
+		Origin:           creation.Response.Origin,
 		UserID:           user.WebAuthnID(),
 		UserVerification: creation.Response.AuthenticatorSelection.UserVerification,
 		Extensions:       creation.Response.Extensions.Session(),
@@ -194,7 +201,7 @@ func (webauthn *WebAuthn) CreateCredential(user User, session SessionData, parse
 
 	var clientDataHash []byte
 
-	if clientDataHash, err = parsedResponse.Verify(session.Challenge, session.GetRelyingPartyID(webauthn.Config.RPID), webauthn.Config.RPOrigins, webauthn.Config.RPOpaqueOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
+	if clientDataHash, err = parsedResponse.Verify(session.Challenge, session.GetRelyingPartyID(webauthn.Config.RPID), session.GetOrigins(webauthn.Config.RPOrigins), webauthn.Config.RPOpaqueOrigins, webauthn.Config.RPTopOrigins, webauthn.Config.RPTopOriginVerificationMode, webauthn.Config.RPAllowCrossOrigin, shouldVerifyUser, shouldVerifyUserPresence, webauthn.Config.MDS, session.CredParams, webauthn.Config.Attestation, webauthn.Config.Signature); err != nil {
 		return nil, err
 	}
 

--- a/webauthn/registration_opt.go
+++ b/webauthn/registration_opt.go
@@ -118,6 +118,30 @@ func WithRegistrationRelyingPartyID(id string) RegistrationOption {
 	}
 }
 
+// WithRegistrationOrigin binds this registration ceremony to a single origin, which [WebAuthn.CreateCredential]
+// verifies the collected client data against in place of every origin in [Config.RPOrigins]. A Relying Party which
+// serves several origins can therefore hold a ceremony to the origin it was begun at, so a response collected at one
+// of its other origins does not complete it.
+//
+// The origin must be one of those configured in [Config.RPOrigins]; the option narrows that set and can't widen it,
+// so a value which is not configured fails at [WebAuthn.BeginRegistration] rather than at the Finish step. It must
+// also be a http or https origin. An opaque origin such as 'android:apk-key-hash:...' is only ever conveyed in the
+// response and so can't be known when the ceremony begins; those configured in [Config.RPOpaqueOrigins] remain
+// acceptable while a ceremony is bound, as a Relying Party which accepts native clients cannot tell them apart from
+// browser clients in advance.
+//
+// The binding covers the ceremony origin only. A topOrigin is verified against [Config.RPTopOrigins] under the
+// configured [protocol.TopOriginVerificationMode] as usual.
+//
+// Specification: §7.1. Registering a New Credential, step 9 (https://www.w3.org/TR/webauthn-3/#sctn-registering-a-new-credential)
+func WithRegistrationOrigin(origin string) RegistrationOption {
+	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {
+		cco.Origin = origin
+
+		return nil
+	}
+}
+
 // WithRegistrationRelyingPartyName sets the relying party name for the registration.
 func WithRegistrationRelyingPartyName(name string) RegistrationOption {
 	return func(cco *protocol.PublicKeyCredentialCreationOptions) error {

--- a/webauthn/registration_test.go
+++ b/webauthn/registration_test.go
@@ -1391,6 +1391,164 @@ func TestCreateCredentialOpaqueOrigin(t *testing.T) {
 	}
 }
 
+// TestBeginRegistrationOrigin covers [WithRegistrationOrigin] recording the bound origin in the session, and the
+// narrowing rule which requires the bound value to be one of the configured [Config.RPOrigins].
+func TestBeginRegistrationOrigin(t *testing.T) {
+	const opaque = "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"
+
+	testCases := []struct {
+		name            string
+		origin          string
+		rpOpaqueOrigins []string
+		expected        string
+		err             string
+	}{
+		{
+			name:     "ShouldNotBindAnOriginWhenTheOptionIsNotSupplied",
+			expected: "",
+		},
+		{
+			name:     "ShouldBindAConfiguredOrigin",
+			origin:   "https://b.example.com",
+			expected: "https://b.example.com",
+		},
+		{
+			name:     "ShouldBindAConfiguredOriginWithAnExplicitDefaultPort",
+			origin:   "https://b.example.com:443",
+			expected: "https://b.example.com:443",
+		},
+		{
+			name:   "ShouldRejectAnOriginWhichIsNotConfigured",
+			origin: "https://c.example.com",
+			err:    "error generating credential creation: the ceremony origin 'https://c.example.com' must be one of the origins in the 'RPOrigins' configuration",
+		},
+		{
+			name:            "ShouldRejectAnOpaqueOriginEvenWhenItIsConfigured",
+			origin:          opaque,
+			rpOpaqueOrigins: []string{opaque},
+			err:             "error generating credential creation: the ceremony origin 'android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk' can't be bound as it's opaque and an opaque origin is only conveyed in the ceremony response",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := New(&Config{
+				RPID:            "example.com",
+				RPDisplayName:   "Test",
+				RPOrigins:       []string{"https://a.example.com", "https://b.example.com"},
+				RPOpaqueOrigins: tc.rpOpaqueOrigins,
+			})
+			require.NoError(t, err)
+
+			var opts []RegistrationOption
+
+			if tc.origin != "" {
+				opts = append(opts, WithRegistrationOrigin(tc.origin))
+			}
+
+			creation, session, err := w.BeginRegistration(&defaultUser{id: []byte(testUserID)}, opts...)
+
+			if tc.err != "" {
+				assert.Nil(t, creation)
+				assert.Nil(t, session)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, session)
+			assert.Equal(t, tc.expected, session.Origin)
+		})
+	}
+}
+
+// TestCreateCredentialBoundOrigin covers [SessionData.Origin] narrowing the origins the registration ceremony is
+// verified against to the single origin the ceremony was begun with.
+func TestCreateCredentialBoundOrigin(t *testing.T) {
+	const (
+		originVector = "https://example.org"
+		originOther  = "https://other.example.org"
+		originOpaque = "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"
+	)
+
+	testCases := []struct {
+		name            string
+		responseOrigin  string
+		sessionOrigin   string
+		rpOpaqueOrigins []string
+		err             string
+	}{
+		{
+			name:          "ShouldAcceptTheBoundOrigin",
+			sessionOrigin: originVector,
+		},
+		{
+			name: "ShouldAcceptAnyConfiguredOriginWhenTheSessionIsNotBound",
+		},
+		{
+			name:          "ShouldRejectAnotherConfiguredOriginWhenTheSessionIsBound",
+			sessionOrigin: originOther,
+			err:           "Error validating origin",
+		},
+		{
+			name:            "ShouldAcceptAConfiguredOpaqueOriginWhileTheSessionIsBound",
+			responseOrigin:  originOpaque,
+			sessionOrigin:   originVector,
+			rpOpaqueOrigins: []string{originOpaque},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				body         []byte
+				challenge    string
+				credentialID []byte
+			)
+
+			if tc.responseOrigin == "" {
+				body, challenge, credentialID = testRegistrationSpecVectorNoneES256(t)
+			} else {
+				body, challenge, credentialID = testRegistrationSpecVectorNoneES256Origin(t, tc.responseOrigin)
+			}
+
+			parsedResponse, err := protocol.ParseCredentialCreationResponseBytes(body)
+			require.NoError(t, err)
+
+			userID := []byte(testUserID)
+
+			w := &WebAuthn{
+				Config: &Config{
+					RPID:            "example.org",
+					RPOrigins:       []string{originVector, originOther},
+					RPOpaqueOrigins: tc.rpOpaqueOrigins,
+				},
+			}
+
+			session := SessionData{
+				Challenge:  challenge,
+				Origin:     tc.sessionOrigin,
+				UserID:     userID,
+				CredParams: []protocol.CredentialParameter{{Type: protocol.PublicKeyCredentialType, Algorithm: webauthncose.AlgES256}},
+			}
+
+			credential, err := w.CreateCredential(&defaultUser{id: userID}, session, parsedResponse)
+
+			if tc.err != "" {
+				assert.Nil(t, credential)
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, credential)
+			assert.Equal(t, credentialID, credential.ID)
+		})
+	}
+}
+
 // testRegistrationSpecVectorPackedSelfES256 returns the spec test vector data for Packed Self ES256 registration.
 // See: https://www.w3.org/TR/webauthn-3/#sctn-test-vectors-packed-self-es256
 func testRegistrationSpecVectorPackedSelfES256(t *testing.T) (body []byte, challenge string, credentialID []byte) {

--- a/webauthn/types_session.go
+++ b/webauthn/types_session.go
@@ -66,6 +66,7 @@ type sessionExtensions struct {
 type SessionData struct {
 	Challenge            string    `json:"challenge" msg:"c"`
 	RelyingPartyID       string    `json:"rpId,omitempty" msg:"r,omitempty"`
+	Origin               string    `json:"origin,omitempty" msg:"o,omitempty"`
 	UserID               []byte    `json:"user_id,omitempty" msg:"u,omitempty"`
 	AllowedCredentialIDs [][]byte  `json:"allowed_credentials,omitempty" msg:"allow,omitempty"`
 	Expires              time.Time `json:"expires" msg:"exp"`
@@ -89,4 +90,15 @@ func (s SessionData) GetRelyingPartyID(fallback string) string {
 	}
 
 	return s.RelyingPartyID
+}
+
+// GetOrigins returns the origins the collected client data of the ceremony response may declare. A ceremony begun with
+// [WithRegistrationOrigin] or [WithLoginOrigin] is bound to exactly one of them, in which case only that origin is
+// returned and a response collected at any other origin the Relying Party serves fails verification.
+func (s SessionData) GetOrigins(fallback []string) []string {
+	if len(s.Origin) == 0 {
+		return fallback
+	}
+
+	return []string{s.Origin}
 }

--- a/webauthn/types_session_gen.go
+++ b/webauthn/types_session_gen.go
@@ -17,7 +17,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 6 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -40,13 +40,20 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 			zb0001Mask |= 0x1
+		case "o":
+			z.Origin, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "Origin")
+				return
+			}
+			zb0001Mask |= 0x2
 		case "u":
 			z.UserID, err = dc.ReadBytes(z.UserID)
 			if err != nil {
 				err = msgp.WrapError(err, "UserID")
 				return
 			}
-			zb0001Mask |= 0x2
+			zb0001Mask |= 0x4
 		case "allow":
 			var zb0002 uint32
 			zb0002, err = dc.ReadArrayHeader()
@@ -66,7 +73,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x4
+			zb0001Mask |= 0x8
 		case "exp":
 			z.Expires, err = dc.ReadTime()
 			if err != nil {
@@ -83,7 +90,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.UserVerification = protocol.UserVerificationRequirement(zb0003)
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x10
 		case "exts":
 			err = (*sessionExtensions)(&z.Extensions).DecodeMsg(dc)
 			if err != nil {
@@ -109,7 +116,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x20
 		case "cmr":
 			{
 				var zb0005 string
@@ -120,7 +127,7 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 				z.Mediation = protocol.CredentialMediationRequirement(zb0005)
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x40
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -130,23 +137,26 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x3f {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.RelyingPartyID = ""
 		}
 		if (zb0001Mask & 0x2) == 0 {
-			z.UserID = nil
+			z.Origin = ""
 		}
 		if (zb0001Mask & 0x4) == 0 {
-			z.AllowedCredentialIDs = nil
+			z.UserID = nil
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.UserVerification = ""
+			z.AllowedCredentialIDs = nil
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.CredParams = nil
+			z.UserVerification = ""
 		}
 		if (zb0001Mask & 0x20) == 0 {
+			z.CredParams = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
 			z.Mediation = ""
 		}
 	}
@@ -156,32 +166,36 @@ func (z *SessionData) DecodeMsg(dc *msgp.Reader) (err error) {
 // EncodeMsg implements msgp.Encodable
 func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 	// check for omitted fields
-	zb0001Len := uint32(9)
-	var zb0001Mask uint16 /* 9 bits */
+	zb0001Len := uint32(10)
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	if z.RelyingPartyID == "" {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if z.UserID == nil {
+	if z.Origin == "" {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.AllowedCredentialIDs == nil {
+	if z.UserID == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
+	if z.AllowedCredentialIDs == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
 	if z.UserVerification == "" {
 		zb0001Len--
-		zb0001Mask |= 0x20
+		zb0001Mask |= 0x40
 	}
 	if z.CredParams == nil {
 		zb0001Len--
-		zb0001Mask |= 0x80
+		zb0001Mask |= 0x100
 	}
 	if z.Mediation == "" {
 		zb0001Len--
-		zb0001Mask |= 0x100
+		zb0001Mask |= 0x200
 	}
 	// variable map header, size zb0001Len
 	err = en.Append(0x80 | uint8(zb0001Len))
@@ -214,6 +228,18 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// write "o"
+			err = en.Append(0xa1, 0x6f)
+			if err != nil {
+				return
+			}
+			err = en.WriteString(z.Origin)
+			if err != nil {
+				err = msgp.WrapError(err, "Origin")
+				return
+			}
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
 			// write "u"
 			err = en.Append(0xa1, 0x75)
 			if err != nil {
@@ -225,7 +251,7 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 				return
 			}
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not omitted
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
 			// write "allow"
 			err = en.Append(0xa5, 0x61, 0x6c, 0x6c, 0x6f, 0x77)
 			if err != nil {
@@ -254,7 +280,7 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "Expires")
 			return
 		}
-		if (zb0001Mask & 0x20) == 0 { // if not omitted
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// write "uv"
 			err = en.Append(0xa2, 0x75, 0x76)
 			if err != nil {
@@ -276,7 +302,7 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 			err = msgp.WrapError(err, "Extensions")
 			return
 		}
-		if (zb0001Mask & 0x80) == 0 { // if not omitted
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// write "params"
 			err = en.Append(0xa6, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73)
 			if err != nil {
@@ -295,7 +321,7 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// write "cmr"
 			err = en.Append(0xa3, 0x63, 0x6d, 0x72)
 			if err != nil {
@@ -315,32 +341,36 @@ func (z *SessionData) EncodeMsg(en *msgp.Writer) (err error) {
 func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	// check for omitted fields
-	zb0001Len := uint32(9)
-	var zb0001Mask uint16 /* 9 bits */
+	zb0001Len := uint32(10)
+	var zb0001Mask uint16 /* 10 bits */
 	_ = zb0001Mask
 	if z.RelyingPartyID == "" {
 		zb0001Len--
 		zb0001Mask |= 0x2
 	}
-	if z.UserID == nil {
+	if z.Origin == "" {
 		zb0001Len--
 		zb0001Mask |= 0x4
 	}
-	if z.AllowedCredentialIDs == nil {
+	if z.UserID == nil {
 		zb0001Len--
 		zb0001Mask |= 0x8
 	}
+	if z.AllowedCredentialIDs == nil {
+		zb0001Len--
+		zb0001Mask |= 0x10
+	}
 	if z.UserVerification == "" {
 		zb0001Len--
-		zb0001Mask |= 0x20
+		zb0001Mask |= 0x40
 	}
 	if z.CredParams == nil {
 		zb0001Len--
-		zb0001Mask |= 0x80
+		zb0001Mask |= 0x100
 	}
 	if z.Mediation == "" {
 		zb0001Len--
-		zb0001Mask |= 0x100
+		zb0001Mask |= 0x200
 	}
 	// variable map header, size zb0001Len
 	o = append(o, 0x80|uint8(zb0001Len))
@@ -356,11 +386,16 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendString(o, z.RelyingPartyID)
 		}
 		if (zb0001Mask & 0x4) == 0 { // if not omitted
+			// string "o"
+			o = append(o, 0xa1, 0x6f)
+			o = msgp.AppendString(o, z.Origin)
+		}
+		if (zb0001Mask & 0x8) == 0 { // if not omitted
 			// string "u"
 			o = append(o, 0xa1, 0x75)
 			o = msgp.AppendBytes(o, z.UserID)
 		}
-		if (zb0001Mask & 0x8) == 0 { // if not omitted
+		if (zb0001Mask & 0x10) == 0 { // if not omitted
 			// string "allow"
 			o = append(o, 0xa5, 0x61, 0x6c, 0x6c, 0x6f, 0x77)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.AllowedCredentialIDs)))
@@ -371,7 +406,7 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 		// string "exp"
 		o = append(o, 0xa3, 0x65, 0x78, 0x70)
 		o = msgp.AppendTime(o, z.Expires)
-		if (zb0001Mask & 0x20) == 0 { // if not omitted
+		if (zb0001Mask & 0x40) == 0 { // if not omitted
 			// string "uv"
 			o = append(o, 0xa2, 0x75, 0x76)
 			o = msgp.AppendString(o, string(z.UserVerification))
@@ -383,7 +418,7 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 			err = msgp.WrapError(err, "Extensions")
 			return
 		}
-		if (zb0001Mask & 0x80) == 0 { // if not omitted
+		if (zb0001Mask & 0x100) == 0 { // if not omitted
 			// string "params"
 			o = append(o, 0xa6, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73)
 			o = msgp.AppendArrayHeader(o, uint32(len(z.CredParams)))
@@ -395,7 +430,7 @@ func (z *SessionData) MarshalMsg(b []byte) (o []byte, err error) {
 				}
 			}
 		}
-		if (zb0001Mask & 0x100) == 0 { // if not omitted
+		if (zb0001Mask & 0x200) == 0 { // if not omitted
 			// string "cmr"
 			o = append(o, 0xa3, 0x63, 0x6d, 0x72)
 			o = msgp.AppendString(o, string(z.Mediation))
@@ -414,7 +449,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
-	var zb0001Mask uint8 /* 6 bits */
+	var zb0001Mask uint8 /* 7 bits */
 	_ = zb0001Mask
 	for zb0001 > 0 {
 		zb0001--
@@ -437,13 +472,20 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 			zb0001Mask |= 0x1
+		case "o":
+			z.Origin, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Origin")
+				return
+			}
+			zb0001Mask |= 0x2
 		case "u":
 			z.UserID, bts, err = msgp.ReadBytesBytes(bts, z.UserID)
 			if err != nil {
 				err = msgp.WrapError(err, "UserID")
 				return
 			}
-			zb0001Mask |= 0x2
+			zb0001Mask |= 0x4
 		case "allow":
 			var zb0002 uint32
 			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
@@ -463,7 +505,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x4
+			zb0001Mask |= 0x8
 		case "exp":
 			z.Expires, bts, err = msgp.ReadTimeBytes(bts)
 			if err != nil {
@@ -480,7 +522,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.UserVerification = protocol.UserVerificationRequirement(zb0003)
 			}
-			zb0001Mask |= 0x8
+			zb0001Mask |= 0x10
 		case "exts":
 			bts, err = (*sessionExtensions)(&z.Extensions).UnmarshalMsg(bts)
 			if err != nil {
@@ -506,7 +548,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-			zb0001Mask |= 0x10
+			zb0001Mask |= 0x20
 		case "cmr":
 			{
 				var zb0005 string
@@ -517,7 +559,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 				z.Mediation = protocol.CredentialMediationRequirement(zb0005)
 			}
-			zb0001Mask |= 0x20
+			zb0001Mask |= 0x40
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -527,23 +569,26 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 	}
 	// Clear omitted fields.
-	if zb0001Mask != 0x3f {
+	if zb0001Mask != 0x7f {
 		if (zb0001Mask & 0x1) == 0 {
 			z.RelyingPartyID = ""
 		}
 		if (zb0001Mask & 0x2) == 0 {
-			z.UserID = nil
+			z.Origin = ""
 		}
 		if (zb0001Mask & 0x4) == 0 {
-			z.AllowedCredentialIDs = nil
+			z.UserID = nil
 		}
 		if (zb0001Mask & 0x8) == 0 {
-			z.UserVerification = ""
+			z.AllowedCredentialIDs = nil
 		}
 		if (zb0001Mask & 0x10) == 0 {
-			z.CredParams = nil
+			z.UserVerification = ""
 		}
 		if (zb0001Mask & 0x20) == 0 {
+			z.CredParams = nil
+		}
+		if (zb0001Mask & 0x40) == 0 {
 			z.Mediation = ""
 		}
 	}
@@ -553,7 +598,7 @@ func (z *SessionData) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *SessionData) Msgsize() (s int) {
-	s = 1 + 2 + msgp.StringPrefixSize + len(z.Challenge) + 2 + msgp.StringPrefixSize + len(z.RelyingPartyID) + 2 + msgp.BytesPrefixSize + len(z.UserID) + 6 + msgp.ArrayHeaderSize
+	s = 1 + 2 + msgp.StringPrefixSize + len(z.Challenge) + 2 + msgp.StringPrefixSize + len(z.RelyingPartyID) + 2 + msgp.StringPrefixSize + len(z.Origin) + 2 + msgp.BytesPrefixSize + len(z.UserID) + 6 + msgp.ArrayHeaderSize
 	for za0001 := range z.AllowedCredentialIDs {
 		s += msgp.BytesPrefixSize + len(z.AllowedCredentialIDs[za0001])
 	}

--- a/webauthn/types_session_test.go
+++ b/webauthn/types_session_test.go
@@ -47,6 +47,39 @@ func TestSessionData_GetRelyingPartyID(t *testing.T) {
 	}
 }
 
+func TestSessionData_GetOrigins(t *testing.T) {
+	testCases := []struct {
+		name     string
+		session  SessionData
+		fallback []string
+		expected []string
+	}{
+		{
+			name:     "ShouldNarrowToTheSessionValue",
+			session:  SessionData{Origin: "https://a.example.com"},
+			fallback: []string{"https://a.example.com", "https://b.example.com"},
+			expected: []string{"https://a.example.com"},
+		},
+		{
+			name:     "ShouldFallBackWhenSessionValueIsEmpty",
+			session:  SessionData{},
+			fallback: []string{"https://a.example.com", "https://b.example.com"},
+			expected: []string{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			name:     "ShouldFallBackToNilWhenNeitherIsSet",
+			session:  SessionData{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.session.GetOrigins(tc.fallback))
+		})
+	}
+}
+
 func TestSessionData_MsgpRoundTrip(t *testing.T) {
 	original := newPopulatedSessionData()
 
@@ -62,6 +95,7 @@ func TestSessionData_MsgpRoundTrip(t *testing.T) {
 
 		assert.Equal(t, original.Challenge, decoded.Challenge)
 		assert.Equal(t, original.RelyingPartyID, decoded.RelyingPartyID)
+		assert.Equal(t, original.Origin, decoded.Origin)
 		assert.Equal(t, original.UserID, decoded.UserID)
 		assert.Equal(t, original.AllowedCredentialIDs, decoded.AllowedCredentialIDs)
 		assert.True(t, original.Expires.Equal(decoded.Expires))
@@ -82,6 +116,7 @@ func TestSessionData_MsgpRoundTrip(t *testing.T) {
 		require.NoError(t, msgp.Decode(&buf, &decoded))
 		assert.Equal(t, original.Challenge, decoded.Challenge)
 		assert.Equal(t, original.RelyingPartyID, decoded.RelyingPartyID)
+		assert.Equal(t, original.Origin, decoded.Origin)
 		assert.Equal(t, original.UserID, decoded.UserID)
 		assert.Equal(t, original.AllowedCredentialIDs, decoded.AllowedCredentialIDs)
 		assert.True(t, original.Expires.Equal(decoded.Expires))
@@ -316,6 +351,7 @@ func newPopulatedSessionData() SessionData {
 	return SessionData{
 		Challenge:      "challenge-bytes-b64url",
 		RelyingPartyID: "example.com",
+		Origin:         "https://a.example.com",
 		UserID:         []byte{0x01, 0x02, 0x03, 0x04, 0x05},
 		AllowedCredentialIDs: [][]byte{
 			{0xAA, 0xBB, 0xCC},

--- a/webauthn/util.go
+++ b/webauthn/util.go
@@ -81,6 +81,20 @@ func validateUserHandle(id any) (err error) {
 	return nil
 }
 
+// validateCeremonyOrigin checks the origin a ceremony is being bound to by [WithRegistrationOrigin] or
+// [WithLoginOrigin] against the origins the Relying Party is configured with.
+func validateCeremonyOrigin(origin string, rpOrigins []string) (err error) {
+	if protocol.IsOpaqueOrigin(origin) {
+		return fmt.Errorf(errFmtOriginBindOpaque, origin)
+	}
+
+	if !protocol.IsOriginInHaystack(origin, rpOrigins) {
+		return fmt.Errorf(errFmtOriginBindUnconfigured, origin)
+	}
+
+	return nil
+}
+
 // hasU2FCredential reports whether any of the given descriptors originated from the legacy FIDO U2F JavaScript
 // API, which is the condition under which the FIDO AppID and AppID Exclusion extensions are meaningful.
 func hasU2FCredential(credentials []protocol.CredentialDescriptor) bool {


### PR DESCRIPTION
A response is verified against every origin in RPOrigins, so a ceremony begun at one of a Relying Party's origins can be completed by a response collected at any of the others. WithRegistrationOrigin and WithLoginOrigin bind a ceremony to a single origin, which is recorded in SessionData and is the only origin the Finish step then accepts.

The bound origin must be one of those configured, so the option can only narrow and an unconfigured value fails when the ceremony begins rather than when it completes. An opaque origin can't be bound as a client conveys one only in the response, though those in RPOpaqueOrigins remain acceptable, and a Top Origin is unaffected. A session carrying no origin behaves as before.