### PR TITLE
fix(protocol): opaque origin matching and validation

### DIFF
--- a/protocol/client.go
+++ b/protocol/client.go
@@ -99,8 +99,13 @@ const (
 )
 
 // FullyQualifiedOrigin returns the origin per the HTML spec: (scheme)://(host)[:(port)].
+//
+// A known opaque origin which carries no authority component, i.e. one a client conveys for a native application such
+// as 'android:apk-key-hash:...' or the origin of a document loaded from the local file system, has no such
+// serialization and is returned unaltered so it can be compared byte for byte. The opaque origins which do carry an
+// authority, such as the origin of a browser extension, are serialized in the usual way.
 func FullyQualifiedOrigin(rawOrigin string) (fqOrigin string, err error) {
-	if strings.HasPrefix(rawOrigin, "android:apk-key-hash:") {
+	if isOpaqueOriginWithoutAuthority(rawOrigin) {
 		return rawOrigin, nil
 	}
 
@@ -130,7 +135,8 @@ func FullyQualifiedOrigin(rawOrigin string) (fqOrigin string, err error) {
 // The rpOpaqueOrigins parameter carries the origins which are not http or https tuple origins, i.e. those for which
 // [IsOpaqueOrigin] returns true. They widen the set the ceremony origin is matched against, and only that set; the
 // Top Origin is deliberately never matched against them as a Top Origin is by definition the origin of a top-level
-// browsing context.
+// browsing context. They are matched by [IsOpaqueOriginInHaystack], i.e. by simple string comparison, never by the
+// origin equality semantics applied to the rpOrigins parameter.
 //
 //nolint:gocyclo
 func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyType, rpOrigins, rpOpaqueOrigins, rpTopOrigins []string, rpTopOriginsVerify TopOriginVerificationMode, allowCrossOrigin bool) (err error) {
@@ -158,7 +164,7 @@ func (c *CollectedClientData) Verify(storedChallenge string, ceremony CeremonyTy
 	// Registration Step 5 & Assertion Step 9. Verify that the value of C.origin matches
 	// the Relying Party's origin.
 
-	if !IsOriginInHaystack(c.Origin, rpOrigins) && !IsOriginInHaystack(c.Origin, rpOpaqueOrigins) {
+	if !IsOriginInHaystack(c.Origin, rpOrigins) && !IsOpaqueOriginInHaystack(c.Origin, rpOpaqueOrigins) {
 		possibleOrigins := rpOrigins
 
 		if len(rpOpaqueOrigins) != 0 {
@@ -298,6 +304,26 @@ func IsOriginInHaystack(needle string, haystack []string) bool {
 			if needle == hay {
 				return true
 			}
+		}
+	}
+
+	return false
+}
+
+// IsOpaqueOriginInHaystack checks if the needle is in the haystack of opaque origins, i.e. the origins for which
+// [IsOpaqueOrigin] returns true, using simple string comparison as defined in RFC3986 Section 6.2.1.
+//
+// This is deliberately not [IsOriginInHaystack]: an opaque origin has no scheme and host to normalize, so there is no
+// case folding and no port normalization to apply to it, and the value a client conveys for one is compared byte for
+// byte or not at all. Routing the opaque origins through this function rather than through [IsOriginInHaystack] keeps
+// that true of a value which merely resembles a URL, such as an http origin which has no host or whose port is out of
+// range; both are opaque, and neither may be matched with the leniency an origin with a host is matched with.
+//
+// See (Simple String Comparison Definition): https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.1
+func IsOpaqueOriginInHaystack(needle string, haystack []string) bool {
+	for _, hay := range haystack {
+		if needle == hay {
+			return true
 		}
 	}
 

--- a/protocol/client_test.go
+++ b/protocol/client_test.go
@@ -159,6 +159,28 @@ func TestVerifyCollectedClientData(t *testing.T) {
 			errInfo:         "Expected Values: [https://example.com android:apk-key-hash:9C4B4AEEF05536E730EC4B802E767F67], Received: android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
 		},
 		{
+			name:            "ShouldFailOpaqueOriginDifferingInCase",
+			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"android:apk-key-hash:2JMJ7L5RSW0YVB-VLWAYKK-YBWK"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			errType:         "verification_error",
+			errDetails:      "Error validating origin",
+			errInfo:         "Expected Values: [https://example.com android:apk-key-hash:2JMJ7L5RSW0YVB-VLWAYKK-YBWK], Received: android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+		},
+		{
+			name:            "ShouldFailOpaqueOriginResemblingAURLDifferingInCase",
+			origin:          "https://example.com:99999",
+			rpOrigins:       []string{"https://example.com"},
+			rpOpaqueOrigins: []string{"https://Example.com:99999"},
+			rpTopOrigins:    []string{"https://example.com"},
+			topOriginMode:   TopOriginExplicitVerificationMode,
+			errType:         "verification_error",
+			errDetails:      "Error validating origin",
+			errInfo:         "Expected Values: [https://example.com https://Example.com:99999], Received: https://example.com:99999",
+		},
+		{
 			name:            "ShouldFailOpaqueTopOriginImplicit",
 			origin:          "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
 			topOrigin:       "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
@@ -319,6 +341,16 @@ func TestFullyQualifiedOrigin(t *testing.T) {
 		{"ShouldParseWithQuery", "https://app.example.com/?abc=123", "https://app.example.com", ``},
 		{"ShouldParseWithFragment", "https://app.example.com/#abc", "https://app.example.com", ``},
 		{"ShouldSkipParsingAndroidNative", "android:apk-key-hash:7d1043473d55bfa90e8530d35801d4e381bc69f0", "android:apk-key-hash:7d1043473d55bfa90e8530d35801d4e381bc69f0", ""},
+		{"ShouldSkipParsingAndroidNativeSHA256", "android:apk-key-hash-sha256:7d1043473d55bfa90e8530d35801d4e381bc69f07d1043473d55bfa90e8530d3", "android:apk-key-hash-sha256:7d1043473d55bfa90e8530d35801d4e381bc69f07d1043473d55bfa90e8530d3", ""},
+		{"ShouldSkipParsingAndroidNativeKeyID", "android:apk-key-id:7d1043473d55bfa90e8530d35801d4e381bc69f0", "android:apk-key-id:7d1043473d55bfa90e8530d35801d4e381bc69f0", ""},
+		{"ShouldSkipParsingIOSNative", "ios:bundle-id:com.example.app", "ios:bundle-id:com.example.app", ""},
+		{"ShouldSkipParsingIOSNativeBundleKey", "ios:bundle-key:7d1043473d55bfa90e8530d35801d4e381bc69f0", "ios:bundle-key:7d1043473d55bfa90e8530d35801d4e381bc69f0", ""},
+		{"ShouldSkipParsingFile", "file://", "file://", ""},
+		{"ShouldParseChromeExtension", "chrome-extension://mbniclmhobmnbdlbpiphghaielnnpgdp", "chrome-extension://mbniclmhobmnbdlbpiphghaielnnpgdp", ""},
+		{"ShouldParseChromeExtensionWithPath", "chrome-extension://mbniclmhobmnbdlbpiphghaielnnpgdp/popup.html", "chrome-extension://mbniclmhobmnbdlbpiphghaielnnpgdp", ""},
+		{"ShouldParseMozExtension", "moz-extension://d56a5b99-51b6-4e83-ab23-796216191c9d", "moz-extension://d56a5b99-51b6-4e83-ab23-796216191c9d", ""},
+		{"ShouldParseMSAppX", "ms-appx://microsoft.windowscalculator_8wekyb3d8bbwe", "ms-appx://microsoft.windowscalculator_8wekyb3d8bbwe", ""},
+		{"ShouldFailToParseAnOpaquePrefixWithoutAValue", "ios:bundle-id:", "", `url 'ios:bundle-id:' does not have a host`},
 		{"ShouldFailToParseMissingScheme", "app.example.com/apath", "", `parse "app.example.com/apath": invalid URI for request`},
 		{"ShouldFailToParseBlankScheme", "://app.example.com/apath", "", `parse "://app.example.com/apath": missing protocol scheme`},
 		{"ShouldFailToParseMissingHost", "https:///apath", "", `url 'https:///apath' does not have a host`},
@@ -489,6 +521,70 @@ func TestIsOriginInHaystack(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, IsOriginInHaystack(tc.origin, tc.haystack))
+		})
+	}
+}
+
+func TestIsOpaqueOriginInHaystack(t *testing.T) {
+	testCases := []struct {
+		name     string
+		origin   string
+		haystack []string
+		expected bool
+	}{
+		{
+			"ShouldMatchAnExactValue",
+			"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			[]string{"ios:bundle-id:com.example.app", "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			true,
+		},
+		{
+			"ShouldNotMatchADifferentCaseValue",
+			"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			[]string{"android:apk-key-hash:2JMJ7L5RSW0YVB-VLWAYKK-YBWK"},
+			false,
+		},
+		{
+			"ShouldNotMatchADifferentCasePrefix",
+			"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+			[]string{"ANDROID:APK-KEY-HASH:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			false,
+		},
+		{
+			"ShouldNotMatchAPrefixOfTheValue",
+			"ios:bundle-id:com.example.app.other",
+			[]string{"ios:bundle-id:com.example.app"},
+			false,
+		},
+		{
+			"ShouldNotMatchAnEmptyHaystack",
+			"ios:bundle-id:com.example.app",
+			nil,
+			false,
+		},
+		{
+			"ShouldNotFoldTheCaseOfAHostlessHTTPSValue",
+			"https://",
+			[]string{"HTTPS://"},
+			false,
+		},
+		{
+			"ShouldNotNormalizeThePortOfAnOutOfRangeHTTPSValue",
+			"https://example.com:99999",
+			[]string{"https://Example.com:99999"},
+			false,
+		},
+		{
+			"ShouldMatchAnOutOfRangeHTTPSValueExactly",
+			"https://example.com:99999",
+			[]string{"https://example.com:99999"},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsOpaqueOriginInHaystack(tc.origin, tc.haystack))
 		})
 	}
 }

--- a/protocol/related_origins.go
+++ b/protocol/related_origins.go
@@ -386,12 +386,19 @@ func IsKnownOpaqueOrigin(origin string) bool {
 
 // hasOpaqueOriginPrefix reports whether the origin begins with one of [opaqueOriginPrefixes] and carries a value after
 // it, or is one of [opaqueOriginsComplete].
+//
+// A complete opaque origin is matched only as itself and never as a prefix, as the value a client conveys for it ends
+// where the prefix does; appending to it, i.e. 'file://localhost', produces a value no client conveys.
 func hasOpaqueOriginPrefix(origin string) bool {
 	if isOpaqueOriginComplete(origin) {
 		return true
 	}
 
 	for _, prefix := range opaqueOriginPrefixes {
+		if isOpaqueOriginComplete(prefix) {
+			continue
+		}
+
 		if len(origin) > len(prefix) && strings.HasPrefix(origin, prefix) {
 			return true
 		}

--- a/protocol/related_origins.go
+++ b/protocol/related_origins.go
@@ -281,17 +281,157 @@ func DefaultRelatedOriginLabeler(origin string) (label string, err error) {
 	return labels[len(labels)-2], nil
 }
 
+const (
+	// OpaqueOriginPrefixAndroidAPKKeyHash is the prefix of the opaque origin a client on Android conveys for a native
+	// application. The remainder is the base64url encoding, without padding, of the SHA-1 digest of the signing
+	// certificate of the APK.
+	OpaqueOriginPrefixAndroidAPKKeyHash = "android:apk-key-hash:"
+
+	// OpaqueOriginPrefixAndroidAPKKeyHashSHA256 is the prefix of the opaque origin a client on Android conveys for a
+	// native application when the digest of the signing certificate of the APK is taken with SHA-256 rather than the
+	// SHA-1 of [OpaqueOriginPrefixAndroidAPKKeyHash].
+	OpaqueOriginPrefixAndroidAPKKeyHashSHA256 = "android:apk-key-hash-sha256:"
+
+	// OpaqueOriginPrefixAndroidAPKKeyID is the prefix of the opaque origin a client on Android conveys for a native
+	// application when it identifies the signing key of the APK by its id rather than by a digest of the signing
+	// certificate.
+	OpaqueOriginPrefixAndroidAPKKeyID = "android:apk-key-id:"
+
+	// OpaqueOriginPrefixIOSBundleID is the prefix of the opaque origin a client on iOS conveys for a native
+	// application. The remainder is the bundle identifier of the application.
+	OpaqueOriginPrefixIOSBundleID = "ios:bundle-id:"
+
+	// OpaqueOriginPrefixIOSBundleKey is the prefix of the opaque origin a client on iOS conveys for a native
+	// application when it identifies the application by its signing key rather than by the bundle identifier of
+	// [OpaqueOriginPrefixIOSBundleID].
+	OpaqueOriginPrefixIOSBundleKey = "ios:bundle-key:"
+
+	// OpaqueOriginPrefixChromeExtension is the prefix of the origin a Chromium based browser conveys for an extension.
+	// The remainder is the id of the extension.
+	OpaqueOriginPrefixChromeExtension = "chrome-extension://"
+
+	// OpaqueOriginPrefixMozExtension is the prefix of the origin Firefox conveys for an extension. The remainder is
+	// the id the browser assigned the extension for the profile it is installed in, which differs between
+	// installations of the same extension.
+	OpaqueOriginPrefixMozExtension = "moz-extension://"
+
+	// OpaqueOriginPrefixFile is the origin a browser conveys for a document loaded from the local file system. A file
+	// origin has no host to serialize, so this is a complete origin rather than a prefix and a client conveys it
+	// exactly as it is given here; see [IsKnownOpaqueOrigin].
+	OpaqueOriginPrefixFile = "file://"
+
+	// OpaqueOriginPrefixMSAppX is the prefix of the origin a client conveys for a Windows application package. The
+	// remainder is the package identity of the application.
+	OpaqueOriginPrefixMSAppX = "ms-appx://"
+)
+
+// opaqueOriginPrefixes is the set of prefixes [IsKnownOpaqueOrigin] accepts. The order is the order the prefixes are
+// rendered in when a caller lists them for a user, so the forms of one platform sit together.
+var opaqueOriginPrefixes = []string{
+	OpaqueOriginPrefixAndroidAPKKeyHash,
+	OpaqueOriginPrefixAndroidAPKKeyHashSHA256,
+	OpaqueOriginPrefixAndroidAPKKeyID,
+	OpaqueOriginPrefixIOSBundleID,
+	OpaqueOriginPrefixIOSBundleKey,
+	OpaqueOriginPrefixChromeExtension,
+	OpaqueOriginPrefixMozExtension,
+	OpaqueOriginPrefixFile,
+	OpaqueOriginPrefixMSAppX,
+}
+
+// opaqueOriginsComplete is the set of opaque origins which are complete as they are, i.e. those a client conveys with
+// nothing following the prefix because the origin has no host to serialize. They are the exception to the rule
+// [hasOpaqueOriginPrefix] otherwise applies, which is that a prefix on its own is a value no client ever conveys.
+var opaqueOriginsComplete = []string{
+	OpaqueOriginPrefixFile,
+}
+
+// OpaqueOriginPrefixes returns the prefixes of the opaque origins this library knows a client conveys, i.e. those
+// which [IsKnownOpaqueOrigin] accepts.
+func OpaqueOriginPrefixes() []string {
+	prefixes := make([]string, len(opaqueOriginPrefixes))
+
+	copy(prefixes, opaqueOriginPrefixes)
+
+	return prefixes
+}
+
 // IsOpaqueOrigin returns true when the origin is not one a [RelatedOrigins] document can express, i.e. anything which
 // is not an absolute http or https URL with a host component. An opaque origin is matched by simple string comparison
 // rather than by the origin equality semantics of [IsOriginInHaystack], and a client never resolves one through the
 // well-known resource, so a Relying Party which accepts an opaque origin such as 'android:apk-key-hash:...' declares
 // it separately from the origins it serves at [WellKnownPathWebAuthn].
 //
+// This says nothing about whether a client conveys the origin; see [IsKnownOpaqueOrigin] for that.
+//
 // Specification: §5.11. Related Origin Requests (https://www.w3.org/TR/webauthn-3/#sctn-related-origins)
 func IsOpaqueOrigin(origin string) bool {
 	_, err := relatedOriginNormalize(origin)
 
 	return err != nil
+}
+
+// IsKnownOpaqueOrigin returns true when the origin is opaque per [IsOpaqueOrigin] and additionally carries one of the
+// prefixes of [OpaqueOriginPrefixes] followed by at least one character, or is one of the few such prefixes which is a
+// complete origin in itself, i.e. [OpaqueOriginPrefixFile]. Those are the forms a client is known to convey for a
+// native application, a browser extension, or a document loaded from the local file system, which are the only opaque
+// origins a Relying Party can meaningfully accept: an opaque origin is matched by simple string comparison against a
+// value the Relying Party configured, so a value no client ever produces can only ever fail to match.
+//
+// The prefix is matched case-sensitively, as the whole value is, because a client conveys these origins in the form
+// given here and the origin as a whole is compared byte for byte.
+func IsKnownOpaqueOrigin(origin string) bool {
+	return hasOpaqueOriginPrefix(origin) && IsOpaqueOrigin(origin)
+}
+
+// hasOpaqueOriginPrefix reports whether the origin begins with one of [opaqueOriginPrefixes] and carries a value after
+// it, or is one of [opaqueOriginsComplete].
+func hasOpaqueOriginPrefix(origin string) bool {
+	if isOpaqueOriginComplete(origin) {
+		return true
+	}
+
+	for _, prefix := range opaqueOriginPrefixes {
+		if len(origin) > len(prefix) && strings.HasPrefix(origin, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isOpaqueOriginWithoutAuthority reports whether the origin is a known opaque origin which has no authority component
+// for a URL parser to reduce to a scheme and host, i.e. one whose prefix is a scheme and a value rather than a scheme
+// and the '//' which introduces an authority, or one which is complete as it is because its authority is empty. Those
+// are the origins [FullyQualifiedOrigin] returns unaltered; the ones with an authority have a serialization it can
+// derive in the usual way.
+func isOpaqueOriginWithoutAuthority(origin string) bool {
+	if isOpaqueOriginComplete(origin) {
+		return true
+	}
+
+	for _, prefix := range opaqueOriginPrefixes {
+		if strings.HasSuffix(prefix, "//") {
+			continue
+		}
+
+		if len(origin) > len(prefix) && strings.HasPrefix(origin, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isOpaqueOriginComplete reports whether the origin is one of [opaqueOriginsComplete].
+func isOpaqueOriginComplete(origin string) bool {
+	for _, complete := range opaqueOriginsComplete {
+		if origin == complete {
+			return true
+		}
+	}
+
+	return false
 }
 
 // relatedOriginNormalize reduces an origin to the scheme and host which identify it, rejecting values which are not

--- a/protocol/related_origins_test.go
+++ b/protocol/related_origins_test.go
@@ -426,7 +426,66 @@ func TestIsOpaqueOrigin(t *testing.T) {
 	}
 }
 
-// testErrorWriter is an [io.Writer] which always fails, used to cover the error paths of the writers.
+func TestIsKnownOpaqueOrigin(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     string
+		expected bool
+	}{
+		{name: "ShouldKnowAnAndroidKeyHash", have: "android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: true},
+		{name: "ShouldKnowAnAndroidKeyHashSHA256", have: "android:apk-key-hash-sha256:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU", expected: true},
+		{name: "ShouldKnowAnAndroidKeyID", have: "android:apk-key-id:2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: true},
+		{name: "ShouldKnowAnIOSBundleID", have: "ios:bundle-id:com.example.app", expected: true},
+		{name: "ShouldKnowAnIOSBundleKey", have: "ios:bundle-key:2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: true},
+		{name: "ShouldKnowAChromeExtension", have: "chrome-extension://mbniclmhobmnbdlbpiphghaielnnpgdp", expected: true},
+		{name: "ShouldKnowAMozExtension", have: "moz-extension://d56a5b99-51b6-4e83-ab23-796216191c9d", expected: true},
+		{name: "ShouldKnowAFileOrigin", have: "file://", expected: true},
+		{name: "ShouldKnowAMSAppXOrigin", have: "ms-appx://microsoft.windowscalculator_8wekyb3d8bbwe", expected: true},
+		{name: "ShouldNotKnowAnAndroidKeyHashWithoutAValue", have: "android:apk-key-hash:", expected: false},
+		{name: "ShouldNotKnowAnIOSBundleIDWithoutAValue", have: "ios:bundle-id:", expected: false},
+		{name: "ShouldNotKnowAChromeExtensionWithoutAnID", have: "chrome-extension://", expected: false},
+		{name: "ShouldNotKnowAnUppercasePrefix", have: "ANDROID:APK-KEY-HASH:2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: false},
+		{name: "ShouldNotKnowAnUppercaseFileOrigin", have: "FILE://", expected: false},
+		{name: "ShouldNotKnowAnAndroidKeyHashWithASingleColon", have: "android:apk-key-hash2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: false},
+		{name: "ShouldNotKnowAnotherNativeScheme", have: "ios:team-id:ABCDE12345", expected: false},
+		{name: "ShouldNotKnowAnotherExtensionScheme", have: "safari-web-extension://d56a5b99-51b6-4e83-ab23-796216191c9d", expected: false},
+		{name: "ShouldNotKnowAnHTTPSOrigin", have: "https://example.com", expected: false},
+		{name: "ShouldNotKnowAnHTTPSOriginWithoutAHost", have: "https:///path", expected: false},
+		{name: "ShouldNotKnowAnHTTPSOriginWithAnOutOfRangePort", have: "https://example.com:99999", expected: false},
+		{name: "ShouldNotKnowASchemelessValue", have: "example.com", expected: false},
+		{name: "ShouldNotKnowAnEmptyValue", have: "", expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, IsKnownOpaqueOrigin(tc.have))
+		})
+	}
+}
+
+func TestOpaqueOriginPrefixes(t *testing.T) {
+	expected := []string{
+		OpaqueOriginPrefixAndroidAPKKeyHash,
+		OpaqueOriginPrefixAndroidAPKKeyHashSHA256,
+		OpaqueOriginPrefixAndroidAPKKeyID,
+		OpaqueOriginPrefixIOSBundleID,
+		OpaqueOriginPrefixIOSBundleKey,
+		OpaqueOriginPrefixChromeExtension,
+		OpaqueOriginPrefixMozExtension,
+		OpaqueOriginPrefixFile,
+		OpaqueOriginPrefixMSAppX,
+	}
+
+	prefixes := OpaqueOriginPrefixes()
+
+	assert.Equal(t, expected, prefixes)
+
+	prefixes[0] = "example:"
+
+	assert.Equal(t, expected, OpaqueOriginPrefixes())
+	assert.True(t, IsKnownOpaqueOrigin("android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk"))
+}
+
 type testErrorWriter struct {
 	err error
 }

--- a/protocol/related_origins_test.go
+++ b/protocol/related_origins_test.go
@@ -444,6 +444,8 @@ func TestIsKnownOpaqueOrigin(t *testing.T) {
 		{name: "ShouldNotKnowAnAndroidKeyHashWithoutAValue", have: "android:apk-key-hash:", expected: false},
 		{name: "ShouldNotKnowAnIOSBundleIDWithoutAValue", have: "ios:bundle-id:", expected: false},
 		{name: "ShouldNotKnowAChromeExtensionWithoutAnID", have: "chrome-extension://", expected: false},
+		{name: "ShouldNotKnowAFileOriginWithAHost", have: "file://localhost", expected: false},
+		{name: "ShouldNotKnowAFileOriginWithAPath", have: "file:///etc/passwd", expected: false},
 		{name: "ShouldNotKnowAnUppercasePrefix", have: "ANDROID:APK-KEY-HASH:2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: false},
 		{name: "ShouldNotKnowAnUppercaseFileOrigin", have: "FILE://", expected: false},
 		{name: "ShouldNotKnowAnAndroidKeyHashWithASingleColon", have: "android:apk-key-hash2jmj7l5rSw0yVb-vlWAYkK-YBwk", expected: false},

--- a/webauthn/const.go
+++ b/webauthn/const.go
@@ -11,6 +11,7 @@ const (
 	errFmtOriginsNotRelated      = "when the 'RPOpaqueOrigins' field is configured the '%s' field must only contain origins a Related Origin Requests document can declare: %w"
 	errFmtOriginsNotRelatedValue = "when the 'RPOpaqueOrigins' field is configured the '%s' field must only contain origins a Related Origin Requests document can declare but the value '%s' is opaque"
 	errFmtOriginsNotOpaqueValue  = "the 'RPOpaqueOrigins' field must only contain opaque origins but the value '%s' is not opaque; it belongs in the 'RPOrigins' field"
+	errFmtOriginsOpaqueUnknown   = "the 'RPOpaqueOrigins' field must only contain opaque origins a client conveys, i.e. one prefixed with %s, but the value '%s' is not one of them"
 
 	errFmtOriginBindOpaque       = "the ceremony origin '%s' can't be bound as it's opaque and an opaque origin is only conveyed in the ceremony response"
 	errFmtOriginBindUnconfigured = "the ceremony origin '%s' must be one of the origins in the 'RPOrigins' configuration"

--- a/webauthn/types.go
+++ b/webauthn/types.go
@@ -50,9 +50,20 @@ type Config struct {
 
 	// RPOpaqueOrigins configures the list of opaque Relying Party Server Origins that are permitted, i.e. those for
 	// which [protocol.IsOpaqueOrigin] returns true because they are not an absolute http or https URL with a host
-	// (i.e. "android:apk-key-hash:..."). These are matched by simple string comparison, they are never matched
-	// against the Top Origin of a cross-origin ceremony, and they are never declared in the Related Origin Requests
-	// document returned by [WebAuthn.RelatedOrigins].
+	// (i.e. "android:apk-key-hash:..."). These are matched by simple string comparison, i.e. as an exact
+	// case-sensitive match and never with the scheme and host semantics [Config.RPOrigins] is matched with, they are
+	// never matched against the Top Origin of a cross-origin ceremony, and they are never declared in the Related
+	// Origin Requests document returned by [WebAuthn.RelatedOrigins].
+	//
+	// Each value must be one of the forms a client conveys for a native application, a browser extension, or a
+	// document loaded from the local file system, i.e. it must carry one of the prefixes of
+	// [protocol.OpaqueOriginPrefixes] and a value after it, or be one of those prefixes which is a complete origin in
+	// itself such as 'file://'; see [protocol.IsKnownOpaqueOrigin]. Any other value is rejected by validation as it
+	// could never match a ceremony.
+	//
+	// An opaque origin is only conveyed in the response of a ceremony, so it is never a value a ceremony can be bound
+	// to with [WithRegistrationOrigin] or [WithLoginOrigin]; the origins configured here stay acceptable while a
+	// ceremony is bound to one of [Config.RPOrigins].
 	//
 	// Configuring this field constrains the other origin fields to what a Related Origin Requests document can
 	// express, so that the origins a client resolves and the origins this Relying Party accepts cannot drift apart:
@@ -232,6 +243,11 @@ func (config *Config) validate() (err error) {
 //
 // The Top Origins are held to the same standard as the Origins minus the label budget, which applies to the origins
 // declared in the document rather than to the origin of a top level browsing context.
+//
+// Each value is additionally held to the forms a client is known to convey, i.e. [protocol.IsKnownOpaqueOrigin]. An
+// opaque origin is only ever matched by simple string comparison against a value configured here, so one no client
+// produces could never match a ceremony, and rejecting it names the mistake rather than leaving a ceremony to fail
+// with an origin error later.
 func (config *Config) validateOpaqueOrigins() (err error) {
 	if len(config.RPOpaqueOrigins) == 0 {
 		return nil
@@ -240,6 +256,10 @@ func (config *Config) validateOpaqueOrigins() (err error) {
 	for _, origin := range config.RPOpaqueOrigins {
 		if !protocol.IsOpaqueOrigin(origin) {
 			return fmt.Errorf(errFmtOriginsNotOpaqueValue, origin)
+		}
+
+		if !protocol.IsKnownOpaqueOrigin(origin) {
+			return fmt.Errorf(errFmtOriginsOpaqueUnknown, joinOpaqueOriginPrefixes(), origin)
 		}
 	}
 

--- a/webauthn/types_test.go
+++ b/webauthn/types_test.go
@@ -205,6 +205,60 @@ func TestConfig_Validate_OpaqueOrigins(t *testing.T) {
 			},
 			err: "error occurred validating the configuration: the 'RPOpaqueOrigins' field must only contain opaque origins but the value 'https://app.example.com' is not opaque; it belongs in the 'RPOrigins' field",
 		},
+		{
+			name: "ShouldPassEveryKnownOpaqueOriginPrefixInRPOpaqueOrigins",
+			config: &Config{
+				RPID:      "example.com",
+				RPOrigins: []string{"https://example.com"},
+				RPOpaqueOrigins: []string{
+					"android:apk-key-hash:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+					"android:apk-key-hash-sha256:47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU",
+					"android:apk-key-id:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+					"ios:bundle-id:com.example.app",
+					"ios:bundle-key:2jmj7l5rSw0yVb-vlWAYkK-YBwk",
+					"chrome-extension://mbniclmhobmnbdlbpiphghaielnnpgdp",
+					"moz-extension://d56a5b99-51b6-4e83-ab23-796216191c9d",
+					"file://",
+					"ms-appx://microsoft.windowscalculator_8wekyb3d8bbwe",
+				},
+			},
+		},
+		{
+			name: "ShouldFailAnUnknownOpaqueOriginPrefixInRPOpaqueOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com"},
+				RPOpaqueOrigins: []string{"safari-web-extension://d56a5b99-51b6-4e83-ab23-796216191c9d"},
+			},
+			err: "error occurred validating the configuration: " + errOpaqueOriginsUnknownPrefix + "'safari-web-extension://d56a5b99-51b6-4e83-ab23-796216191c9d' is not one of them",
+		},
+		{
+			name: "ShouldFailAKnownOpaqueOriginPrefixWithoutAValueInRPOpaqueOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com"},
+				RPOpaqueOrigins: []string{"android:apk-key-hash:"},
+			},
+			err: "error occurred validating the configuration: " + errOpaqueOriginsUnknownPrefix + "'android:apk-key-hash:' is not one of them",
+		},
+		{
+			name: "ShouldFailAKnownOpaqueOriginPrefixInTheWrongCaseInRPOpaqueOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com"},
+				RPOpaqueOrigins: []string{"ANDROID:APK-KEY-HASH:2jmj7l5rSw0yVb-vlWAYkK-YBwk"},
+			},
+			err: "error occurred validating the configuration: " + errOpaqueOriginsUnknownPrefix + "'ANDROID:APK-KEY-HASH:2jmj7l5rSw0yVb-vlWAYkK-YBwk' is not one of them",
+		},
+		{
+			name: "ShouldFailAnOpaqueOriginResemblingAURLInRPOpaqueOrigins",
+			config: &Config{
+				RPID:            "example.com",
+				RPOrigins:       []string{"https://example.com"},
+				RPOpaqueOrigins: []string{"https://example.com:99999"},
+			},
+			err: "error occurred validating the configuration: " + errOpaqueOriginsUnknownPrefix + "'https://example.com:99999' is not one of them",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -499,7 +553,7 @@ func TestConfig_Validate_FilteringMutuallyExclusive(t *testing.T) {
 	})
 }
 
-// Supporting test types and functions.
+const errOpaqueOriginsUnknownPrefix = "the 'RPOpaqueOrigins' field must only contain opaque origins a client conveys, i.e. one prefixed with 'android:apk-key-hash:', 'android:apk-key-hash-sha256:', 'android:apk-key-id:', 'ios:bundle-id:', 'ios:bundle-key:', 'chrome-extension://', 'moz-extension://', 'file://', or 'ms-appx://', but the value "
 
 type defaultUser struct {
 	id          []byte

--- a/webauthn/util.go
+++ b/webauthn/util.go
@@ -3,6 +3,7 @@ package webauthn
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/go-webauthn/webauthn/protocol"
 )
@@ -79,6 +80,25 @@ func validateUserHandle(id any) (err error) {
 	}
 
 	return nil
+}
+
+// joinOpaqueOriginPrefixes renders the prefixes of [protocol.OpaqueOriginPrefixes] for an error message, i.e. as
+// "'a', 'b', or 'c'".
+func joinOpaqueOriginPrefixes() string {
+	prefixes := protocol.OpaqueOriginPrefixes()
+
+	for i, prefix := range prefixes {
+		prefixes[i] = "'" + prefix + "'"
+	}
+
+	switch n := len(prefixes); n {
+	case 0:
+		return ""
+	case 1:
+		return prefixes[0]
+	default:
+		return strings.Join(prefixes[:n-1], ", ") + ", or " + prefixes[n-1]
+	}
 }
 
 // validateCeremonyOrigin checks the origin a ceremony is being bound to by [WithRegistrationOrigin] or


### PR DESCRIPTION
An opaque origin was matched by IsOriginInHaystack, which applies origin equality to any value prefixed with http or https, so one which resembles a URL without being one such as an origin with no host or a port out of range was matched case-insensitively. Opaque origins are now matched by IsOpaqueOriginInHaystack, which is simple string comparison alone, i.e. an exact case-sensitive match.

The RPOpaqueOrigins field is also held to the forms a client conveys, being the prefixes of OpaqueOriginPrefixes, as any other value could never match a ceremony. FullyQualifiedOrigin returns each of those forms which carries no authority unaltered rather than only android:apk-key-hash:.