### PR TITLE
fix(protocol)!: validate relying party id as a domain string

### DIFF
--- a/protocol/const.go
+++ b/protocol/const.go
@@ -24,6 +24,12 @@ const (
 )
 
 const (
+	maxDomainLength           = 253
+	maxDomainLabelLength      = 63
+	forbiddenDomainCodePoints = " #/:<>?@[\\]^|%"
+)
+
+const (
 	attStatementAndroidSafetyNetHostname = "attest.android.com"
 )
 

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -1,5 +1,7 @@
 package protocol
 
+import "errors"
+
 // Error is a struct that describes specific error conditions in a structured format.
 type Error struct {
 	// Short name for the type of error that has occurred.
@@ -151,4 +153,16 @@ var (
 		Type:    "not_implemented",
 		Details: "This field is not yet supported by this library",
 	}
+)
+
+var (
+	errDomainIsIPAddress        = errors.New("the value must be a domain and not an IP address")
+	errDomainNotADomain         = errors.New("the domain component must actually be a domain")
+	errDomainEmptyLabel         = errors.New("the domain must not contain an empty label")
+	errDomainLabelHyphen        = errors.New("the domain labels must not begin or end with a hyphen")
+	errDomainLabelTooLong       = errors.New("the domain labels must not exceed 63 characters")
+	errDomainTooLong            = errors.New("the domain must not exceed 253 characters")
+	errDomainForbiddenCharacter = errors.New("the domain must not contain a forbidden character")
+	errDomainFinalLabelNumeric  = errors.New("the final domain label must not be a number")
+	errDomainNotASCII           = errors.New("the domain must not contain non-ascii characters, apply IDNA normalization to it first")
 )

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -251,8 +252,14 @@ func attestationCredentialPublicKey(credentialPublicKey any) (public crypto.Publ
 }
 
 // ValidateRPID performs non-exhaustive checks to ensure the string is most likely a domain string as
-// relying-party ID's are required to be. Effectively this can be an IP, localhost, or a string that contains a period.
-// The relying-party ID must not contain scheme, port, path, query, or fragment components.
+// relying-party ID's are required to be. Effectively this is localhost or a domain of two or more labels. The
+// relying-party ID must not contain scheme, port, path, query, or fragment components, and must not be an IP
+// address: §5.4.2 defines it as a valid domain string, which an address literal is not, and a client rejects one.
+//
+// No IDNA normalization is performed, so a value carrying non-ASCII characters is rejected rather than converted.
+// A Relying Party ID is hashed verbatim to compare against the rpIdHash an authenticator reports, while a client
+// normalizes the value it was handed, so a name which is not already in its ASCII form can never produce a matching
+// hash. Callers serving an internationalized domain must apply IDNA themselves and configure the resulting A-label.
 //
 // See: https://www.w3.org/TR/webauthn/#rp-id
 //
@@ -263,7 +270,7 @@ func ValidateRPID(value string) (err error) {
 	}
 
 	if ip := net.ParseIP(value); ip != nil {
-		return nil
+		return errDomainIsIPAddress
 	}
 
 	var rpid *url.URL
@@ -310,11 +317,67 @@ func ValidateRPID(value string) (err error) {
 		}
 	}
 
-	if value != "localhost" && !strings.Contains(rpid.Path, ".") {
-		return errors.New("the domain component must actually be a domain")
+	return validateDomainString(value)
+}
+
+func validateDomainString(value string) error {
+	if len(value) > maxDomainLength {
+		return errDomainTooLong
+	}
+
+	labels := strings.Split(value, ".")
+
+	for _, label := range labels {
+		if len(label) == 0 {
+			return errDomainEmptyLabel
+		}
+
+		if len(label) > maxDomainLabelLength {
+			return errDomainLabelTooLong
+		}
+
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return errDomainLabelHyphen
+		}
+
+		if strings.ContainsAny(label, forbiddenDomainCodePoints) {
+			return errDomainForbiddenCharacter
+		}
+
+		for _, r := range label {
+			if r < 0x20 || r == 0x7F {
+				return errDomainForbiddenCharacter
+			}
+
+			if r > 0x7F {
+				return errDomainNotASCII
+			}
+		}
+	}
+
+	if isNumericDomainLabel(labels[len(labels)-1]) {
+		return errDomainFinalLabelNumeric
+	}
+
+	if len(labels) == 1 && value != "localhost" {
+		return errDomainNotADomain
 	}
 
 	return nil
+}
+
+func isNumericDomainLabel(label string) bool {
+	if label == "" {
+		return false
+	}
+
+	if strings.Trim(label, "0123456789") == "" {
+		return true
+	}
+
+	_, err := strconv.ParseUint(label, 0, 64)
+
+	return err == nil
 }
 
 // IsAttestationFormatString reports whether s is one of the WebAuthn-defined attestation statement format

