### PR TITLE
fix(webauthncose): validate okp key algorithm

### DIFF
--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -440,6 +440,17 @@ func validateKeyCurve(keyType string, algorithm, curve int64) error {
 }
 
 func validateOKPPublicKey(k *OKPPublicKeyData) error {
+	// The algorithm is gated before anything else, as [validateEC2PublicKey] gates its own. Without this an OKP key
+	// naming any algorithm at all is accepted and then verified with Ed25519 regardless of what it named, since
+	// Ed25519 is the only OKP curve implemented. It also keeps an OKP key out of the case [validateKeyCurve] passes
+	// over, because every algorithm accepted here is one that map covers.
+	switch alg := COSEAlgorithmIdentifier(k.Algorithm); alg {
+	case AlgEdDSA, AlgEd25519:
+		// Both name the Ed25519 curve, the generic identifier by way of the crv parameter the next check enforces.
+	default:
+		return ErrUnsupportedAlgorithm.WithDetails(fmt.Sprintf("OKP key has unsupported algorithm %s", alg))
+	}
+
 	// The curve is checked before the key material so that both key structures report what the key declares about
 	// itself before what it carries.
 	if err := validateKeyCurve("OKP", k.Algorithm, k.Curve); err != nil {

--- a/protocol/webauthncose/webauthncose_test.go
+++ b/protocol/webauthncose/webauthncose_test.go
@@ -30,6 +30,11 @@ func TestOKPSignatureVerification(t *testing.T) {
 	invalidSig := []byte("invalid")
 
 	key := OKPPublicKeyData{
+		PublicKeyData: PublicKeyData{
+			KeyType:   int64(OctetKey),
+			Algorithm: int64(AlgEdDSA),
+		},
+		Curve:  int64(Ed25519),
 		XCoord: pub,
 	}
 
@@ -41,6 +46,27 @@ func TestOKPSignatureVerification(t *testing.T) {
 	ok, err = key.Verify(data, invalidSig)
 	assert.NoError(t, err)
 	assert.False(t, ok)
+}
+
+func TestOKPVerifyRejectsUnsupportedAlgorithm(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	data := []byte("Sample data to sign")
+	validSig := ed25519.Sign(priv, data)
+
+	key := OKPPublicKeyData{
+		PublicKeyData: PublicKeyData{
+			KeyType:   int64(OctetKey),
+			Algorithm: int64(AlgRS256),
+		},
+		Curve:  int64(Ed25519),
+		XCoord: pub,
+	}
+
+	ok, err := key.Verify(data, validSig)
+	assert.False(t, ok, "a key declaring an algorithm this library does not verify OKP keys with must not verify")
+	assert.EqualError(t, err, "OKP key has unsupported algorithm RS256")
 }
 
 func TestP256SignatureVerification(t *testing.T) {
@@ -105,8 +131,10 @@ MCowBQYDK2VwAyEAe4gQJK3JgtOAuHceO5v45LOZi8fQWDBmAs5NDy/kt4E=
 	key := OKPPublicKeyData{
 		XCoord: pub,
 		PublicKeyData: PublicKeyData{
-			KeyType: int64(OctetKey),
+			KeyType:   int64(OctetKey),
+			Algorithm: int64(AlgEdDSA),
 		},
+		Curve: int64(Ed25519),
 	}
 
 	// Get the CBOR-encoded representation of the OKPPublicKeyData.
@@ -477,6 +505,13 @@ func TestParsePublicKeyValidation(t *testing.T) {
 			"",
 		},
 		{
+			// The fully specified identifier names its curve, so §5.8.5 states no crv requirement for it; the
+			// parameter is supplied here because COSE requires it of an OKP key regardless.
+			"ShouldAcceptValidOKPKeyWithFullySpecifiedAlgorithm",
+			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgEd25519), map[int64]any{-1: int64(Ed25519), -2: []byte(okpPub)}),
+			"",
+		},
+		{
 			"ShouldAcceptValidEC2Key",
 			mustMarshalCOSEKey(t, int64(EllipticKey), int64(AlgES256), map[int64]any{-1: int64(P256), -2: ec2X, -3: ec2Y}),
 			"",
@@ -490,6 +525,17 @@ func TestParsePublicKeyValidation(t *testing.T) {
 			"ShouldRejectOKPWithInvalidXCoordLength",
 			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgEdDSA), map[int64]any{-1: int64(Ed25519), -2: make([]byte, 16)}),
 			"OKP key x coordinate has invalid length 16, expected 32",
+		},
+		{
+			// The key material is a genuine Ed25519 public key, so only the declared algorithm can reject it.
+			"ShouldRejectOKPWithUnsupportedAlgorithm",
+			mustMarshalCOSEKey(t, int64(OctetKey), int64(AlgRS256), map[int64]any{-1: int64(Ed25519), -2: []byte(okpPub)}),
+			"OKP key has unsupported algorithm RS256",
+		},
+		{
+			"ShouldRejectOKPWithUnregisteredAlgorithm",
+			mustMarshalCOSEKey(t, int64(OctetKey), int64(999), map[int64]any{-1: int64(Ed25519), -2: []byte(okpPub)}),
+			"OKP key has unsupported algorithm 999",
 		},
 		{
 			"ShouldRejectEC2WithUnsupportedAlgorithm",


### PR DESCRIPTION
An OKP credential public key was accepted whatever algorithm it named, and Ed25519 verification then ran against it regardless. Only EdDSA and Ed25519 are accepted now, matching the check the EC2 branch already performs. The check lives in the key validator, so it applies to stored keys on the assertion path as well as at registration.

BREAKING CHANGE: A stored credential whose OKP key names an algorithm other than -8 or -19 no longer parses, failing the assertion rather than verifying with Ed25519.