### PR TITLE
fix(protocol): harden credential response and options handling

### DIFF
--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -110,6 +110,12 @@ func (car CredentialAssertionResponse) Parse() (par *ParsedCredentialAssertionDa
 		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with ID not base64url encoded").WithError(err)
 	}
 
+	// The decoder skips CR and LF, so an id composed only of them decodes to no bytes rather than failing above. A
+	// credential id is at least one byte, and the registration path already rejects a zero length decode here.
+	if len(rawID) == 0 {
+		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with ID that decodes to no bytes")
+	}
+
 	if car.Type != string(PublicKeyCredentialType) {
 		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with bad type")
 	}

--- a/protocol/assertion.go
+++ b/protocol/assertion.go
@@ -1,12 +1,14 @@
 package protocol
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 )
@@ -102,12 +104,20 @@ func (car CredentialAssertionResponse) Parse() (par *ParsedCredentialAssertionDa
 		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with ID missing")
 	}
 
-	if _, err = base64.RawURLEncoding.DecodeString(car.ID); err != nil {
+	var rawID []byte
+
+	if rawID, err = base64.RawURLEncoding.DecodeString(car.ID); err != nil {
 		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with ID not base64url encoded").WithError(err)
 	}
 
 	if car.Type != string(PublicKeyCredentialType) {
 		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with bad type")
+	}
+
+	// The id member is defined as the base64url encoding of rawId. Every step below this one uses rawId, so a
+	// disagreement between the two would otherwise be silently resolved in favour of rawId.
+	if !bytes.Equal(rawID, car.RawID) {
+		return nil, ErrBadRequest.WithDetails("CredentialAssertionResponse with ID that does not match the rawId")
 	}
 
 	var attachment AuthenticatorAttachment
@@ -183,7 +193,7 @@ func (p *ParsedCredentialAssertionData) Verify(storedChallenge string, relyingPa
 	// Step 16. Using the credential public key looked up in step 3, verify that sig is
 	// a valid signature over the binary concatenation of authData and hash.
 
-	sigData := append(p.Raw.AssertionResponse.AuthenticatorData, clientDataHash[:]...) //nolint:gocritic // This is intentional.
+	sigData := slices.Concat(p.Raw.AssertionResponse.AuthenticatorData, clientDataHash[:])
 
 	var (
 		key any

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -272,6 +272,19 @@ func TestCredentialAssertionResponse_Parse_Errors(t *testing.T) {
 			err: "CredentialAssertionResponse with ID that does not match the rawId",
 		},
 		{
+			name: "ShouldFailIDDecodingToNoBytes",
+			car: CredentialAssertionResponse{
+				PublicKeyCredential: PublicKeyCredential{
+					Credential: Credential{
+						ID:   "\r\n",
+						Type: string(PublicKeyCredentialType),
+					},
+					RawID: URLEncodedBase64{},
+				},
+			},
+			err: "CredentialAssertionResponse with ID that decodes to no bytes",
+		},
+		{
 			name: "ShouldFailRawIDMissing",
 			car: CredentialAssertionResponse{
 				PublicKeyCredential: PublicKeyCredential{

--- a/protocol/assertion_test.go
+++ b/protocol/assertion_test.go
@@ -258,6 +258,31 @@ func TestCredentialAssertionResponse_Parse_Errors(t *testing.T) {
 			},
 			err: "CredentialAssertionResponse with bad type",
 		},
+		{
+			name: "ShouldFailRawIDMismatch",
+			car: CredentialAssertionResponse{
+				PublicKeyCredential: PublicKeyCredential{
+					Credential: Credential{
+						ID:   "dGVzdA",
+						Type: string(PublicKeyCredentialType),
+					},
+					RawID: URLEncodedBase64("not test"),
+				},
+			},
+			err: "CredentialAssertionResponse with ID that does not match the rawId",
+		},
+		{
+			name: "ShouldFailRawIDMissing",
+			car: CredentialAssertionResponse{
+				PublicKeyCredential: PublicKeyCredential{
+					Credential: Credential{
+						ID:   "dGVzdA",
+						Type: string(PublicKeyCredentialType),
+					},
+				},
+			},
+			err: "CredentialAssertionResponse with ID that does not match the rawId",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -362,6 +387,30 @@ func TestParsedCredentialAssertionData_Verify(t *testing.T) {
 	}
 }
 
+func TestParsedCredentialAssertionData_VerifyDoesNotWriteBeyondAuthenticatorData(t *testing.T) {
+	par, credPubKey, challenge := testAssertionSpecVectorNoneES256(t)
+
+	raw := par.Raw.AssertionResponse.AuthenticatorData
+
+	// Model the spare capacity URLEncodedBase64.UnmarshalJSON leaves behind when the encoded value carried padding,
+	// so an append which writes the client data hash into the caller's backing array is observable.
+	const spare = 32
+
+	buf := make([]byte, len(raw), len(raw)+spare)
+	copy(buf, raw)
+
+	tail := buf[len(raw) : len(raw)+spare]
+	for i := range tail {
+		tail[i] = 0xAA
+	}
+
+	par.Raw.AssertionResponse.AuthenticatorData = buf
+
+	require.NoError(t, par.Verify(challenge, "example.org", "", []string{"https://example.org"}, nil, nil, TopOriginExplicitVerificationMode, false, false, true, credPubKey, SignaturePolicy{}))
+
+	assert.Equal(t, bytes.Repeat([]byte{0xAA}, spare), tail, "verification wrote into the spare capacity of the authenticator data the caller still holds")
+}
+
 func TestParseCredentialRequestResponse_Success(t *testing.T) {
 	body := io.NopCloser(bytes.NewReader([]byte(testAssertionResponses["success"])))
 
@@ -425,6 +474,7 @@ func TestCredentialAssertionResponse_Parse_ClientDataJSONError(t *testing.T) {
 				ID:   "dGVzdA",
 				Type: string(PublicKeyCredentialType),
 			},
+			RawID: URLEncodedBase64("test"),
 		},
 		AssertionResponse: AuthenticatorAssertionResponse{
 			AuthenticatorResponse: AuthenticatorResponse{
@@ -452,6 +502,7 @@ func TestCredentialAssertionResponse_Parse_AuthDataError(t *testing.T) {
 				ID:   "dGVzdA",
 				Type: string(PublicKeyCredentialType),
 			},
+			RawID: URLEncodedBase64("test"),
 		},
 		AssertionResponse: AuthenticatorAssertionResponse{
 			AuthenticatorResponse: AuthenticatorResponse{

--- a/protocol/attestation_androidkey.go
+++ b/protocol/attestation_androidkey.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -79,7 +80,7 @@ func attestationFormatValidationHandlerAndroidKey(att AttestationObject, clientD
 		return "", nil, ErrInvalidAttestation.WithDetails("Error validating x5c cert chain").WithError(err)
 	}
 
-	signatureData := append(att.RawAuthData, clientDataHash...) //nolint:gocritic // This is intentional.
+	signatureData := slices.Concat(att.RawAuthData, clientDataHash)
 
 	if sigAlg := webauthncose.SigAlgFromCOSEAlg(webauthncose.COSEAlgorithmIdentifier(alg)); sigAlg == x509.UnknownSignatureAlgorithm {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Unsupported COSE alg: %d", alg))

--- a/protocol/attestation_apple.go
+++ b/protocol/attestation_apple.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
+	"slices"
 	"time"
 
 	"github.com/go-webauthn/webauthn/metadata"
@@ -50,7 +51,7 @@ func attestationFormatValidationHandlerAppleAnonymous(att AttestationObject, cli
 	}
 
 	// Step 2. Concatenate authenticatorData and clientDataHash to form nonceToHash.
-	nonceToHash := append(att.RawAuthData, clientDataHash...) //nolint:gocritic // This is intentional.
+	nonceToHash := slices.Concat(att.RawAuthData, clientDataHash)
 
 	// Step 3. Perform SHA-256 hash of nonceToHash to produce nonce.
 	nonce := sha256.Sum256(nonceToHash)

--- a/protocol/attestation_packed.go
+++ b/protocol/attestation_packed.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -109,7 +110,7 @@ func handleBasicAttestation(sig, clientDataHash, authData, aaguid []byte, alg in
 		return "", x5c, ErrAttestation.WithDetails("Error getting certificate from x5c cert chain")
 	}
 
-	signatureData := append(authData, clientDataHash...) //nolint:gocritic // This is intentional.
+	signatureData := slices.Concat(authData, clientDataHash)
 
 	if sigAlg := webauthncose.SigAlgFromCOSEAlg(webauthncose.COSEAlgorithmIdentifier(alg)); sigAlg == x509.UnknownSignatureAlgorithm {
 		return "", nil, ErrInvalidAttestation.WithDetails(fmt.Sprintf("Unsupported COSE alg: %d", alg))
@@ -195,7 +196,7 @@ func handleECDAAAttestation(sig, clientDataHash, ecdaaKeyID []byte, _ metadata.P
 }
 
 func handleSelfAttestation(alg int64, pubKey, authData, clientDataHash, sig []byte, _ metadata.Provider, policy SignaturePolicy) (attestationType string, x5cs []any, err error) {
-	verificationData := append(authData, clientDataHash...) //nolint:gocritic // This is intentional.
+	verificationData := slices.Concat(authData, clientDataHash)
 
 	var (
 		key   any

--- a/protocol/attestation_safetynet.go
+++ b/protocol/attestation_safetynet.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -93,7 +94,7 @@ func attestationFormatValidationHandlerAndroidSafetyNet(att AttestationObject, c
 
 	// §8.5.3 Verify that the nonce in the response is identical to the Base64 encoding of the SHA-256 hash of the concatenation
 	// of authenticatorData and clientDataHash.
-	nonceBuffer := sha256.Sum256(append(att.RawAuthData, clientDataHash...))
+	nonceBuffer := sha256.Sum256(slices.Concat(att.RawAuthData, clientDataHash))
 
 	nonceBytes, err := base64.StdEncoding.DecodeString(safetyNetResponse.Nonce)
 	if !bytes.Equal(nonceBuffer[:], nonceBytes) || err != nil {

--- a/protocol/attestation_tpm.go
+++ b/protocol/attestation_tpm.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/google/go-tpm/tpm2"
@@ -133,7 +134,7 @@ func attestationFormatValidationHandlerTPM(att AttestationObject, clientDataHash
 	}
 
 	// Concatenate authenticatorData and clientDataHash to form attToBeSigned.
-	attToBeSigned := append(att.RawAuthData, clientDataHash...) //nolint:gocritic // This is intentional.
+	attToBeSigned := slices.Concat(att.RawAuthData, clientDataHash)
 
 	var certInfo *tpm2.TPMSAttest
 

--- a/protocol/base64.go
+++ b/protocol/base64.go
@@ -3,7 +3,9 @@ package protocol
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"reflect"
+	"strings"
 )
 
 // URLEncodedBase64 represents a byte slice holding URL-encoded base64 data.
@@ -28,21 +30,25 @@ func (e *URLEncodedBase64) UnmarshalJSON(data []byte) error {
 		return errBase64NotJSONString
 	}
 
-	// Trim the leading and trailing quotes from raw JSON data (the whole value part).
-	data = data[1 : len(data)-1]
+	// Decode the JSON string itself rather than reading the raw text between the quotes, so a value spelled with
+	// JSON escapes decodes to the same bytes as the plain spelling. The base64url alphabet contains nothing which
+	// has to be escaped, so such a value is unusual, but it is a legal encoding of one and the raw text is not.
+	var value string
+
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
 
 	// Trim the trailing equal characters.
-	data = bytes.TrimRight(data, "=")
+	value = strings.TrimRight(value, "=")
 
-	out := make([]byte, base64.RawURLEncoding.DecodedLen(len(data)))
-
-	n, err := base64.RawURLEncoding.Decode(out, data)
+	out, err := base64.RawURLEncoding.DecodeString(value)
 	if err != nil {
 		return err
 	}
 
 	v := reflect.ValueOf(e).Elem()
-	v.SetBytes(out[:n])
+	v.SetBytes(out)
 
 	return nil
 }

--- a/protocol/base64.go
+++ b/protocol/base64.go
@@ -22,8 +22,14 @@ func (e *URLEncodedBase64) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	// A JSON value which is not a string is not base64 at all. Without this check the quote trimming below is a no-op
+	// and the value itself is decoded, so a number or a boolean produces silent garbage bytes rather than an error.
+	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+		return errBase64NotJSONString
+	}
+
 	// Trim the leading and trailing quotes from raw JSON data (the whole value part).
-	data = bytes.Trim(data, `"`)
+	data = data[1 : len(data)-1]
 
 	// Trim the trailing equal characters.
 	data = bytes.TrimRight(data, "=")

--- a/protocol/base64_test.go
+++ b/protocol/base64_test.go
@@ -54,6 +54,31 @@ func TestURLEncodedBase64_UnmarshalJSON_Error(t *testing.T) {
 			data: `"not valid base64!!!"`,
 			err:  "illegal base64 data at input byte 3",
 		},
+		{
+			name: "ShouldFailJSONNumber",
+			data: `123456`,
+			err:  errBase64NotJSONString.Error(),
+		},
+		{
+			name: "ShouldFailJSONBoolean",
+			data: `true`,
+			err:  errBase64NotJSONString.Error(),
+		},
+		{
+			name: "ShouldFailJSONObject",
+			data: `{"a":"b"}`,
+			err:  errBase64NotJSONString.Error(),
+		},
+		{
+			name: "ShouldFailJSONArray",
+			data: `["YWJj"]`,
+			err:  errBase64NotJSONString.Error(),
+		},
+		{
+			name: "ShouldFailUnterminatedJSONString",
+			data: `"YWJj`,
+			err:  errBase64NotJSONString.Error(),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -92,6 +117,24 @@ func TestBase64UnmarshalJSON(t *testing.T) {
 			expected: testData{
 				StringData:  "test string",
 				EncodedData: nil,
+			},
+			err: "",
+		},
+		{
+			name:    "ShouldHandlePaddedBase64Data",
+			message: `"YWJjZA=="`,
+			expected: testData{
+				StringData:  "test string",
+				EncodedData: URLEncodedBase64("abcd"),
+			},
+			err: "",
+		},
+		{
+			name:    "ShouldHandleEmptyString",
+			message: `""`,
+			expected: testData{
+				StringData:  "test string",
+				EncodedData: URLEncodedBase64{},
 			},
 			err: "",
 		},

--- a/protocol/base64_test.go
+++ b/protocol/base64_test.go
@@ -130,6 +130,24 @@ func TestBase64UnmarshalJSON(t *testing.T) {
 			err: "",
 		},
 		{
+			name:    "ShouldHandleEscapedBase64Data",
+			message: `"\u0059\u0057\u004a\u006a"`,
+			expected: testData{
+				StringData:  "test string",
+				EncodedData: URLEncodedBase64("abc"),
+			},
+			err: "",
+		},
+		{
+			name:    "ShouldHandlePartiallyEscapedBase64Data",
+			message: `"YW\u004aj"`,
+			expected: testData{
+				StringData:  "test string",
+				EncodedData: URLEncodedBase64("abc"),
+			},
+			err: "",
+		},
+		{
 			name:    "ShouldHandleEmptyString",
 			message: `""`,
 			expected: testData{

--- a/protocol/credential.go
+++ b/protocol/credential.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"io"
@@ -143,6 +144,13 @@ func (ccr CredentialCreationResponse) Parse() (pcc *ParsedCredentialCreationData
 		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo("Type not public-key")
 	}
 
+	// The id member is defined as the base64url encoding of rawId, so the two cannot legitimately disagree. Nothing
+	// downstream reads the id, which is why a disagreement would otherwise pass unnoticed rather than being reported
+	// as the client bug it is.
+	if !bytes.Equal(testB64, ccr.RawID) {
+		return nil, ErrBadRequest.WithDetails("Parse error for Registration").WithInfo("ID does not match rawId")
+	}
+
 	response, err := ccr.AttestationResponse.Parse()
 	if err != nil {
 		return nil, ErrParsingData.WithDetails("Error parsing attestation response")
@@ -187,6 +195,13 @@ func (pcc *ParsedCredentialCreationData) Verify(storedChallenge string, relyingP
 	// Handle steps 9 through 14 - This verifies the attestation object.
 	if err = pcc.Response.AttestationObject.Verify(relyingPartyID, clientDataHash, verifyUser, verifyUserPresence, mds, credParams, policy, signature); err != nil {
 		return clientDataHash, err
+	}
+
+	// Step 27 defines credentialRecord.id as "credential.id or credential.rawId, whichever format is preferred",
+	// which presumes the two agree. The record is built from the attested credential id, as that is the value the
+	// attestation signature covers, so a disagreement is a client which reported a credential it did not create.
+	if !bytes.Equal(pcc.RawID, pcc.Response.AttestationObject.AuthData.AttData.CredentialID) {
+		return clientDataHash, ErrVerification.WithDetails("Error validating the attested credential id").WithInfo("The credential id reported by the client does not match the credential id in the attested credential data")
 	}
 
 	// Step 15. If validation is successful, obtain a list of acceptable trust anchors (attestation root

--- a/protocol/credential_test.go
+++ b/protocol/credential_test.go
@@ -260,6 +260,63 @@ func TestParsedCredentialCreationData_Verify(t *testing.T) {
 			expected: []byte{0xa, 0xaf, 0x43, 0xda, 0x7e, 0xd3, 0x94, 0x98, 0x9b, 0xbc, 0x47, 0xcb, 0x0, 0x72, 0x6b, 0xbc, 0xf3, 0xa2, 0x4a, 0x49, 0x5f, 0x84, 0x4f, 0x45, 0x97, 0x91, 0x6a, 0x2d, 0xff, 0x47, 0xbc, 0xad},
 			err:      "",
 		},
+		{
+			name: "ShouldFailWhenRawIDIsNotTheAttestedCredentialID",
+			fields: fields{
+				ParsedPublicKeyCredential: ParsedPublicKeyCredential{
+					ParsedCredential: ParsedCredential{
+						ID:   "bm90LXRoZS1hdHRlc3RlZC1jcmVkZW50aWFsLWlkISE",
+						Type: string(PublicKeyCredentialType),
+					},
+					RawID: []byte("not-the-attested-credential-id!!"),
+				},
+				Response: ParsedAttestationResponse{
+					CollectedClientData: CollectedClientData{
+						Type:      CeremonyType("webauthn.create"),
+						Challenge: "W8GzFU8pGjhoRbWrLDlamAfq_y4S1CZG1VuoeRLARrE",
+						Origin:    "https://webauthn.io",
+					},
+					AttestationObject: AttestationObject{
+						Format:      "none",
+						RawAuthData: byteAuthData,
+						AuthData: AuthenticatorData{
+							RPIDHash: byteRPIDHash,
+							Counter:  0,
+							Flags:    0x041,
+							AttData: AttestedCredentialData{
+								AAGUID:              make([]byte, 16),
+								CredentialID:        byteID,
+								CredentialPublicKey: byteCredentialPubKey,
+							},
+						},
+					},
+				},
+				Raw: CredentialCreationResponse{
+					PublicKeyCredential: PublicKeyCredential{
+						Credential: Credential{
+							Type: string(PublicKeyCredentialType),
+							ID:   "bm90LXRoZS1hdHRlc3RlZC1jcmVkZW50aWFsLWlkISE",
+						},
+						RawID: []byte("not-the-attested-credential-id!!"),
+					},
+					AttestationResponse: AuthenticatorAttestationResponse{
+						AuthenticatorResponse: AuthenticatorResponse{
+							ClientDataJSON: byteClientDataJSON,
+						},
+						AttestationObject: byteAttObject,
+					},
+				},
+			},
+			args: args{
+				storedChallenge:    URLEncodedBase64(byteChallenge),
+				verifyUser:         false,
+				relyingPartyID:     `webauthn.io`,
+				relyingPartyOrigin: []string{`https://webauthn.io`},
+				credParams:         []CredentialParameter{{Type: "public-key", Algorithm: webauthncose.AlgES256}},
+			},
+			expected: []byte{0xa, 0xaf, 0x43, 0xda, 0x7e, 0xd3, 0x94, 0x98, 0x9b, 0xbc, 0x47, 0xcb, 0x0, 0x72, 0x6b, 0xbc, 0xf3, 0xa2, 0x4a, 0x49, 0x5f, 0x84, 0x4f, 0x45, 0x97, 0x91, 0x6a, 0x2d, 0xff, 0x47, 0xbc, 0xad},
+			err:      "Error validating the attested credential id",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -355,6 +412,31 @@ func TestCredentialCreationResponse_Parse_Errors(t *testing.T) {
 			},
 			err: "Parse error for Registration",
 		},
+		{
+			name: "ShouldFailRawIDMismatch",
+			ccr: CredentialCreationResponse{
+				PublicKeyCredential: PublicKeyCredential{
+					Credential: Credential{
+						ID:   "dGVzdA",
+						Type: string(PublicKeyCredentialType),
+					},
+					RawID: URLEncodedBase64("not test"),
+				},
+			},
+			err: "Parse error for Registration",
+		},
+		{
+			name: "ShouldFailRawIDMissing",
+			ccr: CredentialCreationResponse{
+				PublicKeyCredential: PublicKeyCredential{
+					Credential: Credential{
+						ID:   "dGVzdA",
+						Type: string(PublicKeyCredentialType),
+					},
+				},
+			},
+			err: "Parse error for Registration",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -364,6 +446,29 @@ func TestCredentialCreationResponse_Parse_Errors(t *testing.T) {
 			assert.EqualError(t, err, tc.err)
 		})
 	}
+}
+
+func TestCredentialCreationResponse_Parse_RawIDMismatchIsDistinguishable(t *testing.T) {
+	ccr := CredentialCreationResponse{
+		PublicKeyCredential: PublicKeyCredential{
+			Credential: Credential{
+				ID:   "dGVzdA",
+				Type: string(PublicKeyCredentialType),
+			},
+			RawID: URLEncodedBase64("not test"),
+		},
+	}
+
+	result, err := ccr.Parse()
+	assert.Nil(t, result)
+
+	// The mismatch is structural, so it is reported before the attestation response is parsed. Without the check the
+	// response is rejected for the unrelated reason that it carries no attestation object at all.
+	var e *Error
+
+	require.ErrorAs(t, err, &e)
+	assert.Equal(t, "Parse error for Registration", e.Details)
+	assert.Equal(t, "ID does not match rawId", e.DevInfo)
 }
 
 func TestGetAppID(t *testing.T) {

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -156,6 +156,10 @@ var (
 )
 
 var (
+	errBase64NotJSONString = errors.New("error unmarshalling url encoded base64: expected a JSON string")
+)
+
+var (
 	errDomainIsIPAddress        = errors.New("the value must be a domain and not an IP address")
 	errDomainNotADomain         = errors.New("the domain component must actually be a domain")
 	errDomainEmptyLabel         = errors.New("the domain must not contain an empty label")

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -35,7 +35,7 @@ type PublicKeyCredentialCreationOptions struct {
 	Parameters             []CredentialParameter      `json:"pubKeyCredParams,omitempty"`
 	Timeout                int                        `json:"timeout,omitempty"`
 	CredentialExcludeList  []CredentialDescriptor     `json:"excludeCredentials,omitempty"`
-	AuthenticatorSelection AuthenticatorSelection     `json:"authenticatorSelection,omitempty"`
+	AuthenticatorSelection AuthenticatorSelection     `json:"authenticatorSelection,omitzero"`
 	Hints                  []PublicKeyCredentialHints `json:"hints,omitempty"`
 	Attestation            ConveyancePreference       `json:"attestation,omitempty"`
 	AttestationFormats     []AttestationFormat        `json:"attestationFormats,omitempty"`
@@ -147,6 +147,13 @@ type AuthenticatorSelection struct {
 	// the create() operation. Eligible authenticators are filtered to only those capable of satisfying this
 	// requirement.
 	UserVerification UserVerificationRequirement `json:"userVerification,omitempty"`
+}
+
+// IsZero returns true when no authenticator selection criteria are set. It is used by the encoding/json omitzero tag
+// option so a Relying Party that expresses no criteria does not send an empty authenticatorSelection member to the
+// client, which omitempty cannot do for a struct value.
+func (s AuthenticatorSelection) IsZero() bool {
+	return s.AuthenticatorAttachment == "" && s.RequireResidentKey == nil && s.ResidentKey == "" && s.UserVerification == ""
 }
 
 // ConveyancePreference is the type representing the AttestationConveyancePreference IDL.

--- a/protocol/options_test.go
+++ b/protocol/options_test.go
@@ -129,6 +129,62 @@ func TestCredentialDescriptor_SignalUnknownCredential(t *testing.T) {
 	}
 }
 
+func TestAuthenticatorSelection_IsZero(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     AuthenticatorSelection
+		expected bool
+	}{
+		{"ShouldBeZeroWhenUnset", AuthenticatorSelection{}, true},
+		{"ShouldNotBeZeroWithAttachment", AuthenticatorSelection{AuthenticatorAttachment: Platform}, false},
+		{"ShouldNotBeZeroWithResidentKey", AuthenticatorSelection{ResidentKey: ResidentKeyRequirementRequired}, false},
+		{"ShouldNotBeZeroWithUserVerification", AuthenticatorSelection{UserVerification: VerificationPreferred}, false},
+		{"ShouldNotBeZeroWithRequireResidentKeyTrue", AuthenticatorSelection{RequireResidentKey: ResidentKeyRequired()}, false},
+		{"ShouldNotBeZeroWithRequireResidentKeyFalse", AuthenticatorSelection{RequireResidentKey: ResidentKeyNotRequired()}, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.have.IsZero())
+		})
+	}
+}
+
+func TestPublicKeyCredentialCreationOptions_MarshalAuthenticatorSelection(t *testing.T) {
+	testCases := []struct {
+		name     string
+		have     AuthenticatorSelection
+		expected string
+	}{
+		{
+			// Without the omitzero tag option this emits "authenticatorSelection":{} on every creation options
+			// payload, because omitempty has no effect on a struct value.
+			name:     "ShouldOmitWhenUnset",
+			have:     AuthenticatorSelection{},
+			expected: `{"rp":{"name":"","id":""},"user":{"name":"","displayName":"","id":null},"challenge":null}`,
+		},
+		{
+			name:     "ShouldEmitWhenSet",
+			have:     AuthenticatorSelection{UserVerification: VerificationPreferred},
+			expected: `{"rp":{"name":"","id":""},"user":{"name":"","displayName":"","id":null},"challenge":null,"authenticatorSelection":{"userVerification":"preferred"}}`,
+		},
+		{
+			name:     "ShouldEmitWhenOnlyRequireResidentKeyFalse",
+			have:     AuthenticatorSelection{RequireResidentKey: ResidentKeyNotRequired()},
+			expected: `{"rp":{"name":"","id":""},"user":{"name":"","displayName":"","id":null},"challenge":null,"authenticatorSelection":{"requireResidentKey":false}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(PublicKeyCredentialCreationOptions{AuthenticatorSelection: tc.have})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, string(data))
+		})
+	}
+}
+
 func TestCredentialParameter_MsgpRoundTrip(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
A URLEncodedBase64 member decoded whatever JSON value it was given, so a number or a boolean produced garbage bytes rather than a parse error. The quote trimming that allowed it removed nothing from those values, so it became a slice of the string interior instead. The id and rawId of a credential response must now agree, and a registration response must report the credential id the attestation signature covers rather than an unrelated one.

An empty authenticatorSelection was emitted on every creation options payload, since omitempty has no effect on a struct value. AuthenticatorSelection gained IsZero and the tag became omitzero, matching the extension inputs.

The seven sites that built signed data with append wrote into the spare capacity of a buffer the caller still holds, which becomes a correctness bug as soon as two of them want different suffixes. They use slices.Concat now.