### PR TITLE
fix(webauthncose)!: fail closed on unknown hash algorithm

### DIFF
--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -155,7 +155,11 @@ func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash
 	// 3/4 Verify that extraData is set to the hash of attToBeSigned using the hash algorithm employed in "alg".
 	coseAlg := webauthncose.COSEAlgorithmIdentifier(statement.Algorithm)
 
-	h := webauthncose.HasherFromCOSEAlg(coseAlg)
+	h, supported := webauthncose.HasherFromCOSEAlg(coseAlg)
+	if !supported {
+		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Unsupported COSE alg: %d", statement.Algorithm))
+	}
+
 	h.Write(attToBeSigned)
 
 	if !bytes.Equal(certInfo.ExtraData.Buffer, h.Sum(nil)) {

--- a/protocol/attestation_tpm_test.go
+++ b/protocol/attestation_tpm_test.go
@@ -570,6 +570,17 @@ func TestTPMAttestationVerificationAAGUID(t *testing.T) {
 	}
 }
 
+func TestTPMAttestationRejectsUnsupportedAlgorithmBeforeHashing(t *testing.T) {
+	att := makeTPMAttestation(t, tpmAttestationOptions{basicConstraintsValid: true})
+
+	att.AttStatement[stmtAlgorithm] = int64(9999)
+	att.RawAuthData = []byte{0x01}
+
+	_, _, err := attestationFormatValidationHandlerTPM(att, nil, nil, AttestationPolicy{}, SignaturePolicy{})
+
+	assert.EqualError(t, err, "Unsupported COSE alg: 9999")
+}
+
 func TestTpm2Exponent(t *testing.T) {
 	testCases := []struct {
 		name   string
@@ -930,7 +941,9 @@ func TestTPMAttestationVerificationRSAExponent(t *testing.T) {
 }
 
 func TestTPMAttestationVerificationFailCertInfo(t *testing.T) {
-	h := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
+	h, ok := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
+	require.True(t, ok)
+
 	extraData := h.Sum(nil)
 
 	testCases := []struct {
@@ -1052,7 +1065,8 @@ func TestTPMAttestationVerificationFailX5c(t *testing.T) {
 		},
 	}
 
-	h := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
+	h, ok := webauthncose.HasherFromCOSEAlg(webauthncose.AlgRS256)
+	require.True(t, ok)
 
 	h.Write(att.RawAuthData)
 	extraData := h.Sum(nil)

--- a/protocol/webauthncose/webauthncose.go
+++ b/protocol/webauthncose/webauthncose.go
@@ -2,7 +2,6 @@ package webauthncose
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -93,7 +92,14 @@ func (k *EC2PublicKeyData) Verify(data []byte, sig []byte) (valid bool, err erro
 		return false, err
 	}
 
-	h := HasherFromCOSEAlg(COSEAlgorithmIdentifier(k.Algorithm))
+	// validateEC2PublicKey has already rejected an algorithm with no curve, and every algorithm which survives that
+	// has a hash registered, so this cannot fail as the two are written today. It is checked rather than discarded
+	// so that widening one of the two without the other is an error instead of a silent substitution.
+	h, ok := HasherFromCOSEAlg(COSEAlgorithmIdentifier(k.Algorithm))
+	if !ok {
+		return false, ErrUnsupportedAlgorithm.WithDetails(fmt.Sprintf("EC2 key algorithm %s has no registered hash", COSEAlgorithmIdentifier(k.Algorithm)))
+	}
+
 	h.Write(data)
 
 	e := &ECDSASignature{}
@@ -384,15 +390,17 @@ func SigAlgFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) x509.SignatureAlgorithm 
 	return d.sigAlg
 }
 
-// HasherFromCOSEAlg returns the Hashing interface to be used for a given COSE Algorithm.
-func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) hash.Hash {
+// HasherFromCOSEAlg returns the hashing interface to be used for a given COSE algorithm, and whether this library
+// has one registered for it. An unregistered algorithm yields no hash rather than a substituted one, so a caller
+// which reaches this with an algorithm it has not itself constrained cannot hash with an algorithm the credential
+// never named.
+func HasherFromCOSEAlg(coseAlg COSEAlgorithmIdentifier) (hash.Hash, bool) {
 	d, ok := COSESignatureAlgorithmDetails[coseAlg]
 	if !ok {
-		// default to SHA256?  Why not.
-		return crypto.SHA256.New()
+		return nil, false
 	}
 
-	return d.hash.New()
+	return d.hash.New(), true
 }
 
 // coseAlgorithmCurve describes the elliptic curve a credential public key using a particular algorithm names.

--- a/protocol/webauthncose/webauthncose_test.go
+++ b/protocol/webauthncose/webauthncose_test.go
@@ -1,6 +1,7 @@
 package webauthncose
 
 import (
+	"crypto"
 	"crypto/ecdh"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -143,6 +144,38 @@ MCowBQYDK2VwAyEAe4gQJK3JgtOAuHceO5v45LOZi8fQWDBmAs5NDy/kt4E=
 	actual := DisplayPublicKey(buf)
 
 	assert.Equal(t, expected, actual)
+}
+
+func TestHasherFromCOSEAlg(t *testing.T) {
+	testCases := []struct {
+		name string
+		alg  COSEAlgorithmIdentifier
+		size int
+	}{
+		{"ShouldReturnSHA256ForRS256", AlgRS256, crypto.SHA256.Size()},
+		{"ShouldReturnSHA384ForES384", AlgES384, crypto.SHA384.Size()},
+		{"ShouldReturnSHA512ForES512", AlgES512, crypto.SHA512.Size()},
+		{"ShouldReturnSHA512ForEdDSA", AlgEdDSA, crypto.SHA512.Size()},
+		{"ShouldRejectUnregisteredAlgorithm", COSEAlgorithmIdentifier(9999), 0},
+		{"ShouldRejectZeroAlgorithm", COSEAlgorithmIdentifier(0), 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, ok := HasherFromCOSEAlg(tc.alg)
+
+			if tc.size == 0 {
+				assert.False(t, ok)
+				assert.Nil(t, h, "an unusable algorithm must not yield a hash to write into")
+
+				return
+			}
+
+			require.True(t, ok)
+			require.NotNil(t, h)
+			assert.Equal(t, tc.size, h.Size())
+		})
+	}
 }
 
 func TestRSAExponent(t *testing.T) {


### PR DESCRIPTION
HasherFromCOSEAlg substituted SHA-256 for any algorithm it did not recognize. The TPM attestation handler reached it with an unvalidated algorithm taken from the attestation statement, so an unrecognized one was reported as a mismatched extraData rather than as the unsupported algorithm it was. It is now rejected before the statement is hashed.

BREAKING CHANGE: HasherFromCOSEAlg returns (hash.Hash, bool) and no longer substitutes SHA-256 for an unregistered algorithm. Callers must handle the second value.