### PR TITLE
fix(webauthncbor): reject data trailing the first cbor item

### DIFF
--- a/protocol/attestation_test.go
+++ b/protocol/attestation_test.go
@@ -112,6 +112,20 @@ func TestAttestationResponseParse_Errors(t *testing.T) {
 	}
 }
 
+func TestAttestationResponseParseRejectsTrailingCBOR(t *testing.T) {
+	ccr := CredentialCreationResponse{}
+
+	require.NoError(t, json.Unmarshal([]byte(testAttestationResponses[0]), &ccr))
+
+	_, err := ccr.AttestationResponse.Parse()
+	require.NoError(t, err)
+
+	ccr.AttestationResponse.AttestationObject = append(ccr.AttestationResponse.AttestationObject, 0x01)
+
+	_, err = ccr.AttestationResponse.Parse()
+	require.EqualError(t, err, "Error parsing the authenticator response")
+}
+
 func TestAttestationObject_VerifyAttestation_Errors(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/protocol/webauthncbor/webauthncbor.go
+++ b/protocol/webauthncbor/webauthncbor.go
@@ -31,10 +31,11 @@ var ctap2CBOREncMode, _ = cbor.CTAP2EncOptions().EncMode()
 // Unmarshal parses the CBOR-encoded data into the value pointed to by v
 // following the CTAP2 canonical CBOR encoding form.
 // (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding)
+//
+// The data must hold exactly one CBOR item. Bytes which follow that item are malformed input rather than something to
+// discard, so they are reported. Callers decoding an item embedded in a larger byte sequence want [UnmarshalFirst].
 func Unmarshal(data []byte, v any) error {
-	_, err := ctap2CBORDecMode.UnmarshalFirst(data, v)
-
-	return err
+	return ctap2CBORDecMode.Unmarshal(data, v)
 }
 
 // UnmarshalFirst parses the first CBOR-encoded item in data into the value pointed to by v following the CTAP2

--- a/protocol/webauthncbor/webauthncbor_test.go
+++ b/protocol/webauthncbor/webauthncbor_test.go
@@ -1,0 +1,60 @@
+package webauthncbor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var item = []byte{0xa1, 0x61, 0x61, 0x01}
+
+func TestUnmarshalRejectsTrailingData(t *testing.T) {
+	testCases := []struct {
+		name string
+		data []byte
+		err  string
+	}{
+		{
+			name: "ShouldAcceptExactlyOneItem",
+			data: item,
+		},
+		{
+			name: "ShouldRejectTrailingItem",
+			data: append(append([]byte{}, item...), item...),
+			err:  "cbor: 4 bytes of extraneous data starting at index 4",
+		},
+		{
+			name: "ShouldRejectTrailingByte",
+			data: append(append([]byte{}, item...), 0x01),
+			err:  "cbor: 1 bytes of extraneous data starting at index 4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var decoded map[string]any
+
+			err := Unmarshal(tc.data, &decoded)
+
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, map[string]any{"a": uint64(1)}, decoded)
+		})
+	}
+}
+
+func TestUnmarshalFirstAcceptsTrailingData(t *testing.T) {
+	var decoded map[string]any
+
+	n, err := UnmarshalFirst(append(append([]byte{}, item...), item...), &decoded)
+
+	require.NoError(t, err)
+	assert.Equal(t, len(item), n)
+	assert.Equal(t, map[string]any{"a": uint64(1)}, decoded)
+}


### PR DESCRIPTION
Unmarshal discarded whatever followed the item it decoded, so an attestation object carrying appended bytes was accepted and the remainder silently dropped. The decoder reports the condition itself, and UnmarshalFirst remains the entry point for an item embedded in a larger sequence, which the two callers decoding a prefix already use.