--- a/protocol/utils_test.go
+++ b/protocol/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,25 +37,144 @@ func TestValidateRPID(t *testing.T) {
 			value: "localhost",
 		},
 		{
-			name:  "ValidRPIDUsingIPv4",
+			name:  "ValidRPIDSubdomain",
+			value: "sub.example.com",
+		},
+		{
+			name:  "ValidRPIDPunycode",
+			value: "xn--bcher-kva.example",
+		},
+		{
+			name:  "InvalidRPIDNonASCII",
+			value: "café.example",
+			err:   errDomainNotASCII.Error(),
+		},
+		{
+			name:  "InvalidRPIDIPv4Shorthand",
+			value: "127.1",
+			err:   errDomainFinalLabelNumeric.Error(),
+		},
+		{
+			name:  "InvalidRPIDNumericFinalLabel",
+			value: "example.123",
+			err:   errDomainFinalLabelNumeric.Error(),
+		},
+		{
+			name:  "InvalidRPIDThreeOctetShorthand",
+			value: "1.2.3",
+			err:   errDomainFinalLabelNumeric.Error(),
+		},
+		{
+			name:  "InvalidRPIDOutOfRangeOctets",
+			value: "999.999.999.999",
+			err:   errDomainFinalLabelNumeric.Error(),
+		},
+		{
+			name:  "InvalidRPIDHexadecimalFinalLabel",
+			value: "example.0x1",
+			err:   errDomainFinalLabelNumeric.Error(),
+		},
+		{
+			name:  "InvalidRPIDAllDigits",
+			value: "2130706433",
+			err:   errDomainFinalLabelNumeric.Error(),
+		},
+		{
+			name:  "ValidRPIDUppercase",
+			value: "EXAMPLE.COM",
+		},
+		{
+			name:  "ValidRPIDUnderscoreIsNotForbidden",
+			value: "exa_mple.com",
+		},
+		{
+			name:  "ValidRPIDShortest",
+			value: "a.b",
+		},
+		{
+			name:  "InvalidRPIDUsingIPv4",
 			value: "127.0.0.1",
+			err:   errDomainIsIPAddress.Error(),
 		},
 		{
-			name:  "ValidRPIDUsingIPv4Alt",
+			name:  "InvalidRPIDUsingIPv4Alt",
 			value: "1.1.1.1",
+			err:   errDomainIsIPAddress.Error(),
 		},
 		{
-			name:  "ValidRPIDUsingIPv6",
+			name:  "InvalidRPIDUsingIPv6",
 			value: "2001:DB8:0:0:8:800:200C:417A",
+			err:   errDomainIsIPAddress.Error(),
 		},
 		{
-			name:  "ValidRPIDUsingIPv6Alt",
+			name:  "InvalidRPIDUsingIPv6Alt",
 			value: "::1",
+			err:   errDomainIsIPAddress.Error(),
 		},
 		{
 			name:  "InvalidRPIDNotDomain",
 			value: "example",
-			err:   "the domain component must actually be a domain",
+			err:   errDomainNotADomain.Error(),
+		},
+		{
+			name:  "InvalidRPIDTrailingDot",
+			value: "example.com.",
+			err:   errDomainEmptyLabel.Error(),
+		},
+		{
+			name:  "InvalidRPIDLocalhostTrailingDot",
+			value: "localhost.",
+			err:   errDomainEmptyLabel.Error(),
+		},
+		{
+			name:  "InvalidRPIDLeadingDot",
+			value: ".example.com",
+			err:   errDomainEmptyLabel.Error(),
+		},
+		{
+			name:  "InvalidRPIDOnlyDots",
+			value: "..",
+			err:   errDomainEmptyLabel.Error(),
+		},
+		{
+			name:  "InvalidRPIDEmptyLabel",
+			value: "a..b",
+			err:   errDomainEmptyLabel.Error(),
+		},
+		{
+			name:  "InvalidRPIDHyphenLabels",
+			value: "-.-",
+			err:   errDomainLabelHyphen.Error(),
+		},
+		{
+			name:  "InvalidRPIDLeadingHyphen",
+			value: "-example.com",
+			err:   errDomainLabelHyphen.Error(),
+		},
+		{
+			name:  "InvalidRPIDTrailingHyphen",
+			value: "example-.com",
+			err:   errDomainLabelHyphen.Error(),
+		},
+		{
+			name:  "InvalidRPIDTrailingHyphenLastLabel",
+			value: "a.b-",
+			err:   errDomainLabelHyphen.Error(),
+		},
+		{
+			name:  "InvalidRPIDLeadingSpace",
+			value: " example.com",
+			err:   errDomainForbiddenCharacter.Error(),
+		},
+		{
+			name:  "InvalidRPIDLabelTooLong",
+			value: strings.Repeat("a", 64) + ".com",
+			err:   errDomainLabelTooLong.Error(),
+		},
+		{
+			name:  "InvalidRPIDTooLong",
+			value: strings.Repeat(strings.Repeat("a", 63)+".", 4) + "com",
+			err:   errDomainTooLong.Error(),
 		},
 		{
 			name:  "InvalidRPIDScheme",


### PR DESCRIPTION
ValidateRPID accepted an IP address, an empty label, a leading or trailing hyphen, and a leading space, leaving the failure to the ceremony where a client reports it. Section 5.1.3 requires the origin's effective domain to be a domain and names the address literal as the case it excludes, so an IP relying party id can never succeed. An underscore is still accepted, since the URL standard does not forbid it in a domain.

BREAKING CHANGE: An IP address configured as a relying party id is rejected, so a Config carrying one now fails validation